### PR TITLE
Add bootstrap and lint make targets

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ steps:
   displayName: 'Set up the Go workspace'
 
 - script: |
-     make build test-unit
+     make bootstrap build test-unit lint
   workingDirectory: '$(modulePath)'
   displayName: 'Unit Test'
 

--- a/golangci.yml
+++ b/golangci.yml
@@ -1,0 +1,19 @@
+run:
+  deadline: 2m
+
+linters:
+  disable-all: true
+  enable:
+  - gofmt
+  - goimports
+  - golint
+  - gosimple
+  - ineffassign
+  - misspell
+  - unused
+  - deadcode
+  - govet
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/deislabs/porter


### PR DESCRIPTION
This PR adds `bootstrap` and `lint` targets to the Makefile and Azure Pipelines.


Note that the CI for this PR will fail due to the linter errors:

```
$ make lint
golangci-lint run --config ./golangci.yml
cmd/helm/install.go:9:2: `commandFile` is unused (deadcode)
        commandFile string
        ^
cmd/porter/run.go:37:23: error strings should not be capitalized or end with punctuation or a newline (golint)
                                return fmt.Errorf("invalid --file: the specified porter configuration file %q doesn't exist\n", opts.file)
                                                  ^
pkg/context/helpers.go:79:9: should use c.output.String() instead of string(c.output.Bytes()) (megacheck.{unused,gosimple})
        return string(c.output.Bytes())
               ^
pkg/mixin/exec/version_test.go:19:15: should use output.String() instead of string(output.Bytes()) (megacheck.{unused,gosimple})
        gotOutput := string(output.Bytes())
                     ^
pkg/mixin/helm/version_test.go:19:15: should use output.String() instead of string(output.Bytes()) (megacheck.{unused,gosimple})
        gotOutput := string(output.Bytes())
                     ^
pkg/mixin/runner_test.go:59:21: should use output.String() instead of string(output.Bytes()) (megacheck.{unused,gosimple})
        assert.Contains(t, string(output.Bytes()), "Hello World")
                           ^
pkg/porter/build.go:117:3: should merge variable declaration with assignment on next line (megacheck.{unused,gosimple})
                var mixinContext cxt.Context
                ^
pkg/config/manifest.go:98:2: field `runner` is unused (megacheck.{unused,gosimple})
        runner *mixin.Runner
        ^
Makefile:63: recipe for target 'lint' failed
make: *** [lint] Error 1
```