### PR TITLE
Fixed up a whitespace error

### DIFF
--- a/examples/azure-mysql-wordpress/porter.yaml
+++ b/examples/azure-mysql-wordpress/porter.yaml
@@ -41,7 +41,7 @@ install:
       name: mysql-azure-porter-demo-wordpress
       resourceGroup: "porter-test"
       parameters:
-        administratorLogin: "{{ bundle.parameters.mysql_user }} "
+        administratorLogin: "{{ bundle.parameters.mysql_user }}"
         administratorLoginPassword: "{{ bundle.parameters.mysql_password }}"
         location: "eastus"
         serverName: "{{ bundle.parameters.server_name }}"


### PR DESCRIPTION
Turns out that `azureuser ` is not a valid username! 

The example had a space in the param template, so this fixes that up. 