### PR TITLE
Fix CI test runs so they don't step on each other

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -19,6 +19,9 @@ parameters:
   type: string
   destination:
     env: MYSQL_USER
+- name: namespace
+  type: string
+  default: ''
 
 install:
 - helm:
@@ -26,6 +29,8 @@ install:
     name: porter-ci-mysql
     chart: stable/mysql
     version: 0.10.2
+    namespace:
+      source: bundle.parameters.namespace
     replace: true
     set:
       mysqlDatabase:

--- a/build/testdata/bundles/wordpress/porter.yaml
+++ b/build/testdata/bundles/wordpress/porter.yaml
@@ -22,10 +22,12 @@ parameters:
   default: porter-ci-wordpress
   destination:
     env: WORDPRESS_NAME
-
 - name: wordpress-password
   type: string
   sensitive: true
+- name: namespace
+  type: string
+  default: ''
 
 install:
   - helm:
@@ -33,6 +35,8 @@ install:
       name:
         source: bundle.parameters.wordpress-name
       chart: stable/wordpress
+      namespace:
+        source: bundle.parameters.namespace
       replace: true
       set:
         wordpressPassword:

--- a/scripts/test/test-hello.sh
+++ b/scripts/test/test-hello.sh
@@ -15,3 +15,4 @@ sed -i "s/porter-hello:latest/${REGISTRY}\/porter-hello:latest/g" porter.yaml
 ${PORTER_HOME}/porter build
 ${PORTER_HOME}/porter install --insecure --debug
 cat ${PORTER_HOME}/claims/HELLO.json
+${PORTER_HOME}/porter uninstall --insecure --debug

--- a/scripts/test/test-terraform.sh
+++ b/scripts/test/test-terraform.sh
@@ -40,3 +40,8 @@ fi
 # ${PORTER_HOME}/porter uninstall --insecure --debug
 
 cat ${PORTER_HOME}/claims/porter-terraform.json
+
+# TODO: Figure out why this fails with the following error when the param is being set
+# Error: Error asking for user input: missing required value for "file_contents"
+# See https://github.com/deislabs/porter-terraform/issues/8
+# ${PORTER_HOME}/porter uninstall --insecure --debug --param file_contents='foo!'

--- a/scripts/test/test-wordpress.sh
+++ b/scripts/test/test-wordpress.sh
@@ -30,3 +30,5 @@ if cat ${install_log} | grep -q "${sensitive_value}"; then
 fi
 
 cat ${PORTER_HOME}/claims/wordpress.json
+
+${PORTER_HOME}/porter uninstall --insecure --cred ci --debug

--- a/scripts/test/test-wordpress.sh
+++ b/scripts/test/test-wordpress.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 export REGISTRY=${REGISTRY:-$USER}
 export PORTER_HOME=${PORTER_HOME:-bin}
+export NAMESPACE="$(head /dev/urandom | tr -dc a-z0-9 | head -c 10 ; echo '')"
 export KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
 # Run tests at the root of the repository
 export TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
@@ -20,7 +21,7 @@ install_log=$(mktemp)
 sensitive_value=${RANDOM}-value
 
 # Piping both stderr and stdout to log as debug logs may flow via stderr
-${PORTER_HOME}/porter install --insecure --cred ci --param wordpress-password="${sensitive_value}" --debug 2>&1 | tee ${install_log}
+${PORTER_HOME}/porter install --insecure --cred ci --param wordpress-password="${sensitive_value}" --param namespace=$NAMESPACE --debug 2>&1 | tee ${install_log}
 
 # Be sure that sensitive data is masked
 if cat ${install_log} | grep -q "${sensitive_value}"; then


### PR DESCRIPTION
This should let the CI tests run concurrently without rando failing. The other bundles don't have any global state so they don't need to be modified.

* The k8s related bundles install into a new namespace per test run
* The test now run uninstall at the end of the test run to cleanup after themselves

Closes #215
Closes #268 