### PR TITLE
Use go generate with packr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MIXIN_TAG ?= canary
 HELM_MIXIN_URL = https://deislabs.blob.core.windows.net/porter/mixins/helm/$(MIXIN_TAG)/helm
 AZURE_MIXIN_URL = https://deislabs.blob.core.windows.net/porter/mixins/azure/$(MIXIN_TAG)/azure
 
-build: get-deps build-client build-runtime azure helm
+build: build-client build-runtime azure helm
 	rm -r bin/mixins/porter
 
 build-runtime:
@@ -34,13 +34,16 @@ build-runtime:
 	$(MAKE) build-runtime MIXIN=exec -f mixin.mk
 	mv bin/mixins/porter/porter-runtime$(FILE_EXT) bin/
 
-build-client:
+build-client: generate
 	$(MAKE) build-client MIXIN=porter -f mixin.mk
 	$(MAKE) build-client MIXIN=exec -f mixin.mk
 	mv bin/mixins/porter/porter$(FILE_EXT) bin/
 
+generate: packr2
+	go generate ./...
+
 HAS_PACKR2 := $(shell command -v packr2)
-get-deps:
+packr2:
 ifndef HAS_PACKR2
 	go get -u github.com/gobuffalo/packr/v2/packr2
 endif

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,5 @@
+//go:generate packr2
+
 package config
 
 import (


### PR DESCRIPTION
* Put the go:generate directive at the top of any file that has a box
* The build runs a blanket go generate ./... so that we don't need to figure out which subpackages need to run packr2
* I did tests and swapping go build with packr2 build wasn't sufficient, it missed boxes, like pkg/config.
* Yes, this leaves *-packr.go files around, but at least we ignore them now and don't check them in. Hopefully it's not a problem.

This _isn't_ part of the mega PR of doom. 😀  Just general housekeeping. 

Closes #193 