### PR TITLE
Add spring music example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Porter Examples
+
+This directory contains several example Porter bundles that demonstrate various Porter capabilities.
+
+## Azure Ark
+
+This example creates an Azure storage account using the `azure` and then uses the `helm` mixin to install [Valero](https://github.com/heptio/velero) into an existing Kubernetes cluster. In order to use install this example, you will need an Azure account and a [Service Principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest). You'll also need a Kubernetes cluster in Azure, we recommend using AKS.
+
+## Azure MySQL WordPress
+
+This example creates an Azure MySQL database using the `azure` mixin and then uses the `helm` mixin to install WordPress into an existing Kubernetes cluster. In order to use install this example, you will need an Azure account and a [Service Principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest). You'll also need a Kubernetes cluster in Azure, we recommend using AKS.
+
+## AKS Spring Music
+
+This example represents an advanced use case for Porter. First, the example showcases the use of a base Dockerfile. This allows you to customize the resulting invocation image by installing software not installed by mixins or by adding any other resources needed for your bundle. Next, it uses the `azure` mixin to create an AKS cluster. Next, it uses the `exec` mixin to obtain the kubeconfig for the AKS cluster and the `kubernetes` mixin to apply RBAC policies in support of Tiller. Then, it uses the `exec` mixin to initialize Helm's Tiller component. Once that has been completed, it uses the `azure` mixin to create a CosmosDB instance with MongoDB API compatability. Finally, it uses the `helm` mixin to install the Spring Music showcase application. This bundle requires an Azure account a [Service Principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest).
+

--- a/examples/aks-spring-music/.gitignore
+++ b/examples/aks-spring-music/.gitignore
@@ -1,0 +1,4 @@
+cnab/app/mixins/*
+cnab/app/porter-runtime
+Dockerfile
+bundle.json

--- a/examples/aks-spring-music/README.md
+++ b/examples/aks-spring-music/README.md
@@ -12,7 +12,7 @@ The bundle leverages a base Dockerfile (cnab/app/Dockerfile.base) to customize t
 
 ### Prerequisites
 
-- Porter on local machine. http://porter.sh
+- Porter on local machine. See these helpful [installation instructions](https://porter.sh/install) 
 - Docker on local machine (eg - Docker for Mac)
 - Bash
 - Azure service principal with rights to create a RG, AKS, Cosmos, etc. 

--- a/examples/aks-spring-music/README.md
+++ b/examples/aks-spring-music/README.md
@@ -1,12 +1,14 @@
 # CNAB Bundle with Porter - Spring Music Demo App
 
-This project is a sample CNAB bundle that is created and managed by Porter. https://porter.sh 
+This bundle demonstrates advanced use cases for Porter.
 
-This bundle uses 3 mixins to access your Azure subscription and deploy the app. These values need to be updated in the porter.yaml.
+The bundle leverages a base Dockerfile (cnab/app/Dockerfile.base) to customize the resulting invocation image for the bundle by first installing the `azure cli` so that it can be used by the `exec` mixin. It then uses 4 mixins to access your Azure subscription and deploy the app. These values need to be updated in the porter.yaml.
 
-* The `exec` mixin uses an Azure Service Principal to access via the CLI.
-* The `azure` mixin uses ARM and requires the subscription and tenant info. 
-* The `helm` mixin deploys the chart into your AKS cluster.
+* The `azure` mixin is used to create an AKS cluster using ARM. This requires subscription and tenant info.
+* The `exec` mixin uses an Azure Service Principal to access via the CLI and install Helm's Tiller into an AKS cluster.
+* The `kubernetes` mixin applys RBAC policies for Helm
+* The `helm` mixin deploys the chart into the AKS cluster.
+
 
 ### Prerequisites
 

--- a/examples/aks-spring-music/README.md
+++ b/examples/aks-spring-music/README.md
@@ -1,0 +1,52 @@
+# CNAB Bundle with Porter - Spring Music Demo App
+
+This project is a sample CNAB bundle that is created and managed by Porter. https://porter.sh 
+
+This bundle uses 3 mixins to access your Azure subscription and deploy the app. These values need to be updated in the porter.yaml.
+
+* The `exec` mixin uses an Azure Service Principal to access via the CLI.
+* The `azure` mixin uses ARM and requires the subscription and tenant info. 
+* The `helm` mixin deploys the chart into your AKS cluster.
+
+### Prerequisites
+
+- Porter on local machine. http://porter.sh
+- Docker on local machine (eg - Docker for Mac)
+- Bash
+- Azure service principal with rights to create a RG, AKS, Cosmos, etc. 
+
+    ```bash
+    az ad sp create-for-rbac --name ServicePrincipalName
+    ```
+
+    More details here: https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest 
+
+- Follow the process in the porter docs to add these credentials in your config.
+
+
+### Build / Install this bundle
+
+* Setup credentials with Porter
+
+The bundle will use the service principal created above to interact with Azure. Generate a credential using the `porter credentials generate` command:
+
+    ```bash
+    porter credentials generate azure 
+    ```
+
+* Update params for your deployment
+    * change the `invocationImage` Docker repo to match your Docker Hub account (line 4)
+    * Cosmos and AKS names must be unique. You can either edit the `porter.yaml` file default values (starting on line 90) or you can supply the with the porter CLI as shown below.
+
+* Build the innvocation image
+
+    ```bash
+    porter build
+    ```
+
+* Install the bundle
+
+    ```bash
+    export INSTALL_ID=314
+    porter install -c azure  --param app-resource-group=spring-music-demo-$INSTALL_ID --param aks-resource-group=spring-music-demo-$INSTALL_ID --param aks-cluster-name=briar-aks-spring-$INSTALL_ID --param cosmosdb-service-name=briarspringmusic$INSTALL_ID --param azure-location=eastus
+    ```

--- a/examples/aks-spring-music/cnab/app/Dockerfile.base
+++ b/examples/aks-spring-music/cnab/app/Dockerfile.base
@@ -1,0 +1,3 @@
+FROM debian:stretch
+
+RUN apt-get update -y && apt-get install curl apt-transport-https lsb-release gnupg -y && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && AZ_REPO=$(lsb_release -cs) && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list && apt-get update && apt-get install azure-cli

--- a/examples/aks-spring-music/cnab/app/charts/spring-music/Chart.yaml
+++ b/examples/aks-spring-music/cnab/app/charts/spring-music/Chart.yaml
@@ -1,0 +1,7 @@
+name: spring-music
+home: https://github.com/cloudfoundry-samples/spring-music
+version: 1.0
+description: Spring Music sample app for CNAB bundle demo
+maintainers: 
+  - name: chzbrgr71
+    email: brianisrunning@gmail.com

--- a/examples/aks-spring-music/cnab/app/charts/spring-music/templates/deploy.yaml
+++ b/examples/aks-spring-music/cnab/app/charts/spring-music/templates/deploy.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-music
+spec:
+  selector:
+    matchLabels:
+      app: spring-music
+  replicas: {{.Values.deploy.replicas}}
+  template:
+    metadata:
+      labels:
+        app: spring-music
+    spec:
+      containers:
+      - name: spring-music
+        image: "{{.Values.deploy.image}}:{{.Values.deploy.imageTag}}"
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "1.0"
+          limits:
+            memory: "1024Mi"
+            cpu: "2.0"
+        ports:
+        - containerPort: {{.Values.deploy.containerPort}}
+        env:
+        - name: RUNTIME
+          value: kubernetes
+        - name: SPRING_PROFILES_ACTIVE
+          value: cosmosdb
+        - name: COSMOSDB_URI
+          value: "{{.Values.deploy.cosmosConnectString}}"

--- a/examples/aks-spring-music/cnab/app/charts/spring-music/templates/service.yaml
+++ b/examples/aks-spring-music/cnab/app/charts/spring-music/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spring-music
+  labels:
+    app: spring-music
+spec:
+  type: "{{.Values.service.type}}" 
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{.Values.service.port}}
+    targetPort: {{.Values.service.targetPort}}
+  selector:
+    app: spring-music          

--- a/examples/aks-spring-music/cnab/app/charts/spring-music/values.yaml
+++ b/examples/aks-spring-music/cnab/app/charts/spring-music/values.yaml
@@ -1,0 +1,13 @@
+# Default values for chart
+
+deploy:
+  replicas: 1
+  image: "chzbrgr71/spring-music"
+  imageTag: "v4"
+  containerPort: 8080
+  cosmosConnectString: "dynamic"
+
+service:
+  type: LoadBalancer
+  port: 80
+  targetPort: 8080

--- a/examples/aks-spring-music/cnab/app/manifests/rbac-config.yaml
+++ b/examples/aks-spring-music/cnab/app/manifests/rbac-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/examples/aks-spring-music/cnab/app/run
+++ b/examples/aks-spring-music/cnab/app/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec /cnab/app/porter-runtime run -f /cnab/app/porter.yaml

--- a/examples/aks-spring-music/cnab/app/run
+++ b/examples/aks-spring-music/cnab/app/run
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-exec /cnab/app/porter-runtime run -f /cnab/app/porter.yaml

--- a/examples/aks-spring-music/porter.yaml
+++ b/examples/aks-spring-music/porter.yaml
@@ -1,0 +1,132 @@
+name: spring-music-bundle
+version: 0.1.0
+description: "Spring Music Demo app with Azure Cosmos DB"
+invocationImage: jeremyrickard/spring-music-installer:v314
+dockerfile: cnab/app/Dockerfile.base
+
+mixins:
+  - exec
+  - helm
+  - azure
+  - kubernetes
+
+install:
+  - azure:
+      description: "Create AKS"
+      type: aks
+      name: "{{ bundle.parameters.aks-cluster-name }}"
+      resourceGroup: "{{ bundle.parameters.aks-resource-group }}"
+      parameters:
+        clusterName: "{{ bundle.parameters.aks-cluster-name }}"
+        servicePrincipalClientId: "{{ bundle.credentials.CLIENT_ID}}"
+        servicePrincipalClientSecret: "{{ bundle.credentials.CLIENT_SECRET}}"
+        location: "{{ bundle.parameters.azure-location }}"
+
+  - exec: 
+      description: "Azure CLI login"
+      command: "az"
+      arguments: 
+        - "login" 
+        - "--service-principal"
+        - "--username" 
+        - "{{ bundle.credentials.CLIENT_ID}}"
+        - "--password" 
+        - "{{ bundle.credentials.CLIENT_SECRET}}"
+        - "--tenant" 
+        - "{{ bundle.credentials.TENANT_ID}}"
+
+  - exec: 
+      description: "Azure CLI AKS get-credentials"
+      command: "az"
+      arguments: 
+        - "aks" 
+        - "get-credentials" 
+        - "--resource-group" 
+        - "{{ bundle.parameters.aks-resource-group }}"
+        - "--name"
+        - "{{ bundle.parameters.aks-cluster-name }}"
+
+  - kubernetes:
+      description: "Add RBAC roles for Tiller"
+      manifests:
+        - /cnab/app/manifests
+      wait: true  
+
+  - exec: 
+      description: "Initialize helm on cluster"
+      command: "helm"
+      arguments: 
+        - "init" 
+        - "--service-account"
+        - "tiller" 
+        - "--upgrade"
+
+  - azure:
+      description: "Create Azure Cosmos DB"
+      type: cosmosdb
+      name: spring-music-cosmos
+      resourceGroup: "{{ bundle.parameters.app-resource-group }}"
+      parameters:
+        name: "{{ bundle.parameters.cosmosdb-service-name }}"
+        kind: "MongoDB"
+        location: "{{ bundle.parameters.azure-location }}"
+      outputs:
+        - name: "COSMOSDB_HOST"
+          key: "HOST"
+        - name: "COSMOSDB_KEY"
+          key: "primary_key"       
+        - name: "COSMOSDB_CONNECTION_STRING"
+          key: "connection_string"
+          
+  - helm:
+      description: "Helm Install Spring Music Demo App"
+      name: spring-music-helm
+      chart: /cnab/app/charts/spring-music
+      replace: true
+      set:
+        deploy.cosmosConnectString: $COSMOSDB_CONNECTION_STRING
+
+uninstall:
+  - exec:
+      description: "Uninstall Spring Music Demo"
+      command: bash
+      arguments:
+        - -c
+        - echo App should be uninstalled here, but it is not
+
+credentials:
+- name: SUBSCRIPTION_ID
+  env: AZURE_SUBSCRIPTION_ID
+- name: CLIENT_ID
+  env: AZURE_CLIENT_ID
+- name: TENANT_ID
+  env: AZURE_TENANT_ID
+- name: CLIENT_SECRET
+  env: AZURE_CLIENT_SECRET
+
+parameters:
+- name: app-resource-group
+  type: string
+  default: spring-music-demo
+  destination:
+    env: APP_RESOURCE_GROUP
+- name: aks-resource-group
+  type: string
+  default: spring-music-demo
+  destination:
+    env: AKS_RESOURCE_GROUP
+- name: aks-cluster-name
+  type: string
+  default: my-aks-spring
+  destination:
+    env: AKS_CLUSTER_NAME
+- name: cosmosdb-service-name
+  type: string
+  default: myspringmusic
+  destination:
+    env: COSMOSDB_SERVICE_NAME
+- name: azure-location
+  type: string
+  default: eastus
+  destination:
+    env: AZURE_LOCATION


### PR DESCRIPTION
This adds the AKS (Azure) + Exec + Kuberentes + Helm mixin that @chzbrgr71 and @jschluchter
put together, using a Docker base image.

Don't merge this until we cut a release of Porter and the Azure mixin.

Co-authored-by: Brian Redmond <chzbrgr71@gmail.com>
Co-authored-by: Joey Schluchter <jschluchter@gmail.com>