### PR TITLE
Add install target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ on top of your work.
 1. `make build`, and the resulting binaries are located in `./bin`.
 1. `./bin/porter COMMAND`, such as `./bin/porter build`.
 
+If you would like to install a developer build, run `make install`.
+This copies a dev build to `~/.porter` and symlinks it to `/usr/local/bin`.
+
 # Documentation
 
 We use [Hugo](gohugo.io) to build our documentation site, and it is hosted on [Netlify](netlify.com).

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,11 @@ publish:
 	az storage blob upload-batch -d porter/$(PERMALINK)/templates -s templates
 	az storage blob upload-batch -d porter/$(PERMALINK) -s scripts/install
 
+install: build
+	mkdir -p $(HOME)/.porter
+	cp -R bin/* $(HOME)/.porter/
+	ln -f -s $(HOME)/.porter/porter /usr/local/bin/porter
+
 clean:
 	-rm -fr bin/
 	-rm -fr cnab/


### PR DESCRIPTION
The install target dumps the bin into ~/.porter and symlinks it to /usr/local/bin.

Note that this doesn't work with porter until #139 is merged.