### PR TITLE
Search waffle board for good first issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,5 +49,5 @@ We use [Hugo](gohugo.io) to build our documentation site, and it is hosted on [N
 If anyone is interested in contributing changes to our makefile to improve the authoring exerience, such 
 as doing this with Docker so that you don't need Hugo installed, it would be a welcome contribution! ❤️
 
-[good-first-issue]: https://github.com/deislabs/porter/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3Abacklog+
-[help-wanted]: https://github.com/deislabs/porter/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+label%3Abacklog+
+[good-first-issue]: https://waffle.io/deislabs/porter?search=backlog&label=good%20first%20issue
+[help-wanted]: https://waffle.io/deislabs/porter?search=backlog&label=help%20wanted


### PR DESCRIPTION
I chatted with waffle and they helped me figure out a workaround since you can't filter based on the reserved labels (like backlog).

This is better than the other links because it lets us search across multiple repos at the same time more easily.

Don't merge this until #146 merges so I don't have to rebase it again please! 😀 