### PR TITLE
Fix canary publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,14 +106,17 @@ prep-install-scripts:
 publish: prep-install-scripts
 	$(MAKE) $(MAKE_OPTS) publish MIXIN=exec -f mixin.mk
 	$(MAKE) $(MAKE_OPTS) publish MIXIN=kubernetes -f mixin.mk
+
 	# AZURE_STORAGE_CONNECTION_STRING will be used for auth in the following commands
 	if [[ "$(PERMALINK)" == "latest" ]]; then \
 		az storage blob upload-batch -d porter/$(VERSION) -s bin/$(VERSION); \
-		az storage blob download -c porter -n atom.xml -f bin/atom.xml; \
-		bin/porter mixins feed generate -d bin/mixins -f bin/atom.xml -t build/atom-template.xml; \
-		az storage blob upload -c porter -n atom.xml -f bin/atom.xml; \
 	fi
 	az storage blob upload-batch -d porter/$(PERMALINK) -s bin/$(VERSION)
+
+	# Generate the mixin feed
+	az storage blob download -c porter -n atom.xml -f bin/atom.xml
+	bin/porter mixins feed generate -d bin/mixins -f bin/atom.xml -t build/atom-template.xml
+	az storage blob upload -c porter -n atom.xml -f bin/atom.xml
 
 install:
 	mkdir -p $(HOME)/.porter

--- a/mixin.mk
+++ b/mixin.mk
@@ -53,9 +53,12 @@ $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT):
 publish:
 	# AZURE_STORAGE_CONNECTION_STRING will be used for auth in the following commands
 	if [[ "$(PERMALINK)" == "latest" ]]; then \
-	az storage blob upload-batch -d porter/mixins/$(MIXIN)/$(VERSION) -s $(BINDIR)/$(VERSION); \
+		az storage blob upload-batch -d porter/mixins/$(MIXIN)/$(VERSION) -s $(BINDIR)/$(VERSION); \
+		az storage blob upload-batch -d porter/mixins/$(MIXIN)/$(PERMALINK) -s $(BINDIR)/$(VERSION); \
+	else \
+		mv $(BINDIR)/$(VERSION) $(BINDIR)/$(PERMALINK); \
+		az storage blob upload-batch -d porter/mixins/$(MIXIN)/$(PERMALINK) -s $(BINDIR)/$(PERMALINK); \
 	fi
-	az storage blob upload-batch -d porter/mixins/$(MIXIN)/$(PERMALINK) -s $(BINDIR)/$(VERSION)
 
 clean:
 	-rm -fr bin/mixins/$(MIXIN)

