### PR TITLE
Do not encode -runtime into mixin download filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,19 +60,10 @@ xbuild-mixins: $(addprefix xbuild-mixin-,$(INT_MIXINS))
 xbuild-mixin-%: generate
 	$(MAKE) $(MAKE_OPTS) xbuild-all MIXIN=$* -f mixin.mk
 
-get-mixins: $(addprefix get-mixin-,$(EXT_MIXINS))
-
-get-mixin-helm: bin/mixins/helm/helm
-bin/mixins/helm/helm:
-	bin/porter mixin install helm --version $(MIXIN_TAG) --url $(MIXINS_URL)/helm
-
-get-mixin-azure: bin/mixins/azure/azure
-bin/mixins/azure/azure:
-	bin/porter mixin install azure --version $(MIXIN_TAG) --url $(MIXINS_URL)/azure
-
-get-mixin-terraform: bin/mixins/terraform/terraform
-bin/mixins/terraform/terraform:
-	bin/porter mixin install terraform --version $(MIXIN_TAG) --url $(MIXINS_URL)/terraform
+get-mixins:
+	$(foreach MIXIN, $(EXT_MIXINS), \
+		bin/porter mixin install $(MIXIN) --version $(MIXIN_TAG) --url $(MIXINS_URL)/$(MIXIN); \
+	)
 
 verify: verify-vendor
 
@@ -133,4 +124,3 @@ clean-mixins:
 
 clean-last-testrun:
 	-rm -fr cnab/ porter.yaml Dockerfile bundle.json
-	-helm delete --purge porter-ci-mysql porter-ci-wordpress

--- a/docs/content/mixin-distribution.md
+++ b/docs/content/mixin-distribution.md
@@ -28,7 +28,7 @@ for our DeisLabs mixins helpful as a starting point.
 Porter expects mixins to be published with a specific naming convention:
 
 * client: `VERSION/MIXIN-GOOS-GOARCH[FILE-EXT]`
-* runtime: `VERSION/MIXIN-runtime-linux-amd64`
+* runtime: `VERSION/MIXIN-linux-amd64`
 
 \* Note: Porter uses `GOOS` and `GOARCH` which are terms from the Go programming
 language, because it is written in Go. You must use the same terms, for example
@@ -41,7 +41,6 @@ base url/
 └── v0.4.0-ralpha.1+dubonnet
     ├── exec-darwin-amd64
     ├── exec-linux-amd64
-    ├── exec-runtime-linux-amd64
     └── exec-windows-amd64.exe
 ```
 
@@ -59,7 +58,7 @@ porter mixin install NAME --version VERSION --url URL
 ```
 
 * client url: `URL/VERSION/NAME-GOOS-GOARCH[FILE_EXT]`
-* runtime url: `URL/VERSION/NAME-runtime-linux-amd64`
+* runtime url: `URL/VERSION/NAME-linux-amd64`
 
 When `--version` is not specified, it is defaulted to `latest` which should
 represent the most recent version of the mixin.

--- a/mixin.mk
+++ b/mixin.mk
@@ -12,12 +12,12 @@ LDFLAGS = -w -X $(PKG)/pkg.Version=$(VERSION) -X $(PKG)/pkg.Commit=$(COMMIT)
 XBUILD = CGO_ENABLED=0 go build -a -tags netgo -ldflags '$(LDFLAGS)'
 BINDIR ?= bin/mixins/$(MIXIN)
 
-CLIENT_PLATFORM = $(shell go env GOOS)
-CLIENT_ARCH = $(shell go env GOARCH)
-RUNTIME_PLATFORM = linux
-RUNTIME_ARCH = amd64
-SUPPORTED_CLIENT_PLATFORMS = linux darwin windows
-SUPPORTED_CLIENT_ARCHES = amd64 386
+CLIENT_PLATFORM ?= $(shell go env GOOS)
+CLIENT_ARCH ?= $(shell go env GOARCH)
+RUNTIME_PLATFORM ?= linux
+RUNTIME_ARCH ?= amd64
+SUPPORTED_PLATFORMS = linux darwin windows
+SUPPORTED_ARCHES = amd64
 
 ifeq ($(CLIENT_PLATFORM),windows)
 FILE_EXT=.exe
