### PR TITLE
ref(Makefile): mandate PORTER_HOME value for make; no build prereq for install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ on top of your work.
 1. `./bin/porter COMMAND`, such as `./bin/porter build`.
 
 If you would like to install a developer build, run `make install`.
-This copies a dev build to `~/.porter` and symlinks it to `/usr/local/bin`.
+This copies a dev build (assumed previously built via e.g. `make build`) to `~/.porter` and symlinks it to `/usr/local/bin`.
 
 # Mixins
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION ?= $(shell git describe --tags 2> /dev/null || echo v0)
 PERMALINK ?= $(shell git name-rev --name-only --tags --no-undefined HEAD &> /dev/null && echo latest || echo canary)
 
 KUBECONFIG  ?= $(HOME)/.kube/config
-PORTER_HOME ?= bin
+PORTER_HOME = bin
 
 CLIENT_PLATFORM = $(shell go env GOOS)
 CLIENT_ARCH = $(shell go env GOARCH)
@@ -115,7 +115,7 @@ publish: prep-install-scripts
 	fi
 	az storage blob upload-batch -d porter/$(PERMALINK) -s bin/$(VERSION)
 
-install: build
+install:
 	mkdir -p $(HOME)/.porter
 	cp -R bin/* $(HOME)/.porter/
 	ln -f -s $(HOME)/.porter/porter /usr/local/bin/porter


### PR DESCRIPTION
* Ensure `PORTER_HOME` is set to `bin` for all applicable make targets (not yet setup to run with other, user-defined values)

* Remove `build` target prerequisite from `install` (shortens dev loop for, say, only building the porter binary and installing locally, as in `make build-porter install`)