### PR TITLE
Show how to add porter to the path in install scripts

### DIFF
--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -38,4 +38,6 @@ chmod +x $PORTER_HOME/mixins/azure/azure
 chmod +x $PORTER_HOME/mixins/azure/azure-runtime
 echo Installed azure mixin
 
-echo "Installation complete. Add $PORTER_HOME to your PATH."
+echo "Installation complete."
+echo "Add porter to your path by running:"
+echo "export PATH=\$PATH:~/.porter"

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -40,4 +40,4 @@ echo Installed azure mixin
 
 echo "Installation complete."
 echo "Add porter to your path by running:"
-echo "export PATH=$PATH:$PORTER_HOME"
+echo "export PATH=\$PATH:~/.porter"

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -27,4 +27,6 @@ echo "Installed $(iex "$PORTER_HOME\mixins\helm\helm.exe version")"
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/mixins/azure/$PORTER_VERSION/azure-runtime-linux-amd64", "$PORTER_HOME\mixins\azure\azure-runtime")
 echo "Installed azure mixin"
 
-echo "Installation complete. Add $PORTER_HOME to your PATH."
+echo "Installation complete."
+echo "Add porter to your path by running:"
+echo '$env:PATH+=";$env:USERPROFILE\.porter"'


### PR DESCRIPTION
Add instructions to the remaining install scripts for how to add porter to the path. Also fixed a bash escape goof, so that the variable name, instead of the contents, are printed out for the user to copy.

This is a follow-up to #281.