### PR TITLE
Generate a mixin feed based on a directory

### DIFF
--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -84,6 +84,7 @@ func buildMixinsFeedCommand(p *porter.Porter) *cobra.Command {
 	}
 
 	cmd.AddCommand(BuildMixinFeedGenerateCommand(p))
+	cmd.AddCommand(BuildMixinFeedTemplateCommand(p))
 
 	return cmd
 }
@@ -101,7 +102,7 @@ The file names of the mixins must follow the naming conventions required of publ
 
 VERSION/MIXIN-GOOS-GOARCH[FILE_EXT]
 
-More than one mixin may be present in the directory, and the directories may be nested a few levels dep, as long as the file path ends with the above naming convention, porter will find and match it. Below is an example directory structure that porter can list to generate a feed:
+More than one mixin may be present in the directory, and the directories may be nested a few levels deep, as long as the file path ends with the above naming convention, porter will find and match it. Below is an example directory structure that porter can list to generate a feed:
 
 bin/
 └── v1.2.3/
@@ -128,5 +129,17 @@ See https://porter.sh/mixin-distribution more details.
 	cmd.Flags().StringVarP(&opts.TemplateFile, "template", "t", "atom-template.xml",
 		"The template atom file used to populate the text fields in the generated feed.")
 
+	return cmd
+}
+
+func BuildMixinFeedTemplateCommand(p *porter.Porter) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "template",
+		Short: "Create an atom feed template",
+		Long:  "Create an atom feed template in the current directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.CreateMixinFeedTemplate()
+		},
+	}
 	return cmd
 }

--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/deislabs/porter/pkg/mixin"
+	"github.com/deislabs/porter/pkg/mixin/feed"
 	"github.com/deislabs/porter/pkg/porter"
 	"github.com/deislabs/porter/pkg/printer"
 	"github.com/spf13/cobra"
@@ -12,13 +13,14 @@ func buildMixinsCommand(p *porter.Porter) *cobra.Command {
 		Use:     "mixins",
 		Aliases: []string{"mixin"},
 		Short:   "Mixin commands",
-	}
-	cmd.Annotations = map[string]string{
-		"group": "resource",
+		Annotations: map[string]string{
+			"group": "resource",
+		},
 	}
 
 	cmd.AddCommand(buildMixinsListCommand(p))
 	cmd.AddCommand(BuildMixinInstallCommand(p))
+	cmd.AddCommand(buildMixinsFeedCommand(p))
 
 	return cmd
 }
@@ -67,6 +69,64 @@ func BuildMixinInstallCommand(p *porter.Porter) *cobra.Command {
 		"The mixin version. This can either be a version number, or a tagged release like 'latest' or 'canary'")
 	cmd.Flags().StringVar(&opts.URL, "url", "",
 		"URL from where the mixin can be downloaded, for example https://github.com/org/proj/releases/downloads")
+
+	return cmd
+}
+
+func buildMixinsFeedCommand(p *porter.Porter) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "feed",
+		Aliases: []string{"feeds"},
+		Short:   "Feed commands",
+		Annotations: map[string]string{
+			"group": "resource",
+		},
+	}
+
+	cmd.AddCommand(BuildMixinFeedGenerateCommand(p))
+
+	return cmd
+}
+
+func BuildMixinFeedGenerateCommand(p *porter.Porter) *cobra.Command {
+	opts := feed.GenerateOptions{}
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate an atom feed from the mixins in a directory",
+		Long: `Generate an atom feed from the mixins in a directory. 
+
+A template is required, providing values for text properties such as the author name, base URLs and other values that cannot be inferred from the mixin file names. You can make a default template by running 'porter mixins feed template'.
+
+The file names of the mixins must follow the naming conventions required of published mixins:
+
+VERSION/MIXIN-GOOS-GOARCH[FILE_EXT]
+
+More than one mixin may be present in the directory, and the directories may be nested a few levels dep, as long as the file path ends with the above naming convention, porter will find and match it. Below is an example directory structure that porter can list to generate a feed:
+
+bin/
+└── v1.2.3/
+    ├── mymixin-darwin-amd64
+    ├── mymixin-linux-amd64
+    └── mymixin-windows-amd64.exe
+
+See https://porter.sh/mixin-distribution more details.
+`,
+		Example: `  porter mixin feed generate
+  porter mixin feed generate --dir bin --file bin/atom.xml --template porter-atom-template.xml`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(p.Context)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.GenerateMixinFeed(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.SearchDirectory, "dir", "d", "",
+		"The directory to search for mixin versions to publish in the feed. Defaults to the current directory.")
+	cmd.Flags().StringVarP(&opts.AtomFile, "file", "f", "atom.xml",
+		"The path of the atom feed output by this command.")
+	cmd.Flags().StringVarP(&opts.TemplateFile, "template", "t", "atom-template.xml",
+		"The template atom file used to populate the text fields in the generated feed.")
 
 	return cmd
 }

