### PR TITLE
Migrate invocation image push to `porter publish`

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -272,7 +272,7 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "publish",
 		Short: "Publish a bundle",
-		Long:  "Publishes a bundle by pushing the invocation image, updating the reference in the CNAB bundle.json, and publishing to an OCI registry.",
+		Long:  "Publishes a bundle by pushing the invocation image and bundle to a registry.",
 		Example: `  porter bundle publish
   porter bundle publish --file myapp/porter.yaml
   porter bundle publish --tag deislabs/super-cool-app:v1.0

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -288,7 +288,7 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
-	f.StringVarP(&opts.Tag, "tag", "t", "", "Tag to apply to the CNAB invocation image. Defaults to the value currently in the Porter manifest.")
+	f.StringVarP(&opts.Tag, "tag", "t", "", "Tag to apply to the CNAB bundle. Defaults to the `Tag` value currently in the Porter manifest.")
 	return &cmd
 }
 

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -36,6 +36,7 @@ func buildBundleAliasCommands(p *porter.Porter) []*cobra.Command {
 		buildInstallCommand(p),
 		buildUpgradeCommand(p),
 		buildUninstallCommand(p),
+		buildPublishCommand(p),
 	}
 }
 
@@ -259,6 +260,41 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 func buildUninstallCommand(p *porter.Porter) *cobra.Command {
 	cmd := buildBundleUninstallCommand(p)
 	cmd.Example = strings.Replace(cmd.Example, "porter bundle uninstall", "porter uninstall", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
+
+	opts := porter.PublishOptions{}
+	cmd := cobra.Command{
+		Use:   "publish",
+		Short: "Publish a bundle",
+		Long:  "Publishes a bundle by pushing the invocation image, updating the reference in the CNAB bundle.json, and publishing to an OCI registry.",
+		Example: `  porter bundle publish
+  porter bundle publish --file myapp/porter.yaml
+  porter bundle publish --tag deislabs/super-cool-app:v1.0
+  porter bundle publish --file myapp/porter.yaml --tag deislabs/super-cool-app:v1.0
+		`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(p)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.Publish(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
+	f.StringVarP(&opts.Tag, "tag", "t", "", "Tag to apply to the CNAB invocation image. Defaults to the value currently in the Porter manifest.")
+	return &cmd
+}
+
+func buildPublishCommand(p *porter.Porter) *cobra.Command {
+	cmd := buildBundlePublishCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle publish", "porter publish", -1)
 	cmd.Annotations = map[string]string{
 		"group": "alias",
 	}

--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -32,7 +32,7 @@ dockerfile: dockerfile.tmpl
 * `description`: A description of the bundle
 * `version`: The version of the bundle, uses [semver](https://semver.org)
 * `invocationImage`: The name of the container image to tag the bundle with when it is built. The format is
-`REGISTRY/IMAGE:TAG`. Porter will push to this location during `porter build` so select a location that you have access to.
+`REGISTRY/IMAGE:TAG`. Porter will push to this location during `porter publish` so select a location that you have access to.
 * `dockerfile`: OPTIONAL. The relative path to a Dockerfile to use as a template during `porter build`. It is your responsibility
     to provide a suitable base image, for example one that has root ssl certificates installed. When a Dockerfile template is
     not specified, Porter automatically copies the contents of the current directory into /cnab/app/ of the invocation image. 

--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -49,7 +49,7 @@ uninstall:
 #    path: /root/.kube/config
 ```
 
-After the scaffolding is created, edit the _porter.yaml_ and modify the `invocationImage: porter-hello:latest` element to include a Docker registry that you can push to.
+After the scaffolding is created, you may edit the _porter.yaml_ and modify the `invocationImage: porter-hello:latest` element to include a Docker registry that you can push to. The invocation image is not pushed during the `porter build` workflow, however.
 
 Once you have modified the `porter.yaml`, you can run `porter build` to generate your first invocation image:
 
@@ -92,18 +92,8 @@ Step 6/6 : COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-ce
  ---> ee8ade0c612c
 Successfully built ee8ade0c612c
 Successfully tagged jeremyrickard/porter-hello:latest
