### PR TITLE
Fix create helptext

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -44,7 +44,7 @@ func buildBundleCreateCommand(p *porter.Porter) *cobra.Command {
 	return &cobra.Command{
 		Use:   "create",
 		Short: "Create a bundle",
-		Long:  "Create a bundle. This generates a porter manifest, porter.yaml, and the CNAB run script in the current directory.",
+		Long:  "Create a bundle. This generates a porter bundle in the current directory.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.Create()
 		},


### PR DESCRIPTION
Don't specify the exact files generated by create, they may change over time (they already have) and they are all explained now in the README generated at the root of the bundle.