--- a/mixin.mk
+++ b/mixin.mk
@@ -16,6 +16,7 @@ CLIENT_PLATFORM ?= $(shell go env GOOS)
 CLIENT_ARCH ?= $(shell go env GOARCH)
 RUNTIME_PLATFORM ?= linux
 RUNTIME_ARCH ?= amd64
+# NOTE: When we add more to the build matrix, update the regex for porter mixins feed generate
 SUPPORTED_PLATFORMS = linux darwin windows
 SUPPORTED_ARCHES = amd64
 

--- a/pkg/mixin/feed/feed.go
+++ b/pkg/mixin/feed/feed.go
@@ -1,0 +1,4 @@
+package feed
+
+type MixinFeed struct {
+}

--- a/pkg/mixin/feed/feed.go
+++ b/pkg/mixin/feed/feed.go
@@ -1,4 +1,45 @@
 package feed
 
-type MixinFeed struct {
+import "time"
+
+type MixinFeed map[string]map[string]*MixinFileset
+
+type MixinFileset struct {
+	Mixin   string
+	Version string
+	Files   []MixinFile
+}
+
+func (f *MixinFileset) Updated() string {
+	return toAtomTimestamp(f.GetLastUpdated())
+}
+
+func (f *MixinFileset) GetLastUpdated() time.Time {
+	var max time.Time
+	for _, f := range f.Files {
+		if f.Updated.After(max) {
+			max = f.Updated
+		}
+	}
+	return max
+}
+
+type MixinFile struct {
+	File    string
+	Updated time.Time
+}
+
+// MixinEntries is used to sort the entries in a mixin feed by when they were last updated
+type MixinEntries []*MixinFileset
+
+func (e MixinEntries) Len() int {
+	return len(e)
+}
+
+func (e MixinEntries) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+
+func (e MixinEntries) Less(i, j int) bool {
+	return e[i].GetLastUpdated().Before(e[j].GetLastUpdated())
 }

--- a/pkg/mixin/feed/generate.go
+++ b/pkg/mixin/feed/generate.go
@@ -1,0 +1,168 @@
+package feed
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/cbroglie/mustache"
+	"github.com/deislabs/porter/pkg/context"
+	"github.com/pkg/errors"
+)
+
+type GenerateOptions struct {
+	SearchDirectory string
+	AtomFile        string
+	TemplateFile    string
+}
+
+func (o *GenerateOptions) Validate(c *context.Context) error {
+	err := o.ValidateSearchDirectory(c)
+	if err != nil {
+		return err
+	}
+
+	return o.ValidateTemplateFile(c)
+}
+
+func (o *GenerateOptions) ValidateSearchDirectory(cxt *context.Context) error {
+	if o.SearchDirectory == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "could not get current working directory")
+		}
+
+		o.SearchDirectory = wd
+	}
+
+	if _, err := cxt.FileSystem.Stat(o.SearchDirectory); err != nil {
+		return errors.Wrapf(err, "invalid --directory %s", o.SearchDirectory)
+	}
+
+	return nil
+}
+
+func (o *GenerateOptions) ValidateTemplateFile(cxt *context.Context) error {
+	if _, err := cxt.FileSystem.Stat(o.TemplateFile); err != nil {
+		return errors.Wrapf(err, "invalid --template %s", o.TemplateFile)
+	}
+
+	return nil
+}
+
+type mixinFileset struct {
+	Mixin   string
+	Version string
+	Files   []mixinFile
+}
+
+func (f *mixinFileset) Updated() string {
+	return toAtomTimestamp(f.GetLastUpdated())
+}
+
+func (f *mixinFileset) GetLastUpdated() time.Time {
+	var max time.Time
+	for _, f := range f.Files {
+		if f.Updated.After(max) {
+			max = f.Updated
+		}
+	}
+	return max
+}
+
+type mixinEntries []*mixinFileset
+
+func (e mixinEntries) Len() int {
+	return len(e)
+}
+
+func (e mixinEntries) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+
+func (e mixinEntries) Less(i, j int) bool {
+	return e[i].GetLastUpdated().Before(e[j].GetLastUpdated())
+}
+
+type mixinFile struct {
+	File    string
+	Updated time.Time
+}
+
+type mixinFeed map[string]map[string]*mixinFileset
+
+func Generate(opts GenerateOptions, cxt *context.Context) error {
+	feedTmpl, err := cxt.FileSystem.ReadFile(opts.TemplateFile)
+	if err != nil {
+		return errors.Wrapf(err, "error reading template file at %s", opts.TemplateFile)
+	}
+
+	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z]+)-([a-z0-9]+)-([a-z0-9]+)(\.exe)?`)
+
+	feed := mixinFeed{}
+	found := 0
+	err = cxt.FileSystem.Walk(opts.SearchDirectory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		matches := mixinRegex.FindStringSubmatch(path)
+		if len(matches) > 0 {
+			version := matches[2]
+			mixin := matches[3]
+			filename := info.Name()
+
+			versions, ok := feed[mixin]
+			if !ok {
+				versions = map[string]*mixinFileset{}
+				feed[mixin] = versions
+			}
+
+			fileset, ok := versions[version]
+			if !ok {
+				fileset = &mixinFileset{
+					Mixin:   mixin,
+					Version: version,
+				}
+				versions[version] = fileset
+				found++
+			}
+			fileset.Files = append(fileset.Files, mixinFile{File: filename, Updated: info.ModTime()})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	tmplData := map[string]interface{}{}
+	mixins := make([]string, 0, len(feed))
+	entries := make(mixinEntries, 0, found)
+	for m, versions := range feed {
+		mixins = append(mixins, m)
+		for _, fileset := range versions {
+			entries = append(entries, fileset)
+		}
+	}
+	sort.Sort(sort.Reverse(entries))
+
+	tmplData["Mixins"] = mixins
+	tmplData["Entries"] = entries
+	tmplData["Updated"] = entries[0].Updated()
+
+	atomXml, err := mustache.Render(string(feedTmpl), tmplData)
+	err = cxt.FileSystem.WriteFile(opts.AtomFile, []byte(atomXml), 0644)
+	if err != nil {
+		return errors.Wrapf(err, "could not write feed to %s", opts.AtomFile)
+	}
+
+	fmt.Fprintf(cxt.Out, "wrote feed to %s\n", opts.AtomFile)
+	return nil
+}
+
+func toAtomTimestamp(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}

--- a/pkg/mixin/feed/generate.go
+++ b/pkg/mixin/feed/generate.go
@@ -38,7 +38,7 @@ func (o *GenerateOptions) ValidateSearchDirectory(cxt *context.Context) error {
 	}
 
 	if _, err := cxt.FileSystem.Stat(o.SearchDirectory); err != nil {
-		return errors.Wrapf(err, "invalid --directory %s", o.SearchDirectory)
+		return errors.Wrapf(err, "invalid --dir %s", o.SearchDirectory)
 	}
 
 	return nil
@@ -99,7 +99,7 @@ func Generate(opts GenerateOptions, cxt *context.Context) error {
 		return errors.Wrapf(err, "error reading template file at %s", opts.TemplateFile)
 	}
 
-	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z]+)-([a-z0-9]+)-([a-z0-9]+)(\.exe)?`)
+	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z]+)-(linux|windows|darwin)-(amd64)(\.exe)?`)
 
 	feed := mixinFeed{}
 	found := 0

--- a/pkg/mixin/feed/generate_test.go
+++ b/pkg/mixin/feed/generate_test.go
@@ -49,7 +49,10 @@ func TestGenerate(t *testing.T) {
 		SearchDirectory: "bin",
 		TemplateFile:    "template.xml",
 	}
-	err := Generate(opts, tc.Context)
+	f := MixinFeed{}
+	err := f.Generate(opts, tc.Context)
+	require.NoError(t, err)
+	err = f.Save(opts, tc.Context)
 	require.NoError(t, err)
 
 	b, err := tc.FileSystem.ReadFile("atom.xml")
@@ -68,19 +71,19 @@ func TestMixinEntries_Sort(t *testing.T) {
 	up3, _ := time.Parse("2006-Jan-02", "2013-Feb-03")
 	up4, _ := time.Parse("2006-Jan-02", "2013-Feb-04")
 
-	entries := mixinEntries{
+	entries := MixinEntries{
 		{
-			Files: []mixinFile{
+			Files: []MixinFile{
 				{Updated: up3},
 			},
 		},
 		{
-			Files: []mixinFile{
+			Files: []MixinFile{
 				{Updated: up2},
 			},
 		},
 		{
-			Files: []mixinFile{
+			Files: []MixinFile{
 				{Updated: up4},
 			},
 		},

--- a/pkg/mixin/feed/generate_test.go
+++ b/pkg/mixin/feed/generate_test.go
@@ -1,0 +1,94 @@
+package feed
+
+import (
+	"io/ioutil"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deislabs/porter/pkg/context"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate(t *testing.T) {
+	tc := context.NewTestContext(t)
+	tc.AddTestFile("testdata/atom-template.xml", "template.xml")
+
+	tc.FileSystem.Create("bin/v1.2.3/helm-darwin-amd64")
+	tc.FileSystem.Create("bin/v1.2.3/helm-linux-amd64")
+	tc.FileSystem.Create("bin/v1.2.3/helm-windows-amd64.exe")
+
+	// Force the up3 timestamps to stay the same for each test run
+	up3, _ := time.Parse("2006-Jan-02", "2013-Feb-03")
+	tc.FileSystem.Chtimes("bin/v1.2.3/helm-darwin-amd64", up3, up3)
+	tc.FileSystem.Chtimes("bin/v1.2.3/helm-linux-amd64", up3, up3)
+	tc.FileSystem.Chtimes("bin/v1.2.3/helm-windows-amd64.exe", up3, up3)
+
+	tc.FileSystem.Create("bin/v1.2.4/helm-darwin-amd64")
+	tc.FileSystem.Create("bin/v1.2.4/helm-linux-amd64")
+	tc.FileSystem.Create("bin/v1.2.4/helm-windows-amd64.exe")
+
+	up4, _ := time.Parse("2006-Jan-02", "2013-Feb-04")
+	tc.FileSystem.Chtimes("bin/v1.2.4/helm-darwin-amd64", up4, up4)
+	tc.FileSystem.Chtimes("bin/v1.2.4/helm-linux-amd64", up4, up4)
+	tc.FileSystem.Chtimes("bin/v1.2.4/helm-windows-amd64.exe", up4, up4)
+
+	tc.FileSystem.Create("bin/v1.2.3/exec-darwin-amd64")
+	tc.FileSystem.Create("bin/v1.2.3/exec-linux-amd64")
+	tc.FileSystem.Create("bin/v1.2.3/exec-windows-amd64.exe")
+
+	up2, _ := time.Parse("2006-Jan-02", "2013-Feb-02")
+	tc.FileSystem.Chtimes("bin/v1.2.3/exec-darwin-amd64", up2, up2)
+	tc.FileSystem.Chtimes("bin/v1.2.3/exec-linux-amd64", up2, up2)
+	tc.FileSystem.Chtimes("bin/v1.2.3/exec-windows-amd64.exe", up2, up2)
+
+	opts := GenerateOptions{
+		AtomFile:        "atom.xml",
+		SearchDirectory: "bin",
+		TemplateFile:    "template.xml",
+	}
+	err := Generate(opts, tc.Context)
+	require.NoError(t, err)
+
+	b, err := tc.FileSystem.ReadFile("atom.xml")
+	require.NoError(t, err)
+	gotXml := string(b)
+
+	b, err = ioutil.ReadFile("testdata/atom.xml")
+	require.NoError(t, err)
+	wantXml := string(b)
+
+	assert.Equal(t, wantXml, gotXml)
+}
+
+func TestMixinEntries_Sort(t *testing.T) {
+	up2, _ := time.Parse("2006-Jan-02", "2013-Feb-02")
+	up3, _ := time.Parse("2006-Jan-02", "2013-Feb-03")
+	up4, _ := time.Parse("2006-Jan-02", "2013-Feb-04")
+
+	entries := mixinEntries{
+		{
+			Files: []mixinFile{
+				{Updated: up3},
+			},
+		},
+		{
+			Files: []mixinFile{
+				{Updated: up2},
+			},
+		},
+		{
+			Files: []mixinFile{
+				{Updated: up4},
+			},
+		},
+	}
+
+	sort.Sort(sort.Reverse(entries))
+
+	assert.Equal(t, up4, entries[0].Files[0].Updated)
+	assert.Equal(t, up3, entries[1].Files[0].Updated)
+	assert.Equal(t, up2, entries[2].Files[0].Updated)
+}

--- a/pkg/mixin/feed/template.go
+++ b/pkg/mixin/feed/template.go
@@ -1,0 +1,31 @@
+package feed
+
+import (
+	"fmt"
+
+	"github.com/deislabs/porter/pkg/context"
+	"github.com/gobuffalo/packr/v2"
+	"github.com/pkg/errors"
+)
+
+func CreateTemplate(cxt *context.Context) error {
+	box := NewTemplatesBox()
+	tmpl, err := box.Find("atom-template.xml")
+	if err != nil {
+		return errors.Wrap(err, "error loading mixin feed template")
+	}
+
+	templateFile := "atom-template.xml"
+	err = cxt.FileSystem.WriteFile(templateFile, tmpl, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "error writing mixin feed template to %s", templateFile)
+	}
+
+	fmt.Fprintf(cxt.Out, "wrote mixin feed template to %s\n", templateFile)
+	return nil
+}
+
+// NewSchemas creates or retrieves the packr box with the porter template files.
+func NewTemplatesBox() *packr.Box {
+	return packr.New("github.com/deislabs/porter/pkg/mixin/feed/templates", "./templates")
+}

--- a/pkg/mixin/feed/template_test.go
+++ b/pkg/mixin/feed/template_test.go
@@ -1,0 +1,19 @@
+package feed
+
+import (
+	"testing"
+
+	"github.com/deislabs/porter/pkg/context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTemplate(t *testing.T) {
+	tc := context.NewTestContext(t)
+
+	err := CreateTemplate(tc.Context)
+
+	require.NoError(t, err)
+	success, _ := tc.Context.FileSystem.Exists("atom-template.xml")
+	assert.True(t, success)
+}

--- a/pkg/mixin/feed/templates/atom-template.xml
+++ b/pkg/mixin/feed/templates/atom-template.xml
@@ -1,0 +1,21 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <id>https://example.com/mixins</id>
+    <title>Example Mixins</title>
+    <updated>{{Updated}}</updated>
+    <link rel="self" href="https://example.com/mixins/atom.xml"/>
+    {{#Mixins}}
+    <category term="{{.}}"/>
+    {{/Mixins}}
+    {{#Entries}}
+    <entry>
+        <id>https://example.com/mixins/{{Version}}/{{Mixin}}</id>
+        <title>{{Mixin}} @ {{Version}}</title>
+        <updated>{{Updated}}</updated>
+        <category term="{{Mixin}}"/>
+        <content>{{Version}}</content>
+        {{#Files}}
+        <link ref="download" href="https://example.com/mixins/{{Version}}/{{File}}" />
+        {{/Files}}
+    </entry>
+    {{/Entries}}
+</feed>

--- a/pkg/mixin/feed/templates/atom-template.xml
+++ b/pkg/mixin/feed/templates/atom-template.xml
@@ -14,7 +14,7 @@
         <category term="{{Mixin}}"/>
         <content>{{Version}}</content>
         {{#Files}}
-        <link ref="download" href="https://example.com/mixins/{{Version}}/{{File}}" />
+        <link rel="download" href="https://example.com/mixins/{{Version}}/{{File}}" />
         {{/Files}}
     </entry>
     {{/Entries}}

--- a/pkg/mixin/feed/testdata/atom-template.xml
+++ b/pkg/mixin/feed/testdata/atom-template.xml
@@ -18,7 +18,7 @@
         <category term="{{Mixin}}"/>
         <content>{{Version}}</content>
         {{#Files}}
-        <link ref="download" href="https://porter.sh/mixins/{{Version}}/{{File}}" />
+        <link rel="download" href="https://porter.sh/mixins/{{Version}}/{{File}}" />
         {{/Files}}
     </entry>
     {{/Entries}}

--- a/pkg/mixin/feed/testdata/atom-template.xml
+++ b/pkg/mixin/feed/testdata/atom-template.xml
@@ -1,0 +1,25 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <id>https://porter.sh/mixins</id>
+    <title>DeisLabs Mixins</title>
+    <updated>{{Updated}}</updated>
+    <link rel="self" href="https://porter.sh/mixins/atom.xml"/>
+    <author>
+        <name>DeisLabs</name>
+        <uri>https://deislabs.io</uri>
+    </author>
+    {{#Mixins}}
+    <category term="{{.}}"/>
+    {{/Mixins}}
+    {{#Entries}}
+    <entry>
+        <id>https://porter.sh/mixins/{{Version}}/{{Mixin}}</id>
+        <title>{{Mixin}} @ {{Version}}</title>
+        <updated>{{Updated}}</updated>
+        <category term="{{Mixin}}"/>
+        <content>{{Version}}</content>
+        {{#Files}}
+        <link ref="download" href="https://porter.sh/mixins/{{Version}}/{{File}}" />
+        {{/Files}}
+    </entry>
+    {{/Entries}}
+</feed>

--- a/pkg/mixin/feed/testdata/atom.xml
+++ b/pkg/mixin/feed/testdata/atom.xml
@@ -1,0 +1,42 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <id>https://porter.sh/mixins</id>
+    <title>DeisLabs Mixins</title>
+    <updated>2013-02-04T00:00:00Z</updated>
+    <link rel="self" href="https://porter.sh/mixins/atom.xml"/>
+    <author>
+        <name>DeisLabs</name>
+        <uri>https://deislabs.io</uri>
+    </author>
+    <category term="exec"/>
+    <category term="helm"/>
+    <entry>
+        <id>https://porter.sh/mixins/v1.2.4/helm</id>
+        <title>helm @ v1.2.4</title>
+        <updated>2013-02-04T00:00:00Z</updated>
+        <category term="helm"/>
+        <content>v1.2.4</content>
+        <link ref="download" href="https://porter.sh/mixins/v1.2.4/helm-darwin-amd64" />
+        <link ref="download" href="https://porter.sh/mixins/v1.2.4/helm-linux-amd64" />
+        <link ref="download" href="https://porter.sh/mixins/v1.2.4/helm-windows-amd64.exe" />
+    </entry>
+    <entry>
+        <id>https://porter.sh/mixins/v1.2.3/helm</id>
+        <title>helm @ v1.2.3</title>
+        <updated>2013-02-03T00:00:00Z</updated>
+        <category term="helm"/>
+        <content>v1.2.3</content>
+        <link ref="download" href="https://porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
+        <link ref="download" href="https://porter.sh/mixins/v1.2.3/helm-linux-amd64" />
+        <link ref="download" href="https://porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
+    </entry>
+    <entry>
+        <id>https://porter.sh/mixins/v1.2.3/exec</id>
+        <title>exec @ v1.2.3</title>
+        <updated>2013-02-02T00:00:00Z</updated>
+        <category term="exec"/>
+        <content>v1.2.3</content>
+        <link ref="download" href="https://porter.sh/mixins/v1.2.3/exec-darwin-amd64" />
+        <link ref="download" href="https://porter.sh/mixins/v1.2.3/exec-linux-amd64" />
+        <link ref="download" href="https://porter.sh/mixins/v1.2.3/exec-windows-amd64.exe" />
+    </entry>
+</feed>

--- a/pkg/mixin/feed/testdata/atom.xml
+++ b/pkg/mixin/feed/testdata/atom.xml
@@ -15,9 +15,9 @@
         <updated>2013-02-04T00:00:00Z</updated>
         <category term="helm"/>
         <content>v1.2.4</content>
-        <link ref="download" href="https://porter.sh/mixins/v1.2.4/helm-darwin-amd64" />
-        <link ref="download" href="https://porter.sh/mixins/v1.2.4/helm-linux-amd64" />
-        <link ref="download" href="https://porter.sh/mixins/v1.2.4/helm-windows-amd64.exe" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.4/helm-darwin-amd64" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.4/helm-linux-amd64" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.4/helm-windows-amd64.exe" />
     </entry>
     <entry>
         <id>https://porter.sh/mixins/v1.2.3/helm</id>
@@ -25,9 +25,9 @@
         <updated>2013-02-03T00:00:00Z</updated>
         <category term="helm"/>
         <content>v1.2.3</content>
-        <link ref="download" href="https://porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
-        <link ref="download" href="https://porter.sh/mixins/v1.2.3/helm-linux-amd64" />
-        <link ref="download" href="https://porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-linux-amd64" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
     </entry>
     <entry>
         <id>https://porter.sh/mixins/v1.2.3/exec</id>
@@ -35,8 +35,8 @@
         <updated>2013-02-02T00:00:00Z</updated>
         <category term="exec"/>
         <content>v1.2.3</content>
-        <link ref="download" href="https://porter.sh/mixins/v1.2.3/exec-darwin-amd64" />
-        <link ref="download" href="https://porter.sh/mixins/v1.2.3/exec-linux-amd64" />
-        <link ref="download" href="https://porter.sh/mixins/v1.2.3/exec-windows-amd64.exe" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-darwin-amd64" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-linux-amd64" />
+        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-windows-amd64.exe" />
     </entry>
 </feed>

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/deislabs/porter/pkg/mixin"
-
+	"github.com/deislabs/porter/pkg/mixin/feed"
 	"github.com/deislabs/porter/pkg/printer"
 )
 
@@ -58,4 +58,8 @@ func (p *Porter) InstallMixin(opts mixin.InstallOptions) error {
 	}
 
 	return nil
+}
+
+func (p *Porter) GenerateMixinFeed(opts feed.GenerateOptions) error {
+	return feed.Generate(opts, p.Context)
 }

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -61,7 +61,12 @@ func (p *Porter) InstallMixin(opts mixin.InstallOptions) error {
 }
 
 func (p *Porter) GenerateMixinFeed(opts feed.GenerateOptions) error {
-	return feed.Generate(opts, p.Context)
+	f := feed.MixinFeed{}
+	err := f.Generate(opts, p.Context)
+	if err != nil {
+		return err
+	}
+	return f.Save(opts, p.Context)
 }
 
 func (p *Porter) CreateMixinFeedTemplate() error {

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -63,3 +63,7 @@ func (p *Porter) InstallMixin(opts mixin.InstallOptions) error {
 func (p *Porter) GenerateMixinFeed(opts feed.GenerateOptions) error {
 	return feed.Generate(opts, p.Context)
 }
+
+func (p *Porter) CreateMixinFeedTemplate() error {
+	return feed.CreateTemplate(p.Context)
+}


### PR DESCRIPTION
This adds two commands to porter as a build up to supporting mixin feeds. All alone they aren't really enough to add new docs or anything yet though.

Note: This doesn't update an existing atom.xml file yet. I plan on doing that in a follow-up PR.

```console
$ porter mixins feed template --help
Create an atom feed template in the current directory

