### PR TITLE
Write bundle.json to cnab/

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -129,7 +129,7 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
   porter bundle install --driver debug
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args)
+			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.InstallBundle(opts)
@@ -181,7 +181,7 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
   porter bundle upgrade --driver debug
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args)
+			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.UpgradeBundle(opts)
@@ -233,7 +233,7 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
   porter bundle uninstall --driver debug
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args)
+			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.UninstallBundle(opts)

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -84,7 +84,7 @@ will then provide it to the bundle in the correct location. `,
   porter bundle credential generate kubecred --file myapp/bundle.json --dry-run
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args)
+			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.GenerateCredentials(opts)

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -302,13 +302,13 @@ func (p *Porter) buildBundle(invocationImage string, digest string) error {
 }
 
 func (p Porter) writeBundle(b bundle.Bundle) error {
-	f, err := p.Config.FileSystem.OpenFile("bundle.json", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := p.Config.FileSystem.OpenFile("cnab/bundle.json", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	defer f.Close()
 	if err != nil {
-		return errors.Wrapf(err, "error creating bundle.json")
+		return errors.Wrapf(err, "error creating cnab/bundle.json")
 	}
 	_, err = b.WriteTo(f)
-	return errors.Wrap(err, "error writing to bundle.json")
+	return errors.Wrap(err, "error writing to cnab/bundle.json")
 }
 
 func (p *Porter) generateBundleParameters() map[string]bundle.ParameterDefinition {

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -173,16 +173,16 @@ func TestPorter_buildBundle(t *testing.T) {
 	err = p.buildBundle("foo", "digest")
 	require.NoError(t, err)
 
-	bundleJSONExists, err := p.FileSystem.Exists("bundle.json")
+	bundleJSONExists, err := p.FileSystem.Exists("cnab/bundle.json")
 	require.NoError(t, err)
-	require.True(t, bundleJSONExists, "bundle.json wasn't written")
+	require.True(t, bundleJSONExists, "cnab/bundle.json wasn't written")
 
-	f, _ := p.FileSystem.Stat("bundle.json")
+	f, _ := p.FileSystem.Stat("cnab/bundle.json")
 	if f.Size() == 0 {
-		t.Fatalf("bundle.json is empty")
+		t.Fatalf("cnab/bundle.json is empty")
 	}
 
-	bundleBytes, err := p.FileSystem.ReadFile("bundle.json")
+	bundleBytes, err := p.FileSystem.ReadFile("cnab/bundle.json")
 	require.NoError(t, err)
 
 	var bundle bundle.Bundle
@@ -211,7 +211,7 @@ func TestPorter_paramRequired(t *testing.T) {
 	err = p.buildBundle("foo", "digest")
 	require.NoError(t, err)
 
-	bundleBytes, err := p.FileSystem.ReadFile("bundle.json")
+	bundleBytes, err := p.FileSystem.ReadFile("cnab/bundle.json")
 	require.NoError(t, err)
 
 	var bundle bundle.Bundle

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -3,10 +3,10 @@ package porter
 import (
 	"fmt"
 
+	"github.com/deislabs/porter/pkg/context"
 	"github.com/deislabs/porter/pkg/credentials"
 	"github.com/deislabs/porter/pkg/printer"
 	"github.com/pkg/errors"
-
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -23,13 +23,13 @@ type CredentialOptions struct {
 // Validate prepares for an action and validates the options.
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
-func (g *CredentialOptions) Validate(args []string) error {
+func (g *CredentialOptions) Validate(args []string, cxt *context.Context) error {
 	err := g.validateCredName(args)
 	if err != nil {
 		return err
 	}
 
-	err = g.validateBundlePath()
+	err = g.validateBundlePath(cxt)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
+	"github.com/deislabs/porter/pkg/context"
 )
 
 // InstallOptions that may be specified when installing a bundle.
@@ -12,9 +13,9 @@ type InstallOptions struct {
 	sharedOptions
 }
 
-func (o *InstallOptions) Validate(args []string) error {
+func (o *InstallOptions) Validate(args []string, cxt *context.Context) error {
 	o.bundleRequired = true
-	return o.sharedOptions.Validate(args)
+	return o.sharedOptions.Validate(args, cxt)
 }
 
 // ToDuffleArgs converts this instance of user-provided installation options

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
+	"github.com/deislabs/porter/pkg/context"
 )
 
 // UninstallOptions that may be specified when uninstalling a bundle.
@@ -12,9 +13,9 @@ type UninstallOptions struct {
 	sharedOptions
 }
 
-func (o *UninstallOptions) Validate(args []string) error {
+func (o *UninstallOptions) Validate(args []string, cxt *context.Context) error {
 	o.bundleRequired = false
-	return o.sharedOptions.Validate(args)
+	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UninstallBundle accepts a set of pre-validated UninstallOptions and uses

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
+	"github.com/deislabs/porter/pkg/context"
 )
 
 // UpgradeOptions that may be specified when uninstalling a bundle.
@@ -12,9 +13,9 @@ type UpgradeOptions struct {
 	sharedOptions
 }
 
-func (o *UpgradeOptions) Validate(args []string) error {
+func (o *UpgradeOptions) Validate(args []string, cxt *context.Context) error {
 	o.bundleRequired = false
-	return o.sharedOptions.Validate(args)
+	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UpgradeBundle accepts a set of pre-validated UpgradeOptions and uses


### PR DESCRIPTION
As part of #320, during `porter build` bundle.json is written to cnab/ now, and the cnab actions and publish look for it in cnab/.