### PR TITLE
Link new docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -114,39 +114,55 @@ defaultContentLanguage = "en"
 
 [[menu.main]]
   name = "Developing Mixins"
-  url = "/mixin-dev-guide"
-  identifier = "mixin-dev-guide"
+  identifier = "developing-mixins"
   weight = 300
+  [[menu.main]]
+    name = "Overview"
+    url = "/mixin-dev-guide"
+    identifier = "mixin-dev-guide"
+    weight = 301
+    parent = "developing-mixins"
   [[menu.main]]
     name = "Mixin Architecture"
     url = "/mixin-architecture"
     identifier = "mixin-architecture"
     weight = 310
-    parent = "mixin-dev-guide"
+    parent = "developing-mixins"
   [[menu.main]]
     name = "Distributing Mixins"
     url = "/mixin-distribution"
     identifier = "mixin-distribution"
     weight = 311
-    parent = "mixin-dev-guide"
+    parent = "developing-mixins"
 
 [[menu.main]]
-  name = "Architecture"
-  url = "/architecture"
-  identifier = "architecture"
+  name = "Porter Architecture"
+  identifier = "porter-architecture"
   weight = 400
+  [[menu.main]]
+    name = "Overview"
+    url = "/architecture"
+    identifier = "architecture"
+    weight = 401
+    parent = "porter-architecture"
   [[menu.main]]
     name = "Buildtime"
     url = "/achitecture-buildtime"
     identifier = "architecture-buildtime"
-    weight = 401
-    parent = "architecture"
+    weight = 402
+    parent = "porter-architecture"
   [[menu.main]]
     name = "Runtime"
     url = "/achitecture-runtime"
     identifier = "architecture-runtime"
-    weight = 402
-    parent = "architecture"
+    weight = 403
+    parent = "porter-architecture"
+  [[menu.main]]
+    name = "Invocation Images"
+    url = "/build-image"
+    identifier = "build-image"
+    weight = 404
+    parent = "porter-architecture"
 
 [[menu.main]]
   name = "References"

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -2,3 +2,15 @@
 title: Architecture
 description: Detailed look at how Porter does its magic 🎩✨
 ---
+
+TODO:
+
+* runtime v buildtime
+* Our binaries and mixins
+* Call flow
+* How we implement CNAB, and where we add our own stuff outside of the spec (like dependencies)
+* Oh yeah dependencies and buildtime v runtime
+
+## See Also
+
+* [Porter Build - Making Invocation Images](/build-image/)

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1,3 +1,8 @@
+---
+title: Porter Docs
+description: All the magic of Porter explained
+---
+
 Porter takes the work out of creating CNAB bundles. It provides a declarative authoring 
 experience that lets you to reuse existing bundles, and understands how to translate 
 CNAB actions to Helm, Terraform, Azure, etc.

--- a/docs/content/mixin-architecture.md
+++ b/docs/content/mixin-architecture.md
@@ -1,6 +1,6 @@
 ---
-title: Mixins 
-descriptions: How do mixins work?
+title: Mixin Architecture 
+descriptions: How do mixins work? Hotwiring a porter mixin.
 ---
 
 ## What is a Mixin

--- a/docs/content/mixin-dev-guide.md
+++ b/docs/content/mixin-dev-guide.md
@@ -3,3 +3,11 @@ title: Developing Mixins
 description: Creating and Extending Mixins for Porter
 ---
 
+TODO:
+
+* Explain mixins in general
+* Why you'd want to make your own
+* How to go about it
+
+## See Also
+* [Mixin Architecture](/mixin-architecture/)

--- a/docs/themes/porter/layouts/index.html
+++ b/docs/themes/porter/layouts/index.html
@@ -13,7 +13,7 @@
   <meta property="og:title" content="Porter - A Friendlier Cloud Installer" />
   <meta property="og:url" content="{{ .Site.BaseURL }}" />
   <meta property="og:image" content="{{ .Site.BaseURL }}/src/img/favicon-152.png" />
-  <meta name="google-site-verification" content="dCa3wS47cErhx0IpaxbB85NfcOP-vFxevknVk6fzf5I" />
+  <meta name="google-site-verification" content="TODO" />
 
   <link rel="icon" href="/src/img/favicon-152.png" type="image/x-icon">
 

--- a/docs/themes/porter/layouts/partials/header.html
+++ b/docs/themes/porter/layouts/partials/header.html
@@ -6,14 +6,14 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Helm Docs | {{ .Title }}</title>
+  <title>Porter | {{ .Title }}</title>
 
   <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
   <meta name="author" content="{{ with .Site.Params.name }}{{ . }}{{ end }}">
-  <meta property="og:title" content="Porter - A Cloud Native Package Manager" />
+  <meta property="og:title" content="Porter - A Friendlier Cloud Installer" />
   <meta property="og:url" content="{{ .Site.BaseURL }}" />
   <meta property="og:image" content="{{ .Site.BaseURL }}/src/img/favicon-152.png" />
-  <meta name="google-site-verification" content="dCa3wS47cErhx0IpaxbB85NfcOP-vFxevknVk6fzf5I" />
+  <meta name="google-site-verification" content="TODO" />
 
   <link rel="icon" href="/src/img/favicon-152.png" type="image/x-icon">
   <link href="/src/css/styles.min.css" rel="stylesheet">

--- a/docs/themes/porter/layouts/partials/offcanvas.html
+++ b/docs/themes/porter/layouts/partials/offcanvas.html
@@ -16,7 +16,7 @@
         <ul class="current">
           {{ range .Children.ByWeight }}
           <li class="toctree-l2 {{if $.IsMenuCurrent "main" . }} active {{end}}">
-            <a href="../../{{ .Parent | safeHTMLAttr }}/#{{ .URL | safeHTMLAttr }}" title="Switch to {{ .Name }}">
+            <a href="{{ .URL | safeHTMLAttr }}" title="{{ .Name }}">
               {{ .Name }}
             </a>
           </li>

--- a/docs/themes/porter/layouts/partials/sidebar.html
+++ b/docs/themes/porter/layouts/partials/sidebar.html
@@ -19,7 +19,7 @@
           <ul class="current">
             {{ range .Children.ByWeight }}
             <li class="toctree-l2 {{if $.IsMenuCurrent "main" . }} active {{end}}">
-              <a href="../../docs/{{ .Parent | safeHTMLAttr }}/#{{ .URL | safeHTMLAttr }}" title="Switch to {{ .Name }}">
+              <a href="{{ .URL | safeHTMLAttr }}" title="{{ .Name }}">
                 {{ .Name }}
               </a>
             </li>


### PR DESCRIPTION
This links to the new docs written in #117 and #120.

Preview available at:
* Overview Pages
  * https://deploy-preview-126--porter.netlify.com/architecture/
  * https://deploy-preview-126--porter.netlify.com/mixin-dev-guide/
* https://deploy-preview-126--porter.netlify.com/build-image/
* https://deploy-preview-126--porter.netlify.com/mixin-architecture/