### PR TITLE
feat(examples): make mysql server name a required param

### DIFF
--- a/examples/azure-mysql-wordpress/porter.yaml
+++ b/examples/azure-mysql-wordpress/porter.yaml
@@ -31,6 +31,9 @@ parameters:
   type: string
   default: "wordpress"
 
+- name: server_name
+  type: string
+
 install:
   - azure:
       description: "Create Azure MySQL"
@@ -43,7 +46,8 @@ install:
         administratorLoginPassword:
           source: bundle.parameters.mysql_password
         location: "eastus"
-        serverName: "mysql-jeremy-porter-test"
+        serverName:
+          source: bundle.parameters.server_name
         version: "5.7"
         sslEnforcement: "Disabled"
         databaseName:


### PR DESCRIPTION
Previously, installing this bundle would most definitely result in an error, as the server name was hard-coded.  The ARM deployment error would look something like:

```
Error: error deploying "mysql-azure-porter-demo-wordpress" in resource group "porter-test": error while waiting for deployment to complete: Code="DeploymentFailed" Message="At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details." Details=[{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"ServerNameAlreadyExists\",\r\n    \"message\": \"Specified server name is already used.\"\r\n  }\r\n}"}]
```

(tl;dr: ` \"message\": \"Specified server name is already used.\"`)

Therefore, in this PR, I propose to not only parameterize this value, but also _not_ set a default and thus make it a required param when installing, say, via:

```
porter install --insecure -c amw --param server_name=porter-amw-vdice
```

