### PR TITLE
Stop using relative paths to find bin

### DIFF
--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -31,5 +31,5 @@ func (c *TestConfig) SetupPorterHome() {
 	os.Setenv(EnvHOME, home)
 
 	// Copy bin dir contents to the home directory
-	c.TestContext.AddTestDirectory("../../bin/", home)
+	c.TestContext.AddTestDirectory(c.TestContext.FindBinDir(), home)
 }

--- a/pkg/context/helpers.go
+++ b/pkg/context/helpers.go
@@ -110,3 +110,35 @@ func (c *TestContext) AddTestDirectory(srcDir, destDir string) {
 func (c *TestContext) GetOutput() string {
 	return string(c.output.Bytes())
 }
+
+func (c *TestContext) FindBinDir() string {
+	var binDir string
+	d, err := os.Getwd()
+	if err != nil {
+		c.T.Fatal(err)
+	}
+	for {
+		binDir = c.getBinDir(d)
+		if binDir != "" {
+			return binDir
+		}
+
+		d = filepath.Dir(d)
+		if d == "." || d == "" {
+			c.T.Fatal("could not find the bin directory")
+		}
+	}
+}
+
+func (c *TestContext) getBinDir(dir string) string {
+	children, err := ioutil.ReadDir(dir)
+	if err != nil {
+		c.T.Fatal(err)
+	}
+	for _, child := range children {
+		if child.IsDir() && child.Name() == "bin" {
+			return filepath.Join(dir, child.Name())
+		}
+	}
+	return ""
+}

--- a/pkg/mixin/helpers.go
+++ b/pkg/mixin/helpers.go
@@ -1,6 +1,7 @@
 package mixin
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/deislabs/porter/pkg/context"
@@ -22,7 +23,8 @@ func NewTestRunner(t *testing.T, mixin string, runtime bool) *TestRunner {
 	r.Context = c.Context
 
 	// Setup Mixin Home
-	c.AddTestDirectory("../../bin/mixins", "/root/.porter/mixins")
+	srcMixinsDir := filepath.Join(c.FindBinDir(), "mixins")
+	c.AddTestDirectory(srcMixinsDir, "/root/.porter/mixins")
 
 	return r
 }

--- a/pkg/mixin/runner_test.go
+++ b/pkg/mixin/runner_test.go
@@ -2,8 +2,10 @@ package mixin
 
 import (
 	"bytes"
+	"path/filepath"
 	"testing"
 
+	"github.com/deislabs/porter/pkg/context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,8 +44,10 @@ func TestRunner_Validate_MissingExecutable(t *testing.T) {
 func TestRunner_Run(t *testing.T) {
 	output := &bytes.Buffer{}
 
+	binDir := context.NewTestContext(t).FindBinDir()
+
 	// I'm not using the TestRunner because I want to use the current filesystem, not an isolated one
-	r := NewRunner("exec", "../../bin/mixins/exec", false)
+	r := NewRunner("exec", filepath.Join(binDir, "mixins/exec"), false)
 	r.Command = "install"
 	r.File = "testdata/exec_input.yaml"
 

--- a/pkg/porter/mixins_test.go
+++ b/pkg/porter/mixins_test.go
@@ -44,8 +44,9 @@ func TestPorter_PrintMixins(t *testing.T) {
 	require.Nil(t, err)
 
 	// Just copy in the exec and helm mixins
-	p.TestConfig.TestContext.AddTestDirectory("../../bin/mixins/helm", filepath.Join(mixinsDir, "helm"))
-	p.TestConfig.TestContext.AddTestDirectory("../../bin/mixins/exec", filepath.Join(mixinsDir, "exec"))
+	srcMixinsDir := filepath.Join(p.TestConfig.TestContext.FindBinDir(), "mixins")
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(srcMixinsDir, "/helm"), filepath.Join(mixinsDir, "helm"))
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(srcMixinsDir, "/exec"), filepath.Join(mixinsDir, "exec"))
 
 	opts := printer.PrintOptions{Format: printer.FormatTable}
 	err = p.PrintMixins(opts)


### PR DESCRIPTION
When we run unit tests, we often need to find the bin directory (populated by the build) and then copy files out of it. Doing hard coded relative paths is brittle (and caused me problems in #146), so I've replaced it with a directory lookup.