### PR TITLE
Install mixins using new install command

### DIFF
--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -6,37 +6,17 @@ PORTER_URL=https://deislabs.blob.core.windows.net/porter
 PORTER_VERSION=${PORTER_VERSION:-UNKNOWN}
 echo "Installing porter to $PORTER_HOME"
 
-mkdir -p $PORTER_HOME/templates
-mkdir -p $PORTER_HOME/mixins/porter
-mkdir -p $PORTER_HOME/mixins/exec
-mkdir -p $PORTER_HOME/mixins/helm
-mkdir -p $PORTER_HOME/mixins/azure
+mkdir $PORTER_HOME
 
 curl -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_VERSION/porter-linux-amd64
-curl -fsSLo $PORTER_HOME/mixins/porter/porter-runtime $PORTER_URL/$PORTER_VERSION/porter-runtime-linux-amd64
-curl -fsSLo $PORTER_HOME/templates/porter.yaml $PORTER_URL/$PORTER_VERSION/templates/porter.yaml
-curl -fsSLo $PORTER_HOME/templates/run $PORTER_URL/$PORTER_VERSION/templates/run
 chmod +x $PORTER_HOME/porter
-chmod +x $PORTER_HOME/mixins/porter/porter-runtime
+cp $PORTER_HOME/porter $PORTER_HOME/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
-curl -fsSLo $PORTER_HOME/mixins/exec/exec $PORTER_URL/mixins/exec/$PORTER_VERSION/exec-linux-amd64
-curl -fsSLo $PORTER_HOME/mixins/exec/exec-runtime $PORTER_URL/mixins/exec/$PORTER_VERSION/exec-runtime-linux-amd64
-chmod +x $PORTER_HOME/mixins/exec/exec
-chmod +x $PORTER_HOME/mixins/exec/exec-runtime
-echo Installed `$PORTER_HOME/mixins/exec/exec version`
-
-curl -fsSLo $PORTER_HOME/mixins/helm/helm $PORTER_URL/mixins/helm/$PORTER_VERSION/helm-linux-amd64
-curl -fsSLo $PORTER_HOME/mixins/helm/helm-runtime $PORTER_URL/mixins/helm/$PORTER_VERSION/helm-runtime-linux-amd64
-chmod +x $PORTER_HOME/mixins/helm/helm
-chmod +x $PORTER_HOME/mixins/helm/helm-runtime
-echo Installed `$PORTER_HOME/mixins/helm/helm version`
-
-curl -fsSLo $PORTER_HOME/mixins/azure/azure $PORTER_URL/mixins/azure/$PORTER_VERSION/azure-linux-amd64
-curl -fsSLo $PORTER_HOME/mixins/azure/azure-runtime $PORTER_URL/mixins/azure/$PORTER_VERSION/azure-runtime-linux-amd64
-chmod +x $PORTER_HOME/mixins/azure/azure
-chmod +x $PORTER_HOME/mixins/azure/azure-runtime
-echo Installed azure mixin
+MIXINS_URL=$PORTER_URL/mixins
+$PORTER_HOME/porter mixin install exec --version $PORTER_VERSION --url $MIXINS_URL/exec
+$PORTER_HOME/porter mixin install helm --version $PORTER_VERSION --url $MIXINS_URL/helm
+$PORTER_HOME/porter mixin install azure --version $PORTER_VERSION --url $MIXINS_URL/azure
 
 echo "Installation complete."
 echo "Add porter to your path by running:"

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -6,37 +6,18 @@ PORTER_URL=https://deislabs.blob.core.windows.net/porter
 PORTER_VERSION=${PORTER_VERSION:-UNKNOWN}
 echo "Installing porter to $PORTER_HOME"
 
-mkdir -p $PORTER_HOME/templates
-mkdir -p $PORTER_HOME/mixins/porter
-mkdir -p $PORTER_HOME/mixins/exec
-mkdir -p $PORTER_HOME/mixins/helm
-mkdir -p $PORTER_HOME/mixins/azure
+mkdir $PORTER_HOME
 
 curl -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_VERSION/porter-darwin-amd64
