### PR TITLE
Clean packr files before verifying vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ get-mixins:
 
 verify: verify-vendor
 
-verify-vendor: dep
+verify-vendor: clean-packr dep
 	dep check
 
 HAS_DEP := $(shell command -v dep)
@@ -127,3 +127,9 @@ clean-mixins:
 
 clean-last-testrun:
 	-rm -fr cnab/ porter.yaml Dockerfile bundle.json
+
+clean-packr: packr2
+	cd pkg/porter && packr2 clean
+	$(foreach MIXIN, $(INT_MIXINS), \
+		`cd pkg/$(MIXIN) && packr2 clean`; \
+	)


### PR DESCRIPTION
The packr temp files were throwing off the vendor check locally. This removes them using `packr2 clean` first before we check.