### PR TITLE
Use unique helm release names per test run

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -22,11 +22,15 @@ parameters:
 - name: namespace
   type: string
   default: ''
+- name: mysql-name
+  type: string
+  default: porter-ci-mysql
 
 install:
 - helm:
     description: "Install MySQL"
-    name: porter-ci-mysql
+    name:
+      source: bundle.parameters.mysql-name
     chart: stable/mysql
     version: 0.10.2
     namespace:
@@ -39,14 +43,16 @@ install:
         source: bundle.parameters.mysql-user
     outputs:
     - name: mysql-root-password
-      secret: porter-ci-mysql
+      secret:
+        source: bundle.parameters.mysql-name
       key: mysql-root-password
     - name: mysql-password
-      secret: porter-ci-mysql
+      secret:
+        source: bundle.parameters.mysql-name
       key: mysql-password
 uninstall:
 - helm:
     description: "Uninstall MySQL"
     purge: true
     releases:
-      - porter-ci-mysql
+      - "source: bundle.parameters.mysql-name"

--- a/scripts/test/test-wordpress.sh
+++ b/scripts/test/test-wordpress.sh
@@ -21,7 +21,12 @@ install_log=$(mktemp)
 sensitive_value=${RANDOM}-value
 
 # Piping both stderr and stdout to log as debug logs may flow via stderr
-${PORTER_HOME}/porter install --insecure --cred ci --param wordpress-password="${sensitive_value}" --param namespace=$NAMESPACE --debug 2>&1 | tee ${install_log}
+${PORTER_HOME}/porter install --insecure --cred ci \
+    --param wordpress-password="${sensitive_value}" \
+    --param namespace=$NAMESPACE \
+    --param wordpress-name="porter-ci-wordpress-$NAMESPACE" \
+    --param mysql-name="porter-ci-mysql-$NAMESPACE" \
+    --debug 2>&1 | tee ${install_log}
 
 # Be sure that sensitive data is masked
 if cat ${install_log} | grep -q "${sensitive_value}"; then
@@ -32,3 +37,4 @@ fi
 cat ${PORTER_HOME}/claims/wordpress.json
 
 ${PORTER_HOME}/porter uninstall --insecure --cred ci --debug
+kubectl delete ns $NAMESPACE


### PR DESCRIPTION
helm release names have to be unique for the cluster, not just the namespace. Live 'n learn. 😀 

I also realized that I wasn't deleting the namespace at the end of the test run (I thought Helm did that for me if it made it). So this PR is essentially an homage to me not understanding Helm.