-curl -fsSLo $PORTER_HOME/mixins/porter/porter-runtime $PORTER_URL/$PORTER_VERSION/porter-runtime-linux-amd64
-curl -fsSLo $PORTER_HOME/templates/porter.yaml $PORTER_URL/$PORTER_VERSION/templates/porter.yaml
-curl -fsSLo $PORTER_HOME/templates/run $PORTER_URL/$PORTER_VERSION/templates/run
+curl -fsSLo $PORTER_HOME/porter-runtime $PORTER_URL/$PORTER_VERSION/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
-chmod +x $PORTER_HOME/mixins/porter/porter-runtime
+chmod +x $PORTER_HOME/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
-curl -fsSLo $PORTER_HOME/mixins/exec/exec $PORTER_URL/mixins/exec/$PORTER_VERSION/exec-darwin-amd64
-curl -fsSLo $PORTER_HOME/mixins/exec/exec-runtime $PORTER_URL/mixins/exec/$PORTER_VERSION/exec-runtime-linux-amd64
-chmod +x $PORTER_HOME/mixins/exec/exec
-chmod +x $PORTER_HOME/mixins/exec/exec-runtime
-echo Installed `$PORTER_HOME/mixins/exec/exec version`
-
-curl -fsSLo $PORTER_HOME/mixins/helm/helm $PORTER_URL/mixins/helm/$PORTER_VERSION/helm-darwin-amd64
-curl -fsSLo $PORTER_HOME/mixins/helm/helm-runtime $PORTER_URL/mixins/helm/$PORTER_VERSION/helm-runtime-linux-amd64
-chmod +x $PORTER_HOME/mixins/helm/helm
-chmod +x $PORTER_HOME/mixins/helm/helm-runtime
-echo Installed `$PORTER_HOME/mixins/helm/helm version`
-
-curl -fsSLo $PORTER_HOME/mixins/azure/azure $PORTER_URL/mixins/azure/$PORTER_VERSION/azure-darwin-amd64
-curl -fsSLo $PORTER_HOME/mixins/azure/azure-runtime $PORTER_URL/mixins/azure/$PORTER_VERSION/azure-runtime-linux-amd64
-chmod +x $PORTER_HOME/mixins/azure/azure
-chmod +x $PORTER_HOME/mixins/azure/azure-runtime
-echo Installed azure mixin
+MIXINS_URL=$PORTER_URL/mixins
+$PORTER_HOME/porter mixin install exec --version $PORTER_VERSION --url $MIXINS_URL/exec
+$PORTER_HOME/porter mixin install helm --version $PORTER_VERSION --url $MIXINS_URL/helm
+$PORTER_HOME/porter mixin install azure --version $PORTER_VERSION --url $MIXINS_URL/azure
 
 echo "Installation complete."
 echo "Add porter to your path by running:"

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -3,29 +3,16 @@ $PORTER_URL="https://deislabs.blob.core.windows.net/porter"
 $PORTER_VERSION="UNKNOWN"
 echo "Installing porter to $PORTER_HOME"
 
-mkdir -force -p $PORTER_HOME/templates
-mkdir -force -p $PORTER_HOME/mixins/porter
-mkdir -force -p $PORTER_HOME/mixins/exec
-mkdir -force -p $PORTER_HOME/mixins/helm
-mkdir -force -p $PORTER_HOME/mixins/azure
+mkdir $PORTER_HOME
 
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-windows-amd64.exe", "$PORTER_HOME\porter.exe")
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-runtime-linux-amd64", "$PORTER_HOME\mixins\porter\porter-runtime")
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/templates/porter.yaml", "$PORTER_HOME\templates\porter.yaml")
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/templates/run", "$PORTER_HOME\templates\run")
+(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-linux-amd64", "$PORTER_HOME\porter-runtime")
 echo "Installed $(iex "$PORTER_HOME\porter.exe version")"
 
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/mixins/exec/$PORTER_VERSION/exec-windows-amd64.exe", "$PORTER_HOME\mixins\exec\exec.exe")
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/mixins/exec/$PORTER_VERSION/exec-runtime-linux-amd64", "$PORTER_HOME\mixins\exec\exec-runtime")
-echo "Installed $(iex "$PORTER_HOME\mixins\exec\exec.exe version")"
-
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/mixins/helm/$PORTER_VERSION/helm-windows-amd64.exe", "$PORTER_HOME\mixins\helm\helm.exe")
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/mixins/helm/$PORTER_VERSION/helm-runtime-linux-amd64", "$PORTER_HOME\mixins\helm\helm-runtime")
-echo "Installed $(iex "$PORTER_HOME\mixins\helm\helm.exe version")"
-
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/mixins/azure/$PORTER_VERSION/azure-windows-amd64.exe", "$PORTER_HOME\mixins\azure\azure.exe")
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/mixins/azure/$PORTER_VERSION/azure-runtime-linux-amd64", "$PORTER_HOME\mixins\azure\azure-runtime")
-echo "Installed azure mixin"
+$MIXINS_URL="$PORTER_URL/mixins"
+iex "$PORTER_HOME/porter mixin install exec --version $PORTER_VERSION --url $MIXINS_URL/exec"
+iex "$PORTER_HOME/porter mixin install helm --version $PORTER_VERSION --url $MIXINS_URL/helm"
+iex "$PORTER_HOME/porter mixin install azure --version $PORTER_VERSION --url $MIXINS_URL/azure"
 
 echo "Installation complete."
 echo "Add porter to your path by running:"


### PR DESCRIPTION
* Use `porter mixin install` to install the default set of mixins
* Use new filename for runtime in install script, we now publish using `porter-linux-amd64` instead of `porter-runtime-linux-amd64`
* Refresh script a bit, it was still making a templates directory, putting porter in a mixins directory, etc.