@@ -27,25 +27,24 @@ else
 FILE_EXT=
 endif
 
+.PHONY: build
 build: build-client build-runtime
 
 build-runtime:
 	mkdir -p $(BINDIR)
-	GOARCH=$(RUNTIME_ARCH) GOOS=$(RUNTIME_PLATFORM) go build -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) ./cmd/$(MIXIN)
+	GOARCH=$(RUNTIME_ARCH) GOOS=$(RUNTIME_PLATFORM) $(XBUILD) -o $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) ./cmd/$(MIXIN)
 
 build-client:
 	mkdir -p $(BINDIR)
 	go build -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(MIXIN)$(FILE_EXT) ./cmd/$(MIXIN)
 
-xbuild-all: xbuild-runtime $(addprefix xbuild-for-,$(SUPPORTED_CLIENT_PLATFORMS))
+xbuild-all:
+	$(foreach OS, $(SUPPORTED_PLATFORMS), \
+		$(foreach ARCH, $(SUPPORTED_ARCHES), \
+				$(MAKE) $(MAKE_OPTS) CLIENT_PLATFORM=$(OS) CLIENT_ARCH=$(ARCH) MIXIN=$(MIXIN) xbuild -f mixin.mk; \
+		))
 
-xbuild-for-%:
-	$(MAKE) $(MAKE_OPTS) CLIENT_PLATFORM=$* MIXIN=$(MIXIN) xbuild-client -f mixin.mk
-
-xbuild-runtime:
-	GOARCH=$(RUNTIME_ARCH) GOOS=$(RUNTIME_PLATFORM) $(XBUILD) -o $(BINDIR)/$(VERSION)/$(MIXIN)-runtime-$(RUNTIME_PLATFORM)-$(RUNTIME_ARCH)$(FILE_EXT) ./cmd/$(MIXIN)
-
-xbuild-client: $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
+xbuild: $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
 $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT):
 	mkdir -p $(dir $@)
 	GOOS=$(CLIENT_PLATFORM) GOARCH=$(CLIENT_ARCH) $(XBUILD) -o $@ ./cmd/$(MIXIN)

--- a/pkg/mixin/provider/install.go
+++ b/pkg/mixin/provider/install.go
@@ -29,7 +29,7 @@ func (p *FileSystem) Install(opts mixin.InstallOptions) (mixin.Metadata, error) 
 	}
 
 	runtimeUrl := opts.GetParsedURL()
-	runtimeUrl.Path = path.Join(runtimeUrl.Path, opts.Version, fmt.Sprintf("%s-runtime-linux-amd64", opts.Name))
+	runtimeUrl.Path = path.Join(runtimeUrl.Path, opts.Version, fmt.Sprintf("%s-linux-amd64", opts.Name))
 	runtimePath := filepath.Join(mixinDir, opts.Name+"-runtime")
 	err = p.downloadFile(runtimeUrl, runtimePath)
 	if err != nil {

--- a/pkg/mixin/provider/install_test.go
+++ b/pkg/mixin/provider/install_test.go
@@ -93,7 +93,7 @@ func TestFileSystem_Install_RollbackBadDownload(t *testing.T) {
 func TestFileSystem_Install_RollbackMissingRuntime(t *testing.T) {
 	// serve out a fake mixin
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.RequestURI, "runtime") {
+		if strings.Contains(r.RequestURI, "linux-amd64") {
 			w.WriteHeader(400)
 		} else {
 			fmt.Fprintf(w, "#!/usr/bin/env bash\necho i am a client mixxin\n")


### PR DESCRIPTION
Instead of requiring the runtime binary for the mixin to be uploaded as foo-runtime-linux-amd64, allow the client mixin for linux, which is foo-linux-amd64, to be reused as there is no difference.

This sets us up anyway for when porter needs to support a customizable runtime image that could be a different os/arch.

Note: This doesn't change the name of the file on the filesystem, just what we require the mixin author to upload it as.

- [x] Update da code
- [x] Update all da makefiles
    * generate filenames that match the new format in the porter repo
    * install using porter mixin install
    * consolidate targets for the internal / external mixins

After this PR, I'll update the azure, helm, and terraform repos, and then all of the mixins will have done a canary publish with the new naming conventiong