### PR TITLE
feat(*): add upgrade action support

### DIFF
--- a/cmd/exec/main.go
+++ b/cmd/exec/main.go
@@ -35,6 +35,7 @@ func buildRootCommand(in io.Reader) *cobra.Command {
 	cmd.AddCommand(buildVersionCommand(m))
 	cmd.AddCommand(buildBuildCommand(m))
 	cmd.AddCommand(buildInstallCommand(m))
+	cmd.AddCommand(buildUpgradeCommand(m))
 	cmd.AddCommand(buildUninstallCommand(m))
 
 	return cmd

--- a/cmd/exec/upgrade.go
+++ b/cmd/exec/upgrade.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/deislabs/porter/pkg/mixin/exec"
+	"github.com/spf13/cobra"
+)
+
+func buildUpgradeCommand(m *exec.Mixin) *cobra.Command {
+	var opts struct {
+		file string
+	}
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Execute the upgrade functionality of this mixin",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return m.Upgrade(opts.file)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.file, "file", "f", "", "Path to the script to execute")
+	return cmd
+}

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -228,6 +228,9 @@ func TestManifest_MergeDependency(t *testing.T) {
 		Install: Steps{
 			&Step{Description: "install wordpress"},
 		},
+		Upgrade: Steps{
+			&Step{Description: "upgrade wordpress"},
+		},
 		Uninstall: Steps{
 			&Step{Description: "uninstall wordpress"},
 		},
@@ -238,6 +241,9 @@ func TestManifest_MergeDependency(t *testing.T) {
 			Mixins: []string{"exec", "helm"},
 			Install: Steps{
 				&Step{Description: "install mysql"},
+			},
+			Upgrade: Steps{
+				&Step{Description: "upgrade mysql"},
 			},
 			Uninstall: Steps{
 				&Step{Description: "uninstall mysql"},
@@ -256,6 +262,10 @@ func TestManifest_MergeDependency(t *testing.T) {
 	assert.Len(t, m.Install, 2)
 	assert.Equal(t, "install mysql", m.Install[0].Description)
 	assert.Equal(t, "install wordpress", m.Install[1].Description)
+
+	assert.Len(t, m.Upgrade, 2)
+	assert.Equal(t, "upgrade mysql", m.Upgrade[0].Description)
+	assert.Equal(t, "upgrade wordpress", m.Upgrade[1].Description)
 
 	assert.Len(t, m.Uninstall, 2)
 	assert.Equal(t, "uninstall wordpress", m.Uninstall[0].Description)

--- a/pkg/mixin/exec/upgrade.go
+++ b/pkg/mixin/exec/upgrade.go
@@ -1,6 +1,6 @@
 package exec
 
-func (m *Mixin) Uninstall(commandFile string) error {
+func (m *Mixin) Upgrade(commandFile string) error {
 	// re-use Install's logic
 	return m.Install(commandFile)
 }


### PR DESCRIPTION
Adds `upgrade` action support to porter (and the `exec` mixin).

Closes https://github.com/deislabs/porter/issues/123