-The push refers to repository [docker.io/jeremyrickard/porter-hello]
-937aeedb310f: Preparing
-8f17ef8f8a30: Preparing
-fc9479d629d7: Preparing
-c581f4ede92d: Preparing
-8f17ef8f8a30: Layer already exists
-937aeedb310f: Layer already exists
-fc9479d629d7: Pushed
-c581f4ede92d: Pushed
-latest: digest: sha256:c3187dc004475bd754235caf735d5adc449405126091594b24a38ebba93ae76a size: 1158
 
-Generating Bundle File with Invocation Image jeremyrickard/porter-hello@sha256:c3187dc004475bd754235caf735d5adc449405126091594b24a38ebba93ae76a =======>
+Generating Bundle File with Invocation Image jeremyrickard/porter-hello@latest =======>
 ```
 
 A lot just happened by running that command! Let's break walk through the output and discuss what happened.
@@ -135,7 +125,7 @@ COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.
 
 Porter starts the Dockerfile by using a base image. You can customize the base image by specifying a Dockerfile template in the **porter.yaml**. Next, contents of the current directory are copied into `cnab/app/` in the invocation image. This will include any contributions from dependencies and the mixin executables. Next, an entry point that conforms to the CNAB specification is added to the image. Finally, a set of CA certificates is added.
 
-Once this is completed, the image is built and pushed to the specified Docker registry:
+Once this is completed, the image is built:
 
 ```console
 Starting Invocation Image Build =======>
@@ -157,16 +147,6 @@ Step 6/6 : COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-ce
  ---> ee8ade0c612c
 Successfully built ee8ade0c612c
 Successfully tagged jeremyrickard/porter-hello:latest
