### PR TITLE
 Wrap steps in the containing action

### DIFF
--- a/cmd/exec/main.go
+++ b/cmd/exec/main.go
@@ -28,6 +28,7 @@ func buildRootCommand(in io.Reader) *cobra.Command {
 			m.Out = cmd.OutOrStdout()
 			m.Err = cmd.OutOrStderr()
 		},
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().BoolVar(&m.Debug, "debug", false, "Enable debug logging")

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -8,7 +8,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/deislabs/porter/pkg/config"
+	"github.com/pkg/errors"
+
 	"github.com/deislabs/porter/pkg/context"
 	"github.com/gobuffalo/packr/v2"
 	yaml "gopkg.in/yaml.v2"
@@ -18,22 +19,52 @@ import (
 type Mixin struct {
 	*context.Context
 
-	Step Step
+	Action Action
 
 	schemas *packr.Box
 }
 
+type Action struct {
+	Steps []Step // using UnmarshalYAML so that we don't need a custom type per action
+}
+
+// UnmarshalYAML takes any yaml in this form
+// ACTION:
+// - exec: ...
+// and puts the steps into the Action.Steps field
+func (a *Action) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	actionMap := map[interface{}][]interface{}{}
+	err := unmarshal(&actionMap)
+	if err != nil {
+		return errors.Wrap(err, "could not unmarshal yaml into an action map of exec steps")
+	}
+
+	for _, stepMaps := range actionMap {
+		b, err := yaml.Marshal(stepMaps)
+		if err != nil {
+			return err
+		}
+
+		var steps []Step
+		err = yaml.Unmarshal(b, &steps)
+		if err != nil {
+			return err
+		}
+
+		a.Steps = append(a.Steps, steps...)
+	}
+
+	return nil
+}
+
 type Step struct {
-	Description string              `yaml:"description"`
-	Outputs     []config.StepOutput `yaml:"outputs"`
-	Instruction Instruction         `yaml:"exec"`
+	Instruction `yaml:"exec"`
 }
 
 type Instruction struct {
-	Name       string            `yaml:"name"`
-	Command    string            `yaml:"command"`
-	Arguments  []string          `yaml:"arguments"`
-	Parameters map[string]string `yaml:"parameters"`
+	Description string   `yaml:"description"`
+	Command     string   `yaml:"command"`
+	Arguments   []string `yaml:"arguments"`
 }
 
 // New exec mixin client, initialized with useful defaults.
@@ -48,16 +79,30 @@ func NewSchemaBox() *packr.Box {
 	return packr.New("github.com/deislabs/porter/pkg/exec/schema", "./schema")
 }
 
