### PR TITLE
Inject porter-debug param into all bundles

### DIFF
--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/deislabs/porter/pkg/config"
+
 	cxt "github.com/deislabs/porter/pkg/context"
 	"github.com/deislabs/porter/pkg/mixin"
 	"github.com/docker/cli/cli/command"
@@ -305,7 +307,7 @@ func (p *Porter) buildBundle(invocationImage string, digest string) error {
 
 func (p *Porter) generateBundleParameters() map[string]ParameterDefinition {
 	params := map[string]ParameterDefinition{}
-	for _, param := range p.Manifest.Parameters {
+	for _, param := range append(p.Manifest.Parameters, p.buildDefaultPorterParameters()...) {
 		fmt.Printf("Generating parameter definition %s ====>\n", param.Name)
 		p := ParameterDefinition{
 			DataType:      param.DataType,
@@ -338,6 +340,21 @@ func (p *Porter) generateBundleParameters() map[string]ParameterDefinition {
 		params[param.Name] = p
 	}
 	return params
+}
+
+func (p *Porter) buildDefaultPorterParameters() []config.ParameterDefinition {
+	return []config.ParameterDefinition{
+		{
+			Name: "porter-debug",
+			Destination: &config.Location{
+				EnvironmentVariable: "PORTER_DEBUG",
+			},
+			DataType:     "bool",
+			DefaultValue: false,
+			Metadata: config.ParameterMetadata{
+				Description: "Print debug information from Porter when executing the bundle"},
+		},
+	}
 }
 
 func (p *Porter) generateBundleCredentials() map[string]Location {

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -149,9 +149,15 @@ func TestPorter_buildBundle(t *testing.T) {
 	err = json.Unmarshal(bundleBytes, &bundle)
 	require.NoError(t, err)
 
-	require.Equal(t, bundle.Name, "HELLO")
-	require.Equal(t, bundle.Version, "0.1.0")
-	require.Equal(t, bundle.Description, "An example Porter configuration")
+	assert.Equal(t, bundle.Name, "HELLO")
+	assert.Equal(t, bundle.Version, "0.1.0")
+	assert.Equal(t, bundle.Description, "An example Porter configuration")
+
+	debugParam, ok := bundle.Parameters["porter-debug"]
+	require.True(t, ok)
+	assert.Equal(t, "PORTER_DEBUG", debugParam.Destination.EnvironmentVariable)
+	assert.Equal(t, "bool", debugParam.DataType)
+	assert.Equal(t, false, debugParam.DefaultValue)
 }
 
 func TestPorter_paramRequired(t *testing.T) {


### PR DESCRIPTION
This will let us handoff a --debug flag from porter install into the bundle without the user having to manually specify the parameter.

So the user can run `porter install --debug` and porter will handle automatically turning on the porter-debug parameter when it executes the bundle, and then `porter run` will pick it up and bind its `--debug` flag to that automatically.

This is just the first step of defining the parameter for all porter built bundles.