### PR TITLE
Default the porter-debug flag using --debug

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -17,7 +17,7 @@ func buildBundleCommands(p *porter.Porter) *cobra.Command {
 }
 
 func buildBundleInstallCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.InstallOptions{}
+	opts := &porter.InstallOptions{}
 	cmd := &cobra.Command{
 		Use:   "install [CLAIM]",
 		Short: "Install a bundle",

--- a/scripts/test/test-hello.sh
+++ b/scripts/test/test-hello.sh
@@ -13,5 +13,5 @@ ${PORTER_HOME}/porter create
 sed -i "s/porter-hello:latest/${REGISTRY}\/porter-hello:latest/g" porter.yaml
 
 ${PORTER_HOME}/porter build
-${PORTER_HOME}/porter install --insecure
+${PORTER_HOME}/porter install --insecure --debug
 cat ${PORTER_HOME}/claims/HELLO.json

--- a/scripts/test/test-wordpress.sh
+++ b/scripts/test/test-wordpress.sh
@@ -14,5 +14,5 @@ cp build/testdata/bundles/wordpress/porter.yaml .
 sed -i "s/porter-wordpress:latest/${REGISTRY}\/porter-wordpress:latest/g" porter.yaml
 
 ${PORTER_HOME}/porter build
-${PORTER_HOME}/porter install --insecure --cred ci
+${PORTER_HOME}/porter install --insecure --cred ci --debug
 cat ${PORTER_HOME}/claims/wordpress.json


### PR DESCRIPTION
This finishes up the work of getting `porter install --debug` hooked up completely between the client side and the runtime (inside the bundle) via a CNAB parameter. Check out the output from our test-cli to see that now when we run our integration tests we get debug output from inside the bundle! 🎉 