### PR TITLE
Make install scripts rerunnable

### DIFF
--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -6,7 +6,7 @@ PORTER_URL=https://deislabs.blob.core.windows.net/porter
 PORTER_VERSION=${PORTER_VERSION:-UNKNOWN}
 echo "Installing porter to $PORTER_HOME"
 
-mkdir $PORTER_HOME
+mkdir -p $PORTER_HOME
 
 curl -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_VERSION/porter-linux-amd64
 chmod +x $PORTER_HOME/porter

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -6,7 +6,7 @@ PORTER_URL=https://deislabs.blob.core.windows.net/porter
 PORTER_VERSION=${PORTER_VERSION:-UNKNOWN}
 echo "Installing porter to $PORTER_HOME"
 
-mkdir $PORTER_HOME
+mkdir -p $PORTER_HOME
 
 curl -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_VERSION/porter-darwin-amd64
 curl -fsSLo $PORTER_HOME/porter-runtime $PORTER_URL/$PORTER_VERSION/porter-linux-amd64

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -3,7 +3,7 @@ $PORTER_URL="https://deislabs.blob.core.windows.net/porter"
 $PORTER_VERSION="UNKNOWN"
 echo "Installing porter to $PORTER_HOME"
 
-mkdir $PORTER_HOME
+mkdir -f $PORTER_HOME
 
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-windows-amd64.exe", "$PORTER_HOME\porter.exe")
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-linux-amd64", "$PORTER_HOME\porter-runtime")


### PR DESCRIPTION
The install scripts should succeed when run a second time. If the home directory already exists, that shouldn't cause a failure.