### PR TITLE
Remove extra call to packr2 build

### DIFF
--- a/mixin.mk
+++ b/mixin.mk
@@ -30,12 +30,9 @@ build-runtime:
 	mkdir -p $(BINDIR)
 	GOARCH=$(RUNTIME_ARCH) GOOS=$(RUNTIME_PLATFORM) go build -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) ./cmd/$(MIXIN)
 
-build-client: build-templates
+build-client:
 	mkdir -p $(BINDIR)
 	go build -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(MIXIN)$(FILE_EXT) ./cmd/$(MIXIN)
-
-build-templates:
-	cd pkg/$(MIXIN) && packr2 build
 
 xbuild-all: xbuild-runtime $(addprefix xbuild-for-,$(SUPPORTED_CLIENT_PLATFORMS))
 


### PR DESCRIPTION
This snuck in on a merge but wasn't supposed to be there now that we use go generate.