--- a/pkg/mixin/feed/feed_test.go
+++ b/pkg/mixin/feed/feed_test.go
@@ -12,6 +12,10 @@ func TestMixinFeed_Search_Latest(t *testing.T) {
 	f := NewMixinFeed(tc.Context)
 
 	f.Index["helm"] = make(map[string]*MixinFileset)
+	f.Index["helm"]["canary"] = &MixinFileset{
+		Mixin: "helm",
+		Version:"canary",
+	}
 	f.Index["helm"]["v1.2.3"] = &MixinFileset{
 		Mixin: "helm",
 		Version:"v1.2.3",
@@ -26,4 +30,25 @@ func TestMixinFeed_Search_Latest(t *testing.T) {
 	require.NotNil(t, result)
 
 	assert.Equal(t, "v1.2.4", result.Version)
+}
+
+func TestMixinFeed_Search_Canary(t *testing.T) {
+	tc := context.NewTestContext(t)
+	f := NewMixinFeed(tc.Context)
+
+	f.Index["helm"] = make(map[string]*MixinFileset)
+	f.Index["helm"]["canary"] = &MixinFileset{
+		Mixin: "helm",
+		Version:"canary",
+	}
+	f.Index["helm"]["v1.2.4"] = &MixinFileset{
+		Mixin: "helm",
+		Version:"v1.2.4",
+	}
+
+	result := f.Search("helm", "canary")
+
+	require.NotNil(t, result)
+
+	assert.Equal(t, "canary", result.Version)
 }

--- a/pkg/mixin/feed/generate_test.go
+++ b/pkg/mixin/feed/generate_test.go
@@ -44,6 +44,15 @@ func TestGenerate(t *testing.T) {
 	tc.FileSystem.Chtimes("bin/v1.2.3/exec-linux-amd64", up2, up2)
 	tc.FileSystem.Chtimes("bin/v1.2.3/exec-windows-amd64.exe", up2, up2)
 
+	tc.FileSystem.Create("bin/canary/exec-darwin-amd64")
+	tc.FileSystem.Create("bin/canary/exec-linux-amd64")
+	tc.FileSystem.Create("bin/canary/exec-windows-amd64.exe")
+
+	up10, _ := time.Parse("2006-Jan-02", "2013-Feb-10")
+	tc.FileSystem.Chtimes("bin/canary/exec-darwin-amd64", up10, up10)
+	tc.FileSystem.Chtimes("bin/canary/exec-linux-amd64", up10, up10)
+	tc.FileSystem.Chtimes("bin/canary/exec-windows-amd64.exe", up10, up10)
+
 	opts := GenerateOptions{
 		AtomFile:        "atom.xml",
 		SearchDirectory: "bin",
@@ -80,6 +89,15 @@ func TestGenerate_ExistingFeed(t *testing.T) {
 	tc.FileSystem.Chtimes("bin/v1.2.4/helm-linux-amd64", up4, up4)
 	tc.FileSystem.Chtimes("bin/v1.2.4/helm-windows-amd64.exe", up4, up4)
 
+	tc.FileSystem.Create("bin/canary/exec-darwin-amd64")
+	tc.FileSystem.Create("bin/canary/exec-linux-amd64")
+	tc.FileSystem.Create("bin/canary/exec-windows-amd64.exe")
+
+	up10, _ := time.Parse("2006-Jan-02", "2013-Feb-10")
+	tc.FileSystem.Chtimes("bin/canary/exec-darwin-amd64", up10, up10)
+	tc.FileSystem.Chtimes("bin/canary/exec-linux-amd64", up10, up10)
+	tc.FileSystem.Chtimes("bin/canary/exec-windows-amd64.exe", up10, up10)
+	
 	opts := GenerateOptions{
 		AtomFile:        "atom.xml",
 		SearchDirectory: "bin",

--- a/pkg/mixin/feed/testdata/atom.xml
+++ b/pkg/mixin/feed/testdata/atom.xml
@@ -1,7 +1,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://porter.sh/mixins</id>
     <title>DeisLabs Mixins</title>
-    <updated>2013-02-04T00:00:00Z</updated>
+    <updated>2013-02-10T00:00:00Z</updated>
     <link rel="self" href="https://porter.sh/mixins/atom.xml"/>
     <author>
         <name>DeisLabs</name>
@@ -9,6 +9,16 @@
     </author>
     <category term="exec"/>
     <category term="helm"/>
+    <entry>
+        <id>https://porter.sh/mixins/canary/exec</id>
+        <title>exec @ canary</title>
+        <updated>2013-02-10T00:00:00Z</updated>
+        <category term="exec"/>
+        <content>canary</content>
+        <link rel="download" href="https://porter.sh/mixins/canary/exec-darwin-amd64" />
+        <link rel="download" href="https://porter.sh/mixins/canary/exec-linux-amd64" />
+        <link rel="download" href="https://porter.sh/mixins/canary/exec-windows-amd64.exe" />
+    </entry>
     <entry>
         <id>https://porter.sh/mixins/v1.2.4/helm</id>
         <title>helm @ v1.2.4</title>


### PR DESCRIPTION
An entry for the canary version (the permalink not the funky version
number) needed to be in the mixin feed but wasn't being added because it
wasn't in a directory in bin/mixins/exec/canary before we ran porter
mixin feed generate.

I also noticed that we lost uploading the mixin binaries to the latest
directory in azure storage. That is a nice thing to have in case someone
needed to download them directly using the permalink. So that is fixed
too.

Fixes #337 