### PR TITLE
Prevent using Dockerfile as the template name

### DIFF
--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -262,6 +262,10 @@ func (c *Config) LoadDependencies() error {
 func (m *Manifest) Validate() error {
 	var result error
 
+	if strings.ToLower(m.Dockerfile) == "dockerfile" {
+		return errors.New("Dockerfile template cannot be named 'Dockerfile' because that is the filename generated during porter build")
+	}
+
 	if len(m.Mixins) == 0 {
 		result = multierror.Append(result, errors.New("no mixins declared"))
 	}

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -144,6 +144,22 @@ func TestAction_Validate_RequireSingleMixinData(t *testing.T) {
 	assert.EqualError(t, err, "more than one mixin specified")
 }
 
+func TestManifest_Validate_Dockerfile(t *testing.T) {
+	c := NewTestConfig(t)
+	c.SetupPorterHome()
+
+	c.TestContext.AddTestFile("testdata/simple.porter.yaml", Name)
+
+	err := c.LoadManifest()
+	require.NoError(t, err)
+
+	c.Manifest.Dockerfile = "Dockerfile"
+
+	err = c.Manifest.Validate()
+
+	assert.EqualError(t, err, "Dockerfile template cannot be named 'Dockerfile' because that is the filename generated during porter build")
+}
+
 func TestResolveMapParam(t *testing.T) {
 	m := &Manifest{
 		Parameters: []ParameterDefinition{


### PR DESCRIPTION
Since Porter generates a Dockerfile during porter build, the template
used for the Dockerfile should not be named Dockerfile (or dockerfile
because case-insensitive file systems...) so that the template isn't
overwritten.

Fixes #355 