-func (m *Mixin) LoadInstruction(commandFile string) error {
+func (m *Mixin) loadAction(commandFile string) error {
 	contents, err := m.getCommandFile(commandFile, m.Out)
 	if err != nil {
-		return fmt.Errorf("there was an error getting commands: %s", err)
+		source := "STDIN"
+		if commandFile == "" {
+			source = commandFile
+		}
+		return errors.Wrapf(err, "could not load input from %s", source)
 	}
-	return yaml.Unmarshal(contents, &m.Step)
+
+	err = yaml.Unmarshal(contents, &m.Action)
+	if m.Debug {
+		fmt.Fprintf(m.Err, "DEBUG Parsed Input:\n%#v\n", m.Action)
+	}
+	return errors.Wrapf(err, "could unmarshal input:\n %s", string(contents))
 }
 
 func (m *Mixin) Execute() error {
-	cmd := m.NewCommand(m.Step.Instruction.Command, m.Step.Instruction.Arguments...)
+	if len(m.Action.Steps) != 1 {
+		return errors.Errorf("expected a single step, but got %d", len(m.Action.Steps))
+	}
+	step := m.Action.Steps[0]
+
+	cmd := m.NewCommand(step.Command, step.Arguments...)
 	cmd.Stdout = m.Out
 	cmd.Stderr = m.Err
 

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -1,0 +1,27 @@
+package exec
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestAction_UnmarshalYAML(t *testing.T) {
+	b, err := ioutil.ReadFile("testdata/exec_input.yaml")
+	require.NoError(t, err)
+
+	action := Action{}
+	err = yaml.Unmarshal(b, &action)
+	require.NoError(t, err)
+
+	assert.Len(t, action.Steps, 1)
+	step := action.Steps[0]
+	assert.Equal(t, "bash", step.Command)
+	assert.Equal(t, "Install Hello World", step.Description)
+	assert.Len(t, step.Arguments, 2)
+	assert.Equal(t, "-c", step.Arguments[0])
+	assert.Equal(t, "echo Hello World", step.Arguments[1])
+}

--- a/pkg/exec/install.go
+++ b/pkg/exec/install.go
@@ -1,7 +1,7 @@
 package exec
 
 func (m *Mixin) Install(commandFile string) error {
-	err := m.LoadInstruction(commandFile)
+	err := m.loadAction(commandFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/exec/install_test.go
+++ b/pkg/exec/install_test.go
@@ -22,7 +22,10 @@ func TestMixin_Install(t *testing.T) {
 			Arguments: []string{"-c", "echo Hello World"},
 		},
 	}
-	b, _ := yaml.Marshal(step)
+	action := Action{
+		Steps: []Step{step},
+	}
+	b, _ := yaml.Marshal(action)
 
 	h := NewTestMixin(t)
 	h.In = bytes.NewReader(b)
@@ -36,8 +39,10 @@ func TestMixin_LoadInstructionFromFile(t *testing.T) {
 	h := NewTestMixin(t)
 	h.TestContext.AddTestDirectory("testdata", "testdata")
 
-	err := h.LoadInstruction("testdata/exec_input.yaml")
+	err := h.loadAction("testdata/exec_input.yaml")
 	require.NoError(t, err)
 
-	assert.Equal(t, "bash", h.Mixin.Step.Instruction.Command)
+	assert.Len(t, h.Mixin.Action.Steps, 1)
+	step := h.Mixin.Action.Steps[0]
+	assert.Equal(t, "bash", step.Instruction.Command)
 }

--- a/pkg/exec/testdata/exec_input.yaml
+++ b/pkg/exec/testdata/exec_input.yaml
@@ -1,6 +1,7 @@
-exec:
-  description: "Install Hello World"
-  command: bash
-  arguments:
-  - -c
-  - echo Hello World
+install:
+- exec:
+    description: "Install Hello World"
+    command: bash
+    arguments:
+    - -c
+    - echo Hello World

--- a/pkg/mixin/runner.go
+++ b/pkg/mixin/runner.go
@@ -18,7 +18,7 @@ type Runner struct {
 	Mixin   string
 	Runtime bool
 	Command string
-	Step    string
+	Input   string
 	File    string
 }
 
@@ -53,7 +53,7 @@ func (r *Runner) Run() error {
 		fmt.Fprintf(r.Err, "DEBUG mixin:    %s\n", r.Mixin)
 		fmt.Fprintf(r.Err, "DEBUG mixinDir: %s\n", r.mixinDir)
 		fmt.Fprintf(r.Err, "DEBUG file:     %s\n", r.File)
-		fmt.Fprintf(r.Err, "DEBUG stdin:\n%s\n", r.Step)
+		fmt.Fprintf(r.Err, "DEBUG stdin:\n%s\n", r.Input)
 	}
 
 	mixinPath := r.getMixinPath()
@@ -71,14 +71,14 @@ func (r *Runner) Run() error {
 		cmd.Args = append(cmd.Args, "--debug")
 	}
 
-	if r.Step != "" {
+	if r.Input != "" {
 		stdin, err := cmd.StdinPipe()
 		if err != nil {
 			return err
 		}
 		go func() {
 			defer stdin.Close()
-			io.WriteString(stdin, r.Step)
+			io.WriteString(stdin, r.Input)
 		}()
 	}
 

--- a/pkg/mixin/testdata/exec_input.yaml
+++ b/pkg/mixin/testdata/exec_input.yaml
@@ -1,6 +1,7 @@
-exec:
-  description: "Say Hello"
-  command: bash
-  arguments:
-  - -c
-  - echo Hello World
+install:
+- exec:
+    description: "Say Hello"
+    command: bash
+    arguments:
+    - -c
+    - echo Hello World

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -121,7 +121,7 @@ func (p *Porter) buildMixinsSection() ([]string, error) {
 
 		r := mixin.NewRunner(m, mixinDir, false)
 		r.Command = "build"
-		r.Step = "" // TODO: let the mixin know about which steps will be executed so that it can be more selective about copying into the invocation image
+		r.Input = "" // TODO: let the mixin know about which steps will be executed so that it can be more selective about copying into the invocation image
 
 		// Copy the existing context and tweak to pipe the output differently
 		mixinStdout := &bytes.Buffer{}

--- a/pkg/porter/run_test.go
+++ b/pkg/porter/run_test.go
@@ -4,6 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/deislabs/porter/pkg/config"
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/deislabs/porter/pkg/mixin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,4 +26,24 @@ func TestPorter_readOutputs(t *testing.T) {
 		"A=B",
 	}
 	assert.Equal(t, wantOutputs, gotOutputs)
+}
+
+func TestActionInput_MarshalYAML(t *testing.T) {
+	s := &config.Step{
+		Data: map[string]interface{}{
+			"exec": map[string]interface{}{
+				"command": "echo hi",
+			},
+		},
+	}
+
+	input := &ActionInput{
+		action: config.ActionInstall,
+		Steps:  []*config.Step{s},
+	}
+
+	b, err := yaml.Marshal(input)
+	require.NoError(t, err)
+	wantYaml := "install:\n- exec:\n    command: echo hi\n"
+	assert.Equal(t, wantYaml, string(b))
 }


### PR DESCRIPTION
- [x] Update the exec mixin to look for its step data wrapped in an action
- [x] Porter now sends steps to mixins wrapped in the containing action

```
install:
- exec:
     description: hello world
```

When sending steps to a mixin, provide context by wrapping them in the containing action (e.g. install, uninstall) so that the mixins can validate them against their schemas without having to maintain a
separate set of schema per action. This also will set us up for when `mixin build` will send a list of steps per action to validate.

This _should_ have been in #212 but ... wasn't. 😊 This also fixes the integration tests on master.