### PR TITLE
Remove copyright headers from params package

### DIFF
--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -1,20 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-This file has been modified from the original source
-https://github.com/kubernetes-incubator/service-catalog/blob/129d98e6f6e3c65d16d47a26fcf3357f0c3478de/cmd/svcat/parameters/parameters.go
-to use just one of the original functions that I (Carolyn Van Slyck) wrote for Service Catalog.
-*/
-
 package parameters
 
 import (

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -1,20 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-This file has been modified from the original source
-https://github.com/kubernetes-incubator/service-catalog/blob/129d98e6f6e3c65d16d47a26fcf3357f0c3478de/cmd/svcat/parameters/parameters_test.go
-to use just one of the original functions that I (Carolyn Van Slyck) wrote for Service Catalog.
-*/
-
 package parameters
 
 import (


### PR DESCRIPTION
I wrote this code for svcat, and then it was donated to service catalog, but it is my copyright. So no need for those headers.