### PR TITLE
Use porter install in our docs

### DIFF
--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -86,7 +86,7 @@ parameters:
 Credentials are part of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/802-credential-sets.md) and allow
 you to pass in sensitive data when you execute the bundle, such as passwords or configuration files.
 
-When the bundle is executed, for example when you run `duffle install`, the installer will look on your local system
+When the bundle is executed, for example when you run `porter install`, the installer will look on your local system
 for the named credential and then place the value or file found in the bundle as either an environment variable or file.
 
 By default, all credential values are considered sensitive and will be masked in console output.

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -16,7 +16,7 @@ created Dockerfile
 created bundle.json
 created cnab/app/run
 
-$ duffle install myapp -f bundle.json
+$ porter install
 ```
 
 Here's a sample Porter manifest:

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -60,19 +60,12 @@ able to `docker push` to and that your end-users are able to `docker pull` from.
 
 ## Install the bundle
 
-_Wondering the differences between Duffle and Porter? Please see [this page](/porter-or-duffle/)._
-
-First, make sure Duffle is installed
-(see [install instructions](https://github.com/deislabs/duffle/blob/master/README.md#getting-started)).
-
-You can then use `duffle install` to install your bundle ("demo" is the unique installation name):
+You can then use `porter install` to install your bundle ("demo" is the unique installation name):
 ```
-duffle install demo -f bundle.json
+porter install demo
 ```
 
-The `duffle list` command can be used to show all installed bundles.
-
-If you wish to uninstall the bundle, you can use `duffle uninstall`:
+If you wish to uninstall the bundle, you can use `porter uninstall`:
 ```
-duffle uninstall demo
+porter uninstall demo
 ```


### PR DESCRIPTION
Now that we have porter install/uninstall implemented, we should tell people to use that instead of duffle in our docs.