### PR TITLE
Smart rebuild

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -140,14 +140,16 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles")
 	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the CNAB definition to install. Defaults to the bundle in the current directory.")
+		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
 		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
 	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
-	f.StringVarP(&opts.Driver, "driver", "d", "docker",
+	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
 
 	return cmd
@@ -192,7 +194,9 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles")
 	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the CNAB definition to upgrade. Defaults to the bundle in the current directory.")
+		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
@@ -244,7 +248,9 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles")
 	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the CNAB definition to uninstall. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.")
+		"Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -95,7 +95,9 @@ will then provide it to the bundle in the correct location. `,
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles.")
 	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the CNAB definition to install. Defaults to the bundle in the current directory.")
+		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
 	f.BoolVar(&opts.DryRun, "dry-run", false,
 		"Generate credential but do not save it.")
 	return cmd

--- a/pkg/config/stamp.go
+++ b/pkg/config/stamp.go
@@ -44,7 +44,7 @@ func (c *Config) digestManifest(m *Manifest) (string, error) {
 	return hex.EncodeToString(digest[:]), nil
 }
 
-func (c *Config) LoadStamp(bun bundle.Bundle) (*Stamp, error) {
+func (c *Config) LoadStamp(bun *bundle.Bundle) (*Stamp, error) {
 	data := bun.Custom[CustomBundleKey]
 
 	dataB, err := json.Marshal(data)

--- a/pkg/config/stamp_test.go
+++ b/pkg/config/stamp_test.go
@@ -24,7 +24,7 @@ func TestConfig_ComputeManifestDigest(t *testing.T) {
 func TestConfig_LoadStamp(t *testing.T) {
 	c := NewTestConfig(t)
 
-	bun := bundle.Bundle{
+	bun := &bundle.Bundle{
 		Custom: map[string]interface{}{
 			CustomBundleKey: map[string]interface{}{
 				"manifestDigest": simpleManifestDigest,
@@ -40,7 +40,7 @@ func TestConfig_LoadStamp(t *testing.T) {
 func TestConfig_LoadStamp_Invalid(t *testing.T) {
 	c := NewTestConfig(t)
 
-	bun := bundle.Bundle{
+	bun := &bundle.Bundle{
 		Custom: map[string]interface{}{
 			CustomBundleKey: []string{
 				simpleManifestDigest,

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (p *Porter) Build() error {
-	err := p.Config.LoadManifest()
+	err := p.LoadManifest()
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -185,19 +185,19 @@ func TestPorter_buildBundle(t *testing.T) {
 	bundleBytes, err := p.FileSystem.ReadFile("cnab/bundle.json")
 	require.NoError(t, err)
 
-	var bundle bundle.Bundle
-	err = json.Unmarshal(bundleBytes, &bundle)
+	bun := &bundle.Bundle{}
+	err = json.Unmarshal(bundleBytes, bun)
 	require.NoError(t, err)
 
-	assert.Equal(t, bundle.Name, "HELLO")
-	assert.Equal(t, bundle.Version, "0.1.0")
-	assert.Equal(t, bundle.Description, "An example Porter configuration")
+	assert.Equal(t, bun.Name, "HELLO")
+	assert.Equal(t, bun.Version, "0.1.0")
+	assert.Equal(t, bun.Description, "An example Porter configuration")
 
-	stamp, err := p.LoadStamp(bundle)
+	stamp, err := p.LoadStamp(bun)
 	require.NoError(t, err)
 	assert.Equal(t, "781cc745a6efa4f8618d737f1bd60fa659a55809e34a59adbf4b37f78825d4b5", stamp.ManifestDigest)
 
-	debugParam, ok := bundle.Parameters["porter-debug"]
+	debugParam, ok := bun.Parameters["porter-debug"]
 	require.True(t, ok)
 	assert.Equal(t, "PORTER_DEBUG", debugParam.Destination.EnvironmentVariable)
 	assert.Equal(t, "bool", debugParam.DataType)

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -107,7 +107,7 @@ func (o *sharedOptions) validateClaimName(args []string) error {
 }
 
 // defaultBundleFiles defaults the porter manifest and the bundle.json files.
-func (o *sharedOptions) defaultBundleFiles(cxt *context.Context) error {
+func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
 	if o.File == "" {
 		pwd, err := os.Getwd()
 		if err != nil {
@@ -133,7 +133,7 @@ func (o *sharedOptions) defaultBundleFiles(cxt *context.Context) error {
 	return nil
 }
 
-func (o *sharedOptions) validateBundleFiles(cxt *context.Context) error {
+func (o *bundleFileOptions) validateBundleFiles(cxt *context.Context) error {
 	if o.File != "" && o.CNABFile != "" {
 		return errors.New("cannot specify both --file and --cnab-file")
 	}
@@ -151,7 +151,7 @@ func (o *sharedOptions) validateBundleFiles(cxt *context.Context) error {
 	return nil
 }
 
-func (o *sharedOptions) validateManifest(cxt *context.Context) error {
+func (o *bundleFileOptions) validateManifest(cxt *context.Context) error {
 	if o.File == "" {
 		return nil
 	}
@@ -165,7 +165,7 @@ func (o *sharedOptions) validateManifest(cxt *context.Context) error {
 }
 
 // validateBundleJson converts the bundle file path to an absolute filepath and verifies that it exists.
-func (o *sharedOptions) validateBundleJson(cxt *context.Context) error {
+func (o *bundleFileOptions) validateBundleJson(cxt *context.Context) error {
 	if o.CNABFile == "" {
 		return nil
 	}

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -21,6 +21,8 @@ type CNABProvider interface {
 	Uninstall(arguments cnabprovider.UninstallArguments) error
 }
 
+const DefaultDriver = "docker"
+
 // sharedOptions are common options that apply to multiple CNAB actions.
 type sharedOptions struct {
 	bundleRequired bool

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -23,15 +23,20 @@ type CNABProvider interface {
 
 const DefaultDriver = "docker"
 
+type bundleFileOptions struct {
+	// File path to the porter manifest. Defaults to the bundle in the current directory.
+	File string
+
+	// CNABFile is the path to the bundle.json file. Cannot be specified at the same time as the porter manifest.
+	CNABFile string
+}
+
 // sharedOptions are common options that apply to multiple CNAB actions.
 type sharedOptions struct {
-	bundleRequired bool
+	bundleFileOptions
 
 	// Name of the claim. Defaults to the name of the bundle.
 	Name string
-
-	// File path to the CNAB bundle. Defaults to the bundle in the current directory.
-	File string
 
 	// Insecure bundles allowed.
 	Insecure bool
@@ -67,12 +72,17 @@ func (o *sharedOptions) Validate(args []string, cxt *context.Context) error {
 		return err
 	}
 
-	err = o.validateBundlePath(cxt)
+	err = o.validateBundleFiles(cxt)
 	if err != nil {
 		return err
 	}
 
-	err = o.validateParams()
+	err = o.defaultBundleFiles(cxt)
+	if err != nil {
+		return err
+	}
+
+	err = o.validateParams(cxt)
 	if err != nil {
 		return err
 	}
@@ -96,93 +106,103 @@ func (o *sharedOptions) validateClaimName(args []string) error {
 	return nil
 }
 
-// validateBundlePath gets the absolute path to the bundle file.
-func (o *sharedOptions) validateBundlePath(cxt *context.Context) error {
-	err := o.defaultBundleFile(cxt)
+// defaultBundleFiles defaults the porter manifest and the bundle.json files.
+func (o *sharedOptions) defaultBundleFiles(cxt *context.Context) error {
+	if o.File == "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "could not get current working directory")
+		}
+
+		manifestExists, err := cxt.FileSystem.Exists(filepath.Join(pwd, config.Name))
+		if err != nil {
+			return errors.Wrap(err, "could not check if porter manifest exists in current directory")
+		}
+
+		if manifestExists {
+			o.File = config.Name
+			o.CNABFile = "cnab/bundle.json"
+		}
+	}
+
+	if o.File != "" {
+		bundleDir := filepath.Dir(o.File)
+		o.CNABFile = filepath.Join(bundleDir, "cnab/bundle.json")
+	}
+
+	return nil
+}
+
+func (o *sharedOptions) validateBundleFiles(cxt *context.Context) error {
+	if o.File != "" && o.CNABFile != "" {
+		return errors.New("cannot specify both --file and --cnab-file")
+	}
+
+	err := o.validateManifest(cxt)
 	if err != nil {
 		return err
 	}
 
-	err = o.prepareBundleFile()
+	err = o.validateBundleJson(cxt)
 	if err != nil {
 		return err
 	}
 
-	if !o.bundleRequired && o.File == "" {
+	return nil
+}
+
+func (o *sharedOptions) validateManifest(cxt *context.Context) error {
+	if o.File == "" {
 		return nil
 	}
 
 	// Verify the file can be accessed
-	if _, err := os.Stat(o.File); err != nil {
-		return errors.Wrapf(err, "unable to access bundle file %s", o.File)
+	if _, err := cxt.FileSystem.Stat(o.File); err != nil {
+		return errors.Wrapf(err, "unable to access --file %s", o.File)
 	}
 
 	return nil
 }
 
-// defaultBundleFile defaults the bundle file to the bundle in the current directory
-// when none is set.
-func (o *sharedOptions) defaultBundleFile(cxt *context.Context) error {
-	if o.File != "" {
+// validateBundleJson converts the bundle file path to an absolute filepath and verifies that it exists.
+func (o *sharedOptions) validateBundleJson(cxt *context.Context) error {
+	if o.CNABFile == "" {
 		return nil
 	}
 
-	// We are looking both for a bundle.json OR a porter manifest
-	// If we can't find a bundle.json, but we found manifest, tell them to run porter build first
-	pwd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "could not get current working directory")
-	}
-	foundCNAB, _ := cxt.FileSystem.Exists(filepath.Join(pwd, "cnab/bundle.json"))
-	if foundCNAB {
-		o.File = "cnab/bundle.json"
-	}
-	foundManifest, _ := cxt.FileSystem.Exists(filepath.Join(pwd, config.Name))
+	originalPath := o.CNABFile
+	if !filepath.IsAbs(o.CNABFile) {
+		// Convert to an absolute filepath because duffle needs it that way
+		pwd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "could not get current working directory")
+		}
 
-	if !o.bundleRequired && o.File == "" {
-		return nil
+		f := filepath.Join(pwd, o.CNABFile)
+		f, err = filepath.Abs(f)
+		if err != nil {
+			return errors.Wrapf(err, "could not get absolute path for --cnab-file %s", o.CNABFile)
+		}
+
+		o.CNABFile = f
 	}
 
-	if o.File == "" && foundManifest {
-		return errors.New("first run 'porter build' and then run 'porter install'")
+	// Verify the file can be accessed
+	if _, err := cxt.FileSystem.Stat(o.CNABFile); err != nil {
+		// warn about the original relative path
+		return errors.Wrapf(err, "unable to access --cnab-file %s", originalPath)
 	}
 
 	return nil
 }
 
-// prepareBundleFile converts the bundle file path to an absolute filepath.
-func (o *sharedOptions) prepareBundleFile() error {
-	if !o.bundleRequired && o.File == "" {
-		return nil
-	}
-
-	if filepath.IsAbs(o.File) {
-		return nil
-	}
-
-	// Convert to an absolute filepath
-	pwd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "could not get current working directory")
-	}
-
-	f := filepath.Join(pwd, o.File)
-	f, err = filepath.Abs(f)
-	if err != nil {
-		return errors.Wrapf(err, "could not get absolute path for bundle file %s", f)
-	}
-
-	o.File = f
-	return nil
-}
-
-func (o *sharedOptions) validateParams() error {
+func (o *sharedOptions) validateParams(cxt *context.Context) error {
 	err := o.parseParams()
 	if err != nil {
 		return err
 	}
 
-	err = o.parseParamFiles()
+	err = o.parseParamFiles(cxt)
 	if err != nil {
 		return err
 	}
@@ -203,11 +223,11 @@ func (o *sharedOptions) parseParams() error {
 }
 
 // parseParamFiles parses the variable assignments in ParamFiles.
-func (o *sharedOptions) parseParamFiles() error {
+func (o *sharedOptions) parseParamFiles(cxt *context.Context) error {
 	o.parsedParamFiles = make([]map[string]string, 0, len(o.ParamFiles))
 
 	for _, path := range o.ParamFiles {
-		err := o.parseParamFile(path)
+		err := o.parseParamFile(path, cxt)
 		if err != nil {
 			return err
 		}
@@ -216,8 +236,8 @@ func (o *sharedOptions) parseParamFiles() error {
 	return nil
 }
 
-func (o *sharedOptions) parseParamFile(path string) error {
-	f, err := os.Open(path)
+func (o *sharedOptions) parseParamFile(path string, cxt *context.Context) error {
+	f, err := cxt.FileSystem.Open(path)
 	if err != nil {
 		return errors.Wrapf(err, "could not read param file %s", path)
 	}
@@ -262,6 +282,10 @@ func (o *sharedOptions) combineParameters() map[string]string {
 
 // Validate that the provided driver is supported
 func (o *sharedOptions) validateDriver() error {
+	if o.Driver == "" {
+		o.Driver = DefaultDriver
+	}
+
 	// Not using duffle's driver.Lookup() as it currently does not return an error on invalid drivers
 	switch o.Driver {
 	case "docker", "debug":

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -1,0 +1,81 @@
+package porter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/deislabs/porter/pkg/context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedOptions_defaultBundleFiles(t *testing.T) {
+	cxt := context.NewTestContext(t)
+
+	pwd, _ := os.Getwd()
+	_, err := cxt.FileSystem.Create(filepath.Join(pwd, "porter.yaml"))
+	require.NoError(t, err)
+
+	opts := sharedOptions{}
+	err = opts.defaultBundleFiles(cxt.Context)
+	require.NoError(t, err)
+
+	assert.Equal(t, "porter.yaml", opts.File)
+	assert.Equal(t, "cnab/bundle.json", opts.CNABFile)
+}
+
+func TestSharedOptions_defaultBundleFiles_AltManifest(t *testing.T) {
+	cxt := context.NewTestContext(t)
+
+	opts := sharedOptions{
+		bundleFileOptions: bundleFileOptions{
+			File: "mybun/porter.yaml",
+		},
+	}
+	err := opts.defaultBundleFiles(cxt.Context)
+	require.NoError(t, err)
+
+	assert.Equal(t, "mybun/cnab/bundle.json", opts.CNABFile)
+}
+
+func TestSharedOptions_validateBundleJson(t *testing.T) {
+	pwd, _ := os.Getwd()
+
+	cxt := context.NewTestContext(t)
+
+	cxt.FileSystem.Create("/mybun1/bundle.json")
+	cxt.FileSystem.Create(filepath.Join(pwd, "bundle1.json"))
+
+	testcases := []struct {
+		name           string
+		cnabFile       string
+		wantBundleJson string
+		wantError      string
+	}{
+		{name: "absolute file exists", cnabFile: "/mybun1/bundle.json", wantBundleJson: "/mybun1/bundle.json", wantError: ""},
+		{name: "relative file exists", cnabFile: "bundle1.json", wantBundleJson: filepath.Join(pwd, "bundle1.json"), wantError: ""},
+		{name: "absolute file does not exist", cnabFile: "/mybun2/bundle.json", wantError: "unable to access --cnab-file /mybun2/bundle.json"},
+		{name: "relative file does not", cnabFile: "bundle2.json", wantError: "unable to access --cnab-file bundle2.json"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := sharedOptions{
+				bundleFileOptions: bundleFileOptions{
+					CNABFile: tc.cnabFile,
+				},
+			}
+
+			err := opts.validateBundleJson(cxt.Context)
+
+			if tc.wantError == "" {
+				require.NoError(t, err)
+				assert.Equal(t, opts.CNABFile, tc.wantBundleJson)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantError)
+			}
+		})
+	}
+}

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -29,11 +29,12 @@ func (g *CredentialOptions) Validate(args []string, cxt *context.Context) error 
 		return err
 	}
 
-	err = g.validateBundlePath(cxt)
+	err = g.defaultBundleFiles(cxt)
 	if err != nil {
 		return err
 	}
-	return nil
+
+	return g.validateBundleJson(cxt)
 }
 
 func (g *CredentialOptions) validateCredName(args []string) error {

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -48,7 +48,7 @@ func (g *CredentialOptions) validateCredName(args []string) error {
 func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
 
 	//TODO make this work for either porter.yaml OR a bundle
-	bundle, err := p.CNAB.LoadBundle(opts.File, opts.Insecure)
+	bundle, err := p.CNAB.LoadBundle(opts.CNABFile, opts.Insecure)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -24,7 +24,7 @@ func (o *InstallOptions) ToDuffleArgs() cnabprovider.InstallArguments {
 	args := cnabprovider.InstallArguments{
 		ActionArguments: cnabprovider.ActionArguments{
 			Claim:                 o.Name,
-			BundleIdentifier:      o.File,
+			BundleIdentifier:      o.CNABFile,
 			BundleIsFile:          true,
 			Insecure:              o.Insecure,
 			Params:                make(map[string]string, len(o.combinedParameters)),

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -14,7 +14,6 @@ type InstallOptions struct {
 }
 
 func (o *InstallOptions) Validate(args []string, cxt *context.Context) error {
-	o.bundleRequired = true
 	return o.sharedOptions.Validate(args, cxt)
 }
 
@@ -47,6 +46,11 @@ func (o *InstallOptions) ToDuffleArgs() cnabprovider.InstallArguments {
 // them to install a bundle.
 func (p *Porter) InstallBundle(opts InstallOptions) error {
 	err := p.applyDefaultOptions(&opts.sharedOptions)
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/options.go
+++ b/pkg/porter/options.go
@@ -4,14 +4,18 @@ package porter
 // based on values that beyond just what was supplied by the user
 // such as information in the manifest itself.
 func (p *Porter) applyDefaultOptions(opts *sharedOptions) error {
+	if opts.File != "" {
+		err := p.LoadManifestFrom(opts.File)
+		if err != nil {
+			return err
+		}
+	}
+
 	//
 	// Default the claim name to the bundle name
 	//
-	if opts.Name == "" {
-		err := p.Config.LoadManifest()
-		if err == nil {
-			opts.Name = p.Manifest.Name
-		}
+	if opts.Name == "" && p.Manifest != nil {
+		opts.Name = p.Manifest.Name
 	}
 
 	//

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -21,9 +21,8 @@ import (
 // PublishOptions are options that may be specified when publishing a bundle.
 // Porter handles defaulting any missing values.
 type PublishOptions struct {
-	File     string
-	Tag      string
-	CNABFile string
+	bundleFileOptions
+	Tag string
 }
 
 func (p PublishOptions) Validate(porter *Porter) error {
@@ -58,11 +57,16 @@ func (p PublishOptions) Validate(porter *Porter) error {
 // and then regenerates the bundle.json. Finally it [TODO] publishes the manifest to an OCI registry.
 func (p *Porter) Publish(opts PublishOptions) error {
 	var err error
-	if opts.File != "" {
+	if opts.File != "" { // TODO: Extract validation from sharedOptions so that we aren't diverging logic from the other commands like we are here. Normally file is always populated by Validate.
 		err = p.Config.LoadManifestFrom(opts.File)
 	} else {
 		err = p.Config.LoadManifest()
 	}
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -1,0 +1,52 @@
+package porter
+
+import (
+	"fmt"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/pkg/errors"
+)
+
+// EnsureBundleIsUpToDate ensures that the bundle is up to date with the porter manifest,
+// if it is out-of-date, performs a build of the bundle.
+func (p *Porter) EnsureBundleIsUpToDate(opts bundleFileOptions) error {
+	if opts.File == "" {
+		return nil
+	}
+
+	upToDate, err := p.IsBundleUpToDate(opts)
+	if err != nil {
+		fmt.Fprintln(p.Err, "warning", err)
+	}
+
+	if !upToDate {
+		fmt.Fprintln(p.Out, "Building bundle ===>")
+		return p.Build()
+	}
+	return nil
+}
+
+// IsBundleUpToDate checks the hash of the manifest against the hash in cnab/bundle.json.
+func (p *Porter) IsBundleUpToDate(opts bundleFileOptions) (bool, error) {
+	if exists, _ := p.FileSystem.Exists(opts.CNABFile); exists {
+		bunData, err := p.FileSystem.ReadFile(opts.CNABFile)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not read data from %s", opts.CNABFile)
+		}
+
+		bun, err := bundle.Unmarshal(bunData)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not marshal data from %s", opts.CNABFile)
+		}
+
+		oldStamp, err := p.LoadStamp(bun)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not load stamp from %s", opts.CNABFile)
+		}
+
+		newStamp := p.GenerateStamp(p.Manifest)
+		return oldStamp.ManifestDigest == newStamp.ManifestDigest, nil
+	}
+
+	return false, nil
+}

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -33,7 +33,7 @@ func (o *UninstallOptions) ToDuffleArgs() cnabprovider.UninstallArguments {
 	return cnabprovider.UninstallArguments{
 		ActionArguments: cnabprovider.ActionArguments{
 			Claim:                 o.Name,
-			BundleIdentifier:      o.File,
+			BundleIdentifier:      o.CNABFile,
 			BundleIsFile:          true,
 			Insecure:              o.Insecure,
 			Params:                o.combineParameters(),

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -14,14 +14,21 @@ type UninstallOptions struct {
 }
 
 func (o *UninstallOptions) Validate(args []string, cxt *context.Context) error {
-	o.bundleRequired = false
 	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UninstallBundle accepts a set of pre-validated UninstallOptions and uses
 // them to uninstall a bundle.
 func (p *Porter) UninstallBundle(opts UninstallOptions) error {
-	p.applyDefaultOptions(&opts.sharedOptions)
+	err := p.applyDefaultOptions(&opts.sharedOptions)
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
+	if err != nil {
+		return err
+	}
 
 	fmt.Fprintf(p.Out, "uninstalling %s...\n", opts.Name)
 	return p.CNAB.Uninstall(opts.ToDuffleArgs())

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -33,7 +33,7 @@ func (o *UpgradeOptions) ToDuffleArgs() cnabprovider.UpgradeArguments {
 	return cnabprovider.UpgradeArguments{
 		ActionArguments: cnabprovider.ActionArguments{
 			Claim:                 o.Name,
-			BundleIdentifier:      o.File,
+			BundleIdentifier:      o.CNABFile,
 			BundleIsFile:          true,
 			Insecure:              o.Insecure,
 			Params:                o.combineParameters(),

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -14,14 +14,21 @@ type UpgradeOptions struct {
 }
 
 func (o *UpgradeOptions) Validate(args []string, cxt *context.Context) error {
-	o.bundleRequired = false
 	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UpgradeBundle accepts a set of pre-validated UpgradeOptions and uses
 // them to upgrade a bundle.
 func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
-	p.applyDefaultOptions(&opts.sharedOptions)
+	err := p.applyDefaultOptions(&opts.sharedOptions)
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
+	if err != nil {
+		return err
+	}
 
 	fmt.Fprintf(p.Out, "upgrading %s...\n", opts.Name)
 	return p.CNAB.Upgrade(opts.ToDuffleArgs())


### PR DESCRIPTION
Introduce --cnab-file flag

All commands that supported a --file flag now have a --cnab-file flag,
and --file is now just for specifying the porter.yaml file. When they
need to work with a non-porter bundle, they use the --cnab-file flag to
pass in a bundle.json file.

---

Check hash and rebuild bundle if necessary

When the hash of the porter manifest doesn't match the hash found in the
bundle.json, rebuild the bundle before performing an action that uses
the bundle.json file.