### PR TITLE
Suppress mkdir 'directory exists' output in Windows install

### DIFF
--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -3,11 +3,11 @@ $PORTER_URL="https://deislabs.blob.core.windows.net/porter"
 $PORTER_VERSION="UNKNOWN"
 echo "Installing porter to $PORTER_HOME"
 
-mkdir -p $PORTER_HOME/templates
-mkdir -p $PORTER_HOME/mixins/porter
-mkdir -p $PORTER_HOME/mixins/exec
-mkdir -p $PORTER_HOME/mixins/helm
-mkdir -p $PORTER_HOME/mixins/azure
+mkdir -force -p $PORTER_HOME/templates
+mkdir -force -p $PORTER_HOME/mixins/porter
+mkdir -force -p $PORTER_HOME/mixins/exec
+mkdir -force -p $PORTER_HOME/mixins/helm
+mkdir -force -p $PORTER_HOME/mixins/azure
 
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-windows-amd64.exe", "$PORTER_HOME\porter.exe")
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-runtime-linux-amd64", "$PORTER_HOME\mixins\porter\porter-runtime")


### PR DESCRIPTION
When updating a Windows install, the PowerShell script emits a lot of scary red error text before the discreet few lines about successfully installing.  This turns out to be just `mkdir` saying that the directories already exist and all is well.  This PR tells `mkdir` not to complain about directories already existing.