### PR TITLE
Make it easier to try out canary mixins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,14 @@ on top of your work.
 If you would like to install a developer build, run `make install`.
 This copies a dev build to `~/.porter` and symlinks it to `/usr/local/bin`.
 
+# Mixins
+
+When you run `make build`, the canary\* build of external mixins are automatically installed into your bin directory
+in the root of the repository. If you want to work against a different version of a mixin, then run `make clean build MIXIN_TAG=v1.2.3`.
+or use `latest` for the most recent tagged release.
+
+\* canary = most recent successful build of master
+
 # Documentation
 
 We use [Hugo](gohugo.io) to build our documentation site, and it is hosted on [Netlify](netlify.com).

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ else
 FILE_EXT=
 endif
 
-HELM_MIXIN_URL = https://deislabs.blob.core.windows.net/porter/mixins/helm/latest/helm
-AZURE_MIXIN_URL = https://deislabs.blob.core.windows.net/porter/mixins/azure/latest/azure
+MIXIN_TAG ?= canary
+HELM_MIXIN_URL = https://deislabs.blob.core.windows.net/porter/mixins/helm/$(MIXIN_TAG)/helm
+AZURE_MIXIN_URL = https://deislabs.blob.core.windows.net/porter/mixins/azure/$(MIXIN_TAG)/azure
 
 build: build-client build-runtime azure helm
 


### PR DESCRIPTION
By default when you do a `make build` it uses the latest tagged builds of other mixins. If a mixin is "in tree" like the exec mixin however, then you are getting a canary build of it.

This flips the default to `canary`, and then also make it possible to change the tag that it uses, so someone could use `latest` or a particular tagged version instead.