### PR TITLE
Porter is not a mixin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,17 @@ HELM_MIXIN_URL = https://deislabs.blob.core.windows.net/porter/mixins/helm/lates
 AZURE_MIXIN_URL = https://deislabs.blob.core.windows.net/porter/mixins/azure/latest/azure
 
 build: build-client build-runtime azure helm
+	rm -r bin/mixins/porter
 
 build-runtime:
 	$(MAKE) build-runtime MIXIN=porter -f mixin.mk
 	$(MAKE) build-runtime MIXIN=exec -f mixin.mk
+	mv bin/mixins/porter/porter-runtime$(FILE_EXT) bin/
 
 build-client: build-templates
 	$(MAKE) build-client MIXIN=porter -f mixin.mk
 	$(MAKE) build-client MIXIN=exec -f mixin.mk
-	cp bin/mixins/porter/porter$(FILE_EXT) bin/
+	mv bin/mixins/porter/porter$(FILE_EXT) bin/
 
 build-templates: get-deps
 	cd pkg/porter && packr2 build

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,25 @@ func (c *Config) GetHomeDir() (string, error) {
 	return c.porterHome, nil
 }
 
+func (c *Config) GetPorterPath() (string, error) {
+	home, err := c.GetHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	executablePath := filepath.Join(home, "porter")
+	return executablePath, nil
+}
+
+func (c *Config) GetPorterRuntimePath() (string, error) {
+	path, err := c.GetPorterPath()
+	if err != nil {
+		return "", nil
+	}
+
+	return path + "-runtime", nil
+}
+
 // GetPorterConfigTemplate returns a porter.yaml template file for use in new bundles
 func (c *Config) GetPorterConfigTemplate() ([]byte, error) {
 	t := packr.New("templates", "./templates")

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -156,17 +156,25 @@ func (p *Porter) prepareDockerFilesystem() error {
 		}
 	}
 
+	fmt.Printf("Copying porter runtime ===> \n")
+	pr, err := p.GetPorterRuntimePath()
+	if err != nil {
+		return err
+	}
+	err = p.CopyFile(pr, "cnab/app/porter-runtime")
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("Copying mixins ===> \n")
-	for _, mixin := range append(p.Manifest.Mixins, "porter") {
+	for _, mixin := range p.Manifest.Mixins {
 		err := p.copyMixin(mixin)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Make the porter runtime available at the root of the app
-	err := p.Context.CopyFile("cnab/app/mixins/porter/porter-runtime", "cnab/app/porter-runtime")
-	return errors.Wrap(err, "could not copy porter-runtime mixin")
+	return nil
 }
 
 func (p *Porter) copyDependency(bundle string) error {

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -108,10 +108,10 @@ func TestPorter_prepareDockerFilesystem(t *testing.T) {
 	err = p.prepareDockerFilesystem()
 	require.NoError(t, err)
 
-	wantPorterMixin := "cnab/app/mixins/porter/porter-runtime"
-	porterMixinExists, err := p.FileSystem.Exists(wantPorterMixin)
+	wantPorterRuntime := "cnab/app/porter-runtime"
+	porterMixinExists, err := p.FileSystem.Exists(wantPorterRuntime)
 	require.NoError(t, err)
-	assert.True(t, porterMixinExists, "The porter-runtime mixin wasn't copied into %s", wantPorterMixin)
+	assert.True(t, porterMixinExists, "The porter-runtime wasn't copied into %s", wantPorterRuntime)
 
 	wantExecMixin := "cnab/app/mixins/exec/exec-runtime"
 	execMixinExists, err := p.FileSystem.Exists(wantExecMixin)


### PR DESCRIPTION
When we first wrote porter, we said "Maybe it would make our life easier to treat porter itself as a mixin?!" Well, it makes life harder now. So this ensures that porter is built to the root of bin, and isn't treated _exactly_ the same as other mixins anymore.

I didn't tackle the mixins.mk file because a few small changes to the location of the binary was enough to get it working for now however.