### PR TITLE
scripts/install: make exporting easier for users

### DIFF
--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -38,4 +38,6 @@ chmod +x $PORTER_HOME/mixins/azure/azure
 chmod +x $PORTER_HOME/mixins/azure/azure-runtime
 echo Installed azure mixin
 
-echo "Installation complete. Add $PORTER_HOME to your PATH."
+echo "Installation complete."
+echo "Add porter to your path by running:"
+echo "export $PATH=$PATH:$PORTER_HOME"

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -40,4 +40,4 @@ echo Installed azure mixin
 
 echo "Installation complete."
 echo "Add porter to your path by running:"
-echo "export $PATH=$PATH:$PORTER_HOME"
+echo "export PATH=$PATH:$PORTER_HOME"


### PR DESCRIPTION
This PR shows users the explicit command to add `$PORTER_HOME` to their path.