### PR TITLE
Fix integration tests for required params

### DIFF
--- a/build/testdata/bundles/wordpress/porter.yaml
+++ b/build/testdata/bundles/wordpress/porter.yaml
@@ -8,8 +8,8 @@ invocationImage: porter-wordpress:latest
 dependencies:
 - name: mysql
   parameters:
-    database_name: wordpress
-    mysql_user: wordpress
+    database-name: wordpress
+    mysql-user: wordpress
 
 credentials:
 - name: kubeconfig


### PR DESCRIPTION
When we added in required params, it found a bug in our integration tests. We had underscores instead of hyphens in the parameter names when overriding the default values of parameters in a dependent bundle. So the logic for required parameters was kicking in.