-The push refers to repository [docker.io/jeremyrickard/porter-hello]
-937aeedb310f: Preparing
-8f17ef8f8a30: Preparing
-fc9479d629d7: Preparing
-c581f4ede92d: Preparing
-8f17ef8f8a30: Layer already exists
-937aeedb310f: Layer already exists
-fc9479d629d7: Pushed
-c581f4ede92d: Pushed
-latest: digest: sha256:c3187dc004475bd754235caf735d5adc449405126091594b24a38ebba93ae76a size: 1158
 ```
 
 ## Mixins Help The Build

--- a/docs/content/porter-or-duffle.md
+++ b/docs/content/porter-or-duffle.md
@@ -169,7 +169,7 @@ The `porter build` command handles:
 
 * translating the Porter manifest into a bundle.json
 * creating a Dockerfile for the invocation image
-* building and pushing the invocation image
+* building the invocation image
 
 So it's still there, but you don't have to mess with it. 😎 A few of the sections in the Porter manifest to map 1:1
 to sections in the bundle.json file, such as the bundle metadata, Parameters, and Credentials.

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -48,7 +48,7 @@ func (p PublishOptions) Validate(porter *Porter) error {
 	if p.Tag != "" {
 		_, err := reference.ParseNormalizedNamed(p.Tag)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "invalid bundle tag value")
 		}
 	}
 	return nil

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -1,0 +1,172 @@
+package porter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/deislabs/porter/pkg/config"
+	"github.com/docker/cli/cli/command"
+	cliflags "github.com/docker/cli/cli/flags"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/term"
+	"github.com/docker/docker/registry"
+	"github.com/pkg/errors"
+)
+
+// PublishOptions are options that may be specified when publishing a bundle.
+// Porter handles defaulting any missing values.
+type PublishOptions struct {
+	File     string
+	Tag      string
+	CNABFile string
+}
+
+func (p PublishOptions) Validate(porter *Porter) error {
+	if p.File != "" {
+		return nil
+	}
+	fs := porter.Context.FileSystem
+	pwd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrap(err, "could not get current working directory")
+	}
+	fmt.Println(pwd)
+	files, err := fs.ReadDir(pwd)
+	if err != nil {
+		return errors.Wrapf(err, "could not list current directory %s", pwd)
+	}
+	foundManifest := false
+	for _, f := range files {
+		if !f.IsDir() && f.Name() == config.Name {
+			foundManifest = true
+		}
+	}
+
+	if p.File == "" && foundManifest {
+		return errors.New("first run 'porter build' to generate a bundle.json, then run 'porter install'")
+	}
+
+	if p.Tag != "" {
+		_, err := reference.ParseNormalizedNamed(p.Tag)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Publish is a composite function that publishes an invocation image, rewrites the porter manifest
+// and then regenerates the bundle.json. Finally it [TODO] publishes the manifest to an OCI registry.
+func (p *Porter) Publish(opts PublishOptions) error {
+	var err error
+	if opts.File != "" {
+		err = p.Config.LoadManifestFrom(opts.File)
+	} else {
+		err = p.Config.LoadManifest()
+	}
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	cli, err := p.getDockerClient(ctx)
+	if err != nil {
+		return err
+	}
+	if opts.Tag != "" {
+		fmt.Fprintf(p.Out, "Tagging invocation image from %s to %s...\n", p.Config.Manifest.Image, opts.Tag)
+		cli.Client().ImageTag(ctx, p.Config.Manifest.Image, opts.Tag)
+		p.Config.Manifest.Image = opts.Tag
+	}
+	fmt.Fprintln(p.Out, "Pushing CNAB invocation image...")
+	digest, err := p.publishInvocationImage(ctx, cli)
+	if err != nil {
+		return errors.Wrap(err, "unable to push CNAB invocation image")
+	}
+
+	taggedImage, err := p.rewriteImageWithDigest(p.Config.Manifest.Image, digest)
+	if err != nil {
+		return errors.Wrap(err, "unable to update invocation image reference: %s")
+	}
+
+	fmt.Fprintln(p.Out, "\nGenerating CNAB bundle.json...")
+	err = p.buildBundle(taggedImage, digest)
+	if err != nil {
+		return errors.Wrap(err, "unable to generate CNAB bundle.json")
+	}
+
+	// TODO: Use CNAB-to-OCI to push the bundle (see https://github.com/deislabs/porter/issues/254)
+	return nil
+}
+
+func (p *Porter) getDockerClient(ctx context.Context) (*command.DockerCli, error) {
+	cli, err := command.NewDockerCli()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create new docker client")
+	}
+	if err := cli.Initialize(cliflags.NewClientOptions()); err != nil {
+		return nil, err
+	}
+	return cli, nil
+}
+
+func (p *Porter) publishInvocationImage(ctx context.Context, cli *command.DockerCli) (string, error) {
+
+	ref, err := reference.ParseNormalizedNamed(p.Config.Manifest.Image)
+	if err != nil {
+		return "", err
+	}
+	// Resolve the Repository name from fqn to RepositoryInfo
+	repoInfo, err := registry.ParseRepositoryInfo(ref)
+	if err != nil {
+		return "", err
+	}
+	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
+	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+	if err != nil {
+		return "", err
+	}
+	options := types.ImagePushOptions{
+		All:          true,
+		RegistryAuth: encodedAuth,
+	}
+
+	pushResponse, err := cli.Client().ImagePush(ctx, p.Config.Manifest.Image, options)
+	if err != nil {
+		return "", errors.Wrap(err, "docker push failed")
+	}
+	defer pushResponse.Close()
+
+	termFd, _ := term.GetFdInfo(os.Stdout)
+	// Setting this to false here because Moby os.Exit(1) all over the place and this fails on WSL (only)
+	// when Term is true.
+	isTerm := false
+	err = jsonmessage.DisplayJSONMessagesStream(pushResponse, os.Stdout, termFd, isTerm, nil)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "denied") {
+			return "", errors.Wrap(err, "docker push authentication failed")
+		}
+		return "", errors.Wrap(err, "failed to stream docker push stdout")
+	}
+	dist, err := cli.Client().DistributionInspect(ctx, p.Config.Manifest.Image, encodedAuth)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to inspect docker image")
+	}
+	return string(dist.Descriptor.Digest), nil
+}
+
+func (p *Porter) rewriteImageWithDigest(InvocationImage string, digest string) (string, error) {
+	ref, err := reference.Parse(InvocationImage)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse docker image: %s", err)
+	}
+	named, ok := ref.(reference.Named)
+	if !ok {
+		return "", fmt.Errorf("had an issue with the docker image")
+	}
+	return fmt.Sprintf("%s@%s", named.Name(), digest), nil
+}

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -77,11 +77,6 @@ func (p *Porter) Publish(opts PublishOptions) error {
 	if err != nil {
 		return err
 	}
-	if opts.Tag != "" {
-		fmt.Fprintf(p.Out, "Tagging invocation image from %s to %s...\n", p.Config.Manifest.Image, opts.Tag)
-		cli.Client().ImageTag(ctx, p.Config.Manifest.Image, opts.Tag)
-		p.Config.Manifest.Image = opts.Tag
-	}
 	fmt.Fprintln(p.Out, "Pushing CNAB invocation image...")
 	digest, err := p.publishInvocationImage(ctx, cli)
 	if err != nil {
@@ -98,6 +93,11 @@ func (p *Porter) Publish(opts PublishOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to generate CNAB bundle.json")
 	}
+
+	if opts.Tag != "" {
+		//p.Config.Manifest.Tag = opts.Tag
+	}
+	fmt.Fprintf(p.Out, "Tagging bundle image as %s...\n", "")
 
 	// TODO: Use CNAB-to-OCI to push the bundle (see https://github.com/deislabs/porter/issues/254)
 	return nil

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -48,7 +48,7 @@ func (p PublishOptions) Validate(porter *Porter) error {
 	if p.Tag != "" {
 		_, err := reference.ParseNormalizedNamed(p.Tag)
 		if err != nil {
-			return errors.Wrap(err, "invalid bundle tag value")
+			return errors.Wrap(err, "invalid --tag value. expected format is REGISTRY/IMAGE:TAG")
 		}
 	}
 	return nil

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -46,8 +46,8 @@ func (p PublishOptions) Validate(porter *Porter) error {
 		}
 	}
 
-	if p.File == "" && foundManifest {
-		return errors.New("first run 'porter build' to generate a bundle.json, then run 'porter install'")
+	if p.File == "" && !foundManifest {
+		return errors.New("could not find porter.yaml. run `porter create` and `porter build` to create a new bundle before publishing")
 	}
 
 	if p.Tag != "" {

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -13,14 +13,14 @@ func TestPublish_PorterYamlExists(t *testing.T) {
 	p.TestConfig.SetupPorterHome()
 	pwd, err := os.Getwd()
 	require.NoError(t, err, "should not have gotten an error")
-	p.TestConfig.TestContext.AddTestDirectory(p.TestConfig.TestContext.FindBinDir(), pwd)
+	t.Log(p.TestConfig.TestContext.FindBinDir())
+	p.TestConfig.TestContext.AddTestDirectory("testdata", pwd)
 	opts := PublishOptions{}
 	err = opts.Validate(p.Porter)
 	require.NoError(t, err, "should have no error")
 }
 
 func TestPublish_PorterYamlDoesNotExist(t *testing.T) {
-
 	p := NewTestPorter(t)
 	p.TestConfig.SetupPorterHome()
 	opts := PublishOptions{}
@@ -34,7 +34,7 @@ func TestPublish_ValidTag(t *testing.T) {
 	p.TestConfig.SetupPorterHome()
 	pwd, err := os.Getwd()
 	require.NoError(t, err, "should not have gotten an error")
-	p.TestConfig.TestContext.AddTestDirectory(p.TestConfig.TestContext.FindBinDir(), pwd)
+	p.TestConfig.TestContext.AddTestDirectory("testdata", pwd)
 	opts := PublishOptions{}
 	opts.Tag = "somerepo/thing:10"
 
@@ -48,7 +48,7 @@ func TestPublish_InValidTag(t *testing.T) {
 	p.TestConfig.SetupPorterHome()
 	pwd, err := os.Getwd()
 	require.NoError(t, err, "should not have gotten an error")
-	p.TestConfig.TestContext.AddTestDirectory(p.TestConfig.TestContext.FindBinDir(), pwd)
+	p.TestConfig.TestContext.AddTestDirectory("testdata", pwd)
 	opts := PublishOptions{}
 	opts.Tag = "someinvalid/repo/thing:10:10"
 

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -62,5 +62,10 @@ func TestPublish_InValidTag(t *testing.T) {
 
 	err = opts.Validate(p.Porter)
 	require.Error(t, err, "options contained invalid tag, should have gotten an error")
-	assert.EqualError(t, err, "invalid reference format", "porter.yaml not present so should have failed validation")
+	assert.EqualError(
+		t,
+		err,
+		"invalid bundle tag value: invalid reference format",
+		"porter.yaml not present so should have failed validation",
+	)
 }

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -65,7 +65,7 @@ func TestPublish_InValidTag(t *testing.T) {
 	assert.EqualError(
 		t,
 		err,
-		"invalid bundle tag value: invalid reference format",
+		"invalid --tag value. expected format is REGISTRY/IMAGE:TAG: invalid reference format",
 		"porter.yaml not present so should have failed validation",
 	)
 }

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -1,0 +1,57 @@
+package porter
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublish_PorterYamlExists(t *testing.T) {
+
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+	pwd, err := os.Getwd()
+	require.NoError(t, err, "should not have gotten an error")
+	p.TestConfig.TestContext.AddTestDirectory(p.TestConfig.TestContext.FindBinDir(), pwd)
+	opts := PublishOptions{}
+	err = opts.Validate(p.Porter)
+	require.NoError(t, err, "should have no error")
+}
+
+func TestPublish_PorterYamlDoesNotExist(t *testing.T) {
+
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+	opts := PublishOptions{}
+	err := opts.Validate(p.Porter)
+	require.Error(t, err, "should have no error")
+}
+
+func TestPublish_ValidTag(t *testing.T) {
+
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+	pwd, err := os.Getwd()
+	require.NoError(t, err, "should not have gotten an error")
+	p.TestConfig.TestContext.AddTestDirectory(p.TestConfig.TestContext.FindBinDir(), pwd)
+	opts := PublishOptions{}
+	opts.Tag = "somerepo/thing:10"
+
+	err = opts.Validate(p.Porter)
+	require.NoError(t, err, "should have no error")
+}
+
+func TestPublish_InValidTag(t *testing.T) {
+
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+	pwd, err := os.Getwd()
+	require.NoError(t, err, "should not have gotten an error")
+	p.TestConfig.TestContext.AddTestDirectory(p.TestConfig.TestContext.FindBinDir(), pwd)
+	opts := PublishOptions{}
+	opts.Tag = "someinvalid/repo/thing:10:10"
+
+	err = opts.Validate(p.Porter)
+	require.Error(t, err, "should have no error")
+}

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,12 +13,13 @@ func TestPublish_PorterYamlExists(t *testing.T) {
 	p := NewTestPorter(t)
 	p.TestConfig.SetupPorterHome()
 	pwd, err := os.Getwd()
-	require.NoError(t, err, "should not have gotten an error")
+	require.NoError(t, err, "should not have gotten an error obtaining current working directory")
 	t.Log(p.TestConfig.TestContext.FindBinDir())
 	p.TestConfig.TestContext.AddTestDirectory("testdata", pwd)
 	opts := PublishOptions{}
 	err = opts.Validate(p.Porter)
-	require.NoError(t, err, "should have no error")
+	require.NoError(t, err, "validating should not have failed")
+
 }
 
 func TestPublish_PorterYamlDoesNotExist(t *testing.T) {
@@ -25,7 +27,13 @@ func TestPublish_PorterYamlDoesNotExist(t *testing.T) {
 	p.TestConfig.SetupPorterHome()
 	opts := PublishOptions{}
 	err := opts.Validate(p.Porter)
-	require.Error(t, err, "should have no error")
+	require.Error(t, err, "validation should have failed")
+	assert.EqualError(
+		t,
+		err,
+		"could not find porter.yaml. run `porter create` and `porter build` to create a new bundle before publishing",
+		"porter.yaml not present so should have failed validation",
+	)
 }
 
 func TestPublish_ValidTag(t *testing.T) {
@@ -33,13 +41,13 @@ func TestPublish_ValidTag(t *testing.T) {
 	p := NewTestPorter(t)
 	p.TestConfig.SetupPorterHome()
 	pwd, err := os.Getwd()
-	require.NoError(t, err, "should not have gotten an error")
+	require.NoError(t, err, "should not have gotten an error obtaining current working directory")
+	t.Log(p.TestConfig.TestContext.FindBinDir())
 	p.TestConfig.TestContext.AddTestDirectory("testdata", pwd)
 	opts := PublishOptions{}
 	opts.Tag = "somerepo/thing:10"
-
 	err = opts.Validate(p.Porter)
-	require.NoError(t, err, "should have no error")
+	require.NoError(t, err, "options were valid, should not have failed validation")
 }
 
 func TestPublish_InValidTag(t *testing.T) {
@@ -53,5 +61,6 @@ func TestPublish_InValidTag(t *testing.T) {
 	opts.Tag = "someinvalid/repo/thing:10:10"
 
 	err = opts.Validate(p.Porter)
-	require.Error(t, err, "should have no error")
+	require.Error(t, err, "options contained invalid tag, should have gotten an error")
+	assert.EqualError(t, err, "invalid reference format", "porter.yaml not present so should have failed validation")
 }


### PR DESCRIPTION
This PR migrates the image push functionality to a new command `porter publish` (the command doesn't actually publish the bundle itself to OCI yet). Now when you do a `porter build` the invocation image is still _built_, but it is not pushed to a registry. The bundle.json is generated with whatever tag is present in the `porter.yaml`. 

To push the image and regenerate the bundle.json, you now do a `porter publish`. 

Command outputs below:

```
porter build
Copying dependencies ===>
Copying porter runtime ===>
Copying mixins ===>
Copying mixin kubernetes ===>

