### PR TITLE
Default --debug to the porter-debug parameter at runtime

### DIFF
--- a/cmd/porter/run.go
+++ b/cmd/porter/run.go
@@ -1,47 +1,26 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/deislabs/porter/pkg/config"
 	"github.com/deislabs/porter/pkg/porter"
 	"github.com/spf13/cobra"
 )
 
 func buildRunCommand(p *porter.Porter) *cobra.Command {
-	var opts struct {
-		file      string
-		rawAction string
-		action    config.Action
-	}
+	opts := porter.NewRunOptions(p.Config)
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Execute runtime bundle instructions",
 		Long:  "Execute the runtime bundle instructions contained in a porter configuration file",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if opts.rawAction == "" {
-				opts.rawAction = os.Getenv(config.EnvACTION)
-				if p.Debug {
-					fmt.Fprintf(p.Err, "DEBUG: defaulting action to %s (%s)\n", config.EnvACTION, opts.rawAction)
-				}
-			}
-
-			var err error
-			opts.action, err = config.ParseAction(opts.rawAction)
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.Run(opts.file, opts.action)
+			return p.Run(opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.file, "file", "f", "porter.yaml", "The porter configuration file (Defaults to porter.yaml)")
-	cmd.Flags().StringVar(&opts.rawAction, "action", "", "The bundle action to execute (Defaults to CNAB_ACTION)")
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "porter.yaml", "The porter configuration file (Defaults to porter.yaml)")
+	cmd.Flags().StringVar(&opts.Action, "action", "", "The bundle action to execute (Defaults to CNAB_ACTION)")
 
 	return cmd
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,9 @@ const (
 
 	// EnvACTION is the request
 	EnvACTION = "CNAB_ACTION"
+
+	// EnvDEBUG is a custom porter parameter that signals that --debug flag has been passed through from the client to the runtime.
+	EnvDEBUG = "PORTER_DEBUG"
 )
 
 // These are functions that afero doesn't support, so this lets us stub them out for tests to set the
@@ -39,10 +42,9 @@ type Config struct {
 // New Config initializes a default porter configuration.
 func New() *Config {
 	return &Config{
-		Context:   context.New(),
+		Context: context.New(),
 	}
 }
-
 
 // GetHomeDir determines the path to the porter home directory.
 func (c *Config) GetHomeDir() (string, error) {

--- a/pkg/porter/run_test.go
+++ b/pkg/porter/run_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,6 +27,28 @@ func TestPorter_readOutputs(t *testing.T) {
 		"A=B",
 	}
 	assert.Equal(t, wantOutputs, gotOutputs)
+}
+
+func TestPorter_defaultDebugToOff(t *testing.T) {
+	p := New() // Don't use the test porter, it has debug on by default
+	opts := NewRunOptions(p.Config)
+
+	err := opts.defaultDebug()
+	require.NoError(t, err)
+	assert.False(t, p.Config.Debug)
+}
+
+func TestPorter_defaultDebugUsesEnvVar(t *testing.T) {
+	os.Setenv(config.EnvDEBUG, "true")
+	defer os.Unsetenv(config.EnvDEBUG)
+
+	p := New() // Don't use the test porter, it has debug on by default
+	opts := NewRunOptions(p.Config)
+
+	err := opts.defaultDebug()
+	require.NoError(t, err)
+
+	assert.True(t, p.Config.Debug)
 }
 
 func TestActionInput_MarshalYAML(t *testing.T) {


### PR DESCRIPTION
Look for the new porter-debug parameter that are included in porter bundles now and use it to default the porter run --debug flag.