Usage:
  porter mixins feed template
```

```console
$ porter mixins feed generate --help
Generate an atom feed from the mixins in a directory.

A template is required, providing values for text properties such as the author name, 
base URLs and other values that cannot be inferred from the mixin file names. You 
can make a default template by running 'porter mixins feed template'.

The file names of the mixins must follow the naming conventions required of published 
mixins:

VERSION/MIXIN-GOOS-GOARCH[FILE_EXT]

More than one mixin may be present in the directory, and the directories may be nested 
a few levels deep, as long as the file path ends with the above naming convention, porter 
will find and match it. Below is an example directory structure that porter can list to 
generate a feed:

bin/
└── v1.2.3/
    ├── mymixin-darwin-amd64
    ├── mymixin-linux-amd64
    └── mymixin-windows-amd64.exe

See https://porter.sh/mixin-distribution more details.

Usage:
  porter mixins feed generate [flags]

Examples:
porter mixin feed generate
porter mixin feed generate --dir bin --file bin/atom.xml --template porter-atom-template.xml

Flags:
  -d, --dir string        The directory to search for mixin versions to publish in the feed. Defaults to 
the current directory.
  -f, --file string       The path of the atom feed output by this command. (default "atom.xml")
  -h, --help              help for generate
  -t, --template string   The template atom file used to populate the text fields in the generated 
feed. (default "atom-template.xml")
```