Generating Dockerfile =======>
FROM quay.io/deis/lightweight-docker-go:v0.2.0
FROM debian:stretch
COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
RUN apt-get update && \
apt-get install -y apt-transport-https curl && \
curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && \
mv kubectl /usr/local/bin && \
chmod a+x /usr/local/bin/kubectl

COPY cnab/ /cnab/
COPY porter.yaml /cnab/app/porter.yaml
CMD ["/cnab/app/run"]

Writing Dockerfile =======>
FROM quay.io/deis/lightweight-docker-go:v0.2.0
FROM debian:stretch
COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
RUN apt-get update && \
apt-get install -y apt-transport-https curl && \
curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && \
mv kubectl /usr/local/bin && \
chmod a+x /usr/local/bin/kubectl

COPY cnab/ /cnab/
COPY porter.yaml /cnab/app/porter.yaml
CMD ["/cnab/app/run"]

Starting Invocation Image Build =======>
Step 1/7 : FROM quay.io/deis/lightweight-docker-go:v0.2.0
 ---> acf6712d2918
Step 2/7 : FROM debian:stretch
 ---> de8b49d4b0b3
Step 3/7 : COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ---> Using cache
 ---> 6bf0ab0d751e
Step 4/7 : RUN apt-get update && apt-get install -y apt-transport-https curl && curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl && mv kubectl /usr/local/bin && chmod a+x /usr/local/bin/kubectl
 ---> Using cache
 ---> 1fd544730ffe
Step 5/7 : COPY cnab/ /cnab/
 ---> ba4fdfd5ef4b
Step 6/7 : COPY porter.yaml /cnab/app/porter.yaml
 ---> eb4a04350e4a
Step 7/7 : CMD ["/cnab/app/run"]
 ---> Running in 043633b8fcca
 ---> 49aaf30f0465
Successfully built 49aaf30f0465
Successfully tagged jeremyrickard/porter-kubernetes:latest

Generating Bundle File with Invocation Image jeremyrickard/porter-kubernetes:latest =======>
Generating parameter definition porter-debug ====>
Generating credential kubeconfig ====>
```

Then a `porter publish`

```
porter publish --tag jeremyrickard/hashi-mashi:v1.0
Pushing CNAB invocation image...
The push refers to repository [docker.io/jeremyrickard/hashi-mashi]
15efbe06773e: Preparing
c7fa3bae30d9: Preparing
49037d9d1b30: Preparing
c7956a703d1e: Preparing
c581f4ede92d: Preparing
15efbe06773e: Mounted from jeremyrickard/porter-kubernetes
c581f4ede92d: Mounted from jeremyrickard/spring-music-installer
c7fa3bae30d9: Mounted from jeremyrickard/porter-kubernetes
c7956a703d1e: Mounted from jeremyrickard/porter-azure-wordpress
49037d9d1b30: Mounted from jeremyrickard/porter-kubernetes
v1.0: digest: sha256:c90044b7bfdab915d213ceccdce3910f51e5815a4dae72592fa357e2044c9717 size: 1370

Generating CNAB bundle.json...

Generating Bundle File with Invocation Image jeremyrickard/hashi-mashi@sha256:c90044b7bfdab915d213ceccdce3910f51e5815a4dae72592fa357e2044c9717 =======>
Generating parameter definition porter-debug ====>
Generating credential kubeconfig ====>
```


Closes: #354