### PR TITLE
Complete the exec schema command

### DIFF
--- a/pkg/config/actions.go
+++ b/pkg/config/actions.go
@@ -31,6 +31,10 @@ func ParseAction(value string) (Action, error) {
 	}
 }
 
+func GetSupportActions() []Action {
+	return []Action{ActionInstall, ActionUpgrade, ActionUninstall}
+}
+
 // IsInvalidActionError determines if an error is the error returned by ParseAction when
 // a value isn't a valid action.
 func IsInvalidActionError(err error) bool {

--- a/pkg/exec/schema/exec.json
+++ b/pkg/exec/schema/exec.json
@@ -3,24 +3,82 @@
   "install": {
     "type": "object",
     "properties": {
-      "description": {
-        "type": "string"
-      },
       "exec": {
         "type": "object",
         "properties": {
+          "description": {
+            "type": "string"
+          },
           "command": {
             "type": "string"
           },
           "arguments": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minItems": 1
             }
           }
-        }
+        },
+        "additionalProperties": false,
+        "required": ["description", "command"]
       }
-    }
+    },
+    "additionalProperties": false,
+    "required": ["exec"]
   },
-  "additionalProperties": false
+  "upgrade": {
+    "type": "object",
+    "properties": {
+      "exec": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minItems": 1
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": ["description", "command"]
+      }
+    },
+    "additionalProperties": false,
+    "required": ["exec"]
+  },
+  "uninstall": {
+    "type": "object",
+    "properties": {
+      "exec": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minItems": 1
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": ["description", "command"]
+      }
+    },
+    "additionalProperties": false,
+    "required": ["exec"]
+  }
 }

--- a/pkg/exec/testdata/schema.json
+++ b/pkg/exec/testdata/schema.json
@@ -3,24 +3,82 @@
   "install": {
     "type": "object",
     "properties": {
-      "description": {
-        "type": "string"
-      },
       "exec": {
         "type": "object",
         "properties": {
+          "description": {
+            "type": "string"
+          },
           "command": {
             "type": "string"
           },
           "arguments": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minItems": 1
             }
           }
-        }
+        },
+        "additionalProperties": false,
+        "required": ["description", "command"]
       }
-    }
+    },
+    "additionalProperties": false,
+    "required": ["exec"]
   },
-  "additionalProperties": false
+  "upgrade": {
+    "type": "object",
+    "properties": {
+      "exec": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minItems": 1
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": ["description", "command"]
+      }
+    },
+    "additionalProperties": false,
+    "required": ["exec"]
+  },
+  "uninstall": {
+    "type": "object",
+    "properties": {
+      "exec": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minItems": 1
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": ["description", "command"]
+      }
+    },
+    "additionalProperties": false,
+    "required": ["exec"]
+  }
 }

--- a/pkg/porter/schema.go
+++ b/pkg/porter/schema.go
@@ -92,10 +92,8 @@ func (p *Porter) GetManifestSchema() (map[string]interface{}, error) {
 			return nil, errors.Wrapf(err, "could not unmarshal mixin schema for %s, %q", mixin.Name, mixinSchema)
 		}
 
-		for action, actionSchema := range mixinSchemaMap {
-			if !config.IsSupportedAction(action) {
-				continue
-			}
+		for _, action := range config.GetSupportActions() {
+			actionSchema := mixinSchemaMap[string(action)]
 
 			ref := fmt.Sprintf("%s.%s", mixin.Name, action)
 			definitionSchema[ref] = actionSchema

--- a/pkg/porter/schema_test.go
+++ b/pkg/porter/schema_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMixin_PrintSchema(t *testing.T) {
+func TestPorter_PrintManifestSchema(t *testing.T) {
 	p := NewTestPorter(t)
 	p.TestConfig.SetupPorterHome()
 

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -3,25 +3,99 @@
   "additionalProperties": false,
   "definitions": {
     "exec.install": {
+      "additionalProperties": false,
       "properties": {
-        "description": {
-          "type": "string"
-        },
         "exec": {
+          "additionalProperties": false,
           "properties": {
             "arguments": {
               "items": {
+                "minItems": 1,
                 "type": "string"
               },
               "type": "array"
             },
             "command": {
               "type": "string"
+            },
+            "description": {
+              "type": "string"
             }
           },
+          "required": [
+            "description",
+            "command"
+          ],
           "type": "object"
         }
       },
+      "required": [
+        "exec"
+      ],
+      "type": "object"
+    },
+    "exec.uninstall": {
+      "additionalProperties": false,
+      "properties": {
+        "exec": {
+          "additionalProperties": false,
+          "properties": {
+            "arguments": {
+              "items": {
+                "minItems": 1,
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "command": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "command"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "exec"
+      ],
+      "type": "object"
+    },
+    "exec.upgrade": {
+      "additionalProperties": false,
+      "properties": {
+        "exec": {
+          "additionalProperties": false,
+          "properties": {
+            "arguments": {
+              "items": {
+                "minItems": 1,
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "command": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "command"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "exec"
+      ],
       "type": "object"
     }
   },
@@ -33,6 +107,12 @@
       "anyOf": [
         {
           "$ref": "#/definitions/exec.install"
+        },
+        {
+          "$ref": "#/definitions/exec.upgrade"
+        },
+        {
+          "$ref": "#/definitions/exec.uninstall"
         }
       ],
       "type": "array"
@@ -43,6 +123,8 @@
     "mixins": {
       "items": {
         "enum": [
+          "exec",
+          "exec",
           "exec"
         ],
         "type": "string"


### PR DESCRIPTION
Closes #181 

Looking at this makes me wonder if I'm going about merging json schema documents into a single document the hard way / wrong way (because the tricks* that one would use to reduce duplication don't work with how I'm doing the merge). Unless someone knows the right way, right now, I'm hoping we can merge this and revisit later. Let me know what you think though.

\* By tricks, I mean what I was immediately tempted to do in this PR was to add a definition once for an exec step and then reference it in each action. However the way schemas from mixins are merged _right now_ by porter, is to only grab the action from the schema and incorporate it into the final schema document. I think we'd need a second pass to figure out the right way (or if there isn't a right way, a more robust way) to merge schema documents without conflicts cropping up (for example each manifest has an install).