### PR TITLE
Explain when to create issues before a PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,12 @@
 # Philosophy
 PRs are most welcome!
 
+* If there isn't an issue for your PR, please make an issue first and explain the problem or motivation for
+the change you are proposing. When the solution isn't straightforward, for example "Implement missing command X",
+then also outline your proposed solution. Your PR will go smoother if the solution is agreed upon before you've
+spent a lot of time implementing it.
+  * It's OK to submit a PR directly for problems such as misspellings or other things where the motivation/problem is
+    unambiguous.
 * If you aren't sure about your solution yet, put WIP in the title so that people know to be nice and 
 wait for you to finish before commenting.
 * Try to keep your PRs to a single task. Please don't tackle multiple things in a single PR if possible. Otherwise, grouping related changes into commits will help us out a bunch when reviewing!


### PR DESCRIPTION
Add a tip to the contributing guide on when an issue should be created and collaborated upon before submitting a pull request.