### PR TITLE
feat(test-cli): add integer and boolean sets to wordpress example/test bundle

### DIFF
--- a/build/testdata/bundles/wordpress/porter.yaml
+++ b/build/testdata/bundles/wordpress/porter.yaml
@@ -42,6 +42,8 @@ install:
         #externalDatabase.host: "{{ bundle.dependencies.mysql.outputs.services }}"
         externalDatabase.user: "{{ bundle.dependencies.mysql.parameters.mysql-user }}"
         externalDatabase.password: "{{ bundle.dependencies.mysql.outputs.mysql-password }}"
+        externalDatabase.port: 3306
+        mariadb.enabled: false
 
 uninstall:
   - helm:


### PR DESCRIPTION
Adding a couple non-string set values to our test bundle (installed via `make test-cli`) to ensure porter-helm mixin support.  

Will fail until https://github.com/deislabs/porter-helm/pull/30 is merged/released.