### PR TITLE
feat(manifest): enable bundle name interpolation

### DIFF
--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -574,6 +574,9 @@ func (m *Manifest) buildSourceData() (map[string]interface{}, error) {
 	bundle := make(map[string]interface{})
 	data["bundle"] = bundle
 
+	// Enable interpolation of manifest/bundle name via bundle.name
+	bundle["name"] = m.Name
+
 	params := make(map[string]interface{})
 	bundle["parameters"] = params
 	for _, param := range m.Parameters {

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -776,3 +776,24 @@ func TestManifest_MergeParameters(t *testing.T) {
 	require.Len(t, m.Parameters, 1)
 	assert.Equal(t, "wordpress", m.Parameters[0].DefaultValue)
 }
+
+func TestManifest_ResolveBundleName(t *testing.T) {
+	m := &Manifest{
+		Name: "mybundle",
+	}
+
+	s := &Step{
+		Data: map[string]interface{}{
+			"description": "a test step exercising bundle name interpolation",
+			"Arguments": []string{
+				"{{ bundle.name }}",
+			},
+		},
+	}
+
+	err := m.ResolveStep(s)
+	require.NoError(t, err)
+	args, ok := s.Data["Arguments"].([]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "mybundle", args[0].(string))
+}


### PR DESCRIPTION
This enhancement came about as I wrote a bundle that had a use for passing the bundle name to a mixin action (via templating in the porter manifest).

If this feature gets the go ahead, do we also want to add similar for a dependency bundle name, such that one could also reference/interpolate `bundle.dependency.name` at some point in a porter manifest?