### PR TITLE
 Stamp bundle.json with a digest of porter.yaml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -213,12 +213,12 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:8cd271f26db91626bd5993ed540069dbade9f6149134e7f8a0ed951cbbf4f2ec"
+  branch = "custom-extensions"
+  digest = "1:dfe6ce9e92d2315c432afc126c2527b99b1b2212f4af7df1629c818d0d8dafbe"
   name = "github.com/deislabs/cnab-go"
   packages = ["bundle"]
   pruneopts = "NUT"
-  revision = "7cd944a8ee450ee465795d21ad7302bed34ad1b0"
+  revision = "1aa435456c4b74dba1d2276cb45a8482e33477a9"
 
 [[projects]]
   digest = "1:a222203ae2f42f5a3d06fde5f9746e51291567a3df8a5ebedce334cd93b7b97a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,6 +4,10 @@
   version = "=0.1.0-ralpha.5+englishrose"
 
 [[constraint]]
+  name = "github.com/deislabs/cnab-go"
+  branch = "custom-extensions"
+  
+[[constraint]]
   name = "github.com/carolynvs/datetime-printer"
   version = "v0.2.0"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,8 @@ const (
 
 	// EnvDEBUG is a custom porter parameter that signals that --debug flag has been passed through from the client to the runtime.
 	EnvDEBUG = "PORTER_DEBUG"
+
+	CustomBundleKey = "sh.porter"
 )
 
 // These are functions that afero doesn't support, so this lets us stub them out for tests to set the

--- a/pkg/config/stamp.go
+++ b/pkg/config/stamp.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/pkg/errors"
+)
+
+type Stamp struct {
+	ManifestDigest string `json:"manifestDigest"`
+}
+
+func (c *Config) GenerateStamp(m *Manifest) Stamp {
+	stamp := Stamp{}
+
+	digest, err := c.digestManifest(m)
+	if err != nil {
+		// The digest is only used to decide if we need to rebuild, it is not an error condition to not
+		// have a digest.
+		fmt.Fprintln(c.Err, errors.Wrap(err, "WARNING: Could not digest the porter manifest file"))
+		stamp.ManifestDigest = "unknown"
+	} else {
+		stamp.ManifestDigest = digest
+	}
+
+	return stamp
+}
+
+func (c *Config) digestManifest(m *Manifest) (string, error) {
+	if exists, _ := c.FileSystem.Exists(m.path); !exists {
+		return "", errors.Errorf("the specified porter configuration file %s does not exist", m.path)
+	}
+
+	data, err := c.FileSystem.ReadFile(m.path)
+	if err != nil {
+		return "", errors.Wrapf(err, "could not read manifest at %q", m.path)
+	}
+
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func (c *Config) LoadStamp(bun bundle.Bundle) (*Stamp, error) {
+	data := bun.Custom[CustomBundleKey]
+
+	dataB, err := json.Marshal(data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not marshal the porter stamp %q", string(dataB))
+	}
+
+	stamp := &Stamp{}
+	err = json.Unmarshal(dataB, stamp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not unmarshal the porter stamp %q", string(dataB))
+	}
+
+	return stamp, nil
+}

--- a/pkg/config/stamp_test.go
+++ b/pkg/config/stamp_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var simpleManifestDigest = "b3adf8240f3289c8e7a6076ce7538bc7381d5c1d581f993b627f13d9102a3617"
+
+func TestConfig_ComputeManifestDigest(t *testing.T) {
+	c := NewTestConfig(t)
+	c.TestContext.AddTestFile("testdata/simple.porter.yaml", Name)
+
+	err := c.LoadManifest()
+	require.NoError(t, err)
+
+	stamp := c.GenerateStamp(c.Manifest)
+	assert.Equal(t, simpleManifestDigest, stamp.ManifestDigest)
+}
+
+func TestConfig_LoadStamp(t *testing.T) {
+	c := NewTestConfig(t)
+
+	bun := bundle.Bundle{
+		Custom: map[string]interface{}{
+			CustomBundleKey: map[string]interface{}{
+				"manifestDigest": simpleManifestDigest,
+			},
+		},
+	}
+
+	stamp, err := c.LoadStamp(bun)
+	require.NoError(t, err)
+	assert.Equal(t, simpleManifestDigest, stamp.ManifestDigest)
+}
+
+func TestConfig_LoadStamp_Invalid(t *testing.T) {
+	c := NewTestConfig(t)
+
+	bun := bundle.Bundle{
+		Custom: map[string]interface{}{
+			CustomBundleKey: []string{
+				simpleManifestDigest,
+			},
+		},
+	}
+
+	stamp, err := c.LoadStamp(bun)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not unmarshal the porter stamp")
+	assert.Nil(t, stamp)
+}

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -285,6 +285,7 @@ func (p *Porter) buildBundle(invocationImage string, digest string) error {
 		Name:        p.Config.Manifest.Name,
 		Description: p.Config.Manifest.Description,
 		Version:     p.Config.Manifest.Version,
+		Custom:      make(map[string]interface{}, 1),
 	}
 	image := bundle.InvocationImage{
 		BaseImage: bundle.BaseImage{
@@ -298,6 +299,8 @@ func (p *Porter) buildBundle(invocationImage string, digest string) error {
 	b.InvocationImages = []bundle.InvocationImage{image}
 	b.Parameters = p.generateBundleParameters()
 	b.Credentials = p.generateBundleCredentials()
+	b.Custom[config.CustomBundleKey] = p.GenerateStamp(p.Manifest)
+
 	return p.writeBundle(b)
 }
 

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -193,6 +193,10 @@ func TestPorter_buildBundle(t *testing.T) {
 	assert.Equal(t, bundle.Version, "0.1.0")
 	assert.Equal(t, bundle.Description, "An example Porter configuration")
 
+	stamp, err := p.LoadStamp(bundle)
+	require.NoError(t, err)
+	assert.Equal(t, "781cc745a6efa4f8618d737f1bd60fa659a55809e34a59adbf4b37f78825d4b5", stamp.ManifestDigest)
+
 	debugParam, ok := bundle.Parameters["porter-debug"]
 	require.True(t, ok)
 	assert.Equal(t, "PORTER_DEBUG", debugParam.Destination.EnvironmentVariable)

--- a/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
@@ -23,6 +23,10 @@ type Bundle struct {
 	Actions          map[string]Action              `json:"actions,omitempty" mapstructure:"actions"`
 	Parameters       map[string]ParameterDefinition `json:"parameters" mapstructure:"parameters"`
 	Credentials      map[string]Location            `json:"credentials" mapstructure:"credentials"`
+
+	// Custom extension metadata is a named collection of auxiliary data whose
+	// meaning is defined outside of the CNAB specification.
+	Custom map[string]interface{} `json:"custom" mapstructure:"custom"`
 }
 
 //Unmarshal unmarshals a Bundle that was not signed.


### PR DESCRIPTION
We are only stamping with the on disk representation of the porter.yaml,
not the dirty in-memory representation. We don't care about in-mem, this
digest will be used later to determine if a rebuild is needed because
the porter.yaml on disk is out of sync with the bundle.json.