### PR TITLE
Fix typo in porter create

### DIFF
--- a/pkg/porter/create.go
+++ b/pkg/porter/create.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (p *Porter) Create() error {
-	fmt.Fprintln(p.Out, "creates porter configuration in the current directory")
+	fmt.Fprintln(p.Out, "creating porter configuration in the current directory")
 
 	configTmpl, err := p.Config.GetPorterConfigTemplate()
 	if err != nil {


### PR DESCRIPTION
The verb should indicate that we are performing the action now. There is no turning back. dah duh DUM! 😀 