### PR TITLE
Improve helptext template

### DIFF
--- a/cmd/porter/helptext/usage.txt
+++ b/cmd/porter/helptext/usage.txt
@@ -6,19 +6,19 @@ Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Examples:
-{{.Example}}{{end}}{{if not .HasParent }}
+{{.Example}}{{end}}{{if ShouldShowGroupCommands . "resource"}}
 
-Resources:{{range .Commands}}{{if eq (index .Annotations "group") "resource"}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+Resources:{{range .Commands}}{{if ShouldShowGroupCommand . "resource"}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if ShouldShowUngroupedCommands .}}
 
-Aliases:{{range .Commands}}{{if eq (index .Annotations "group") "alias"}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+Commands:{{range .Commands}}{{if ShouldShowUngroupedCommand . }}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if ShouldShowGroupCommands . "alias"}}
 
-Metadata:{{range .Commands}}{{if eq (index .Annotations "group") "meta"}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{if .HasAvailableSubCommands}}
+Aliased Commands:{{range .Commands}}{{if ShouldShowGroupCommand . "alias"}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if ShouldShowGroupCommands . "meta"}}
 
-Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+Meta Commands:{{range .Commands}}{{if ShouldShowGroupCommand . "meta"}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}


### PR DESCRIPTION
* Fix the template to work for resources nested at lower levels, like
porter mixin feed, where feed is a resource.
* Use go functions in the template to decide whether or not to show/hide
a section or a command instead of template conditionals
* Do not show the help command itself
* Show commands (like install) before aliased commands or meta commands (like version) which aren't as common/important