### PR TITLE
Add a call to MkdirAll for the credentials directory path.

### DIFF
--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -178,9 +178,12 @@ func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
 	// Make the credentials path if it doesn't exist. MkdirAll does nothing if it already exists
 	// Readable, writable only by the user
 	err = p.Config.FileSystem.MkdirAll(credentialsDir, 0700)
+	if err != nil {
+		return errors.Wrap(err, "unable to create credentials directory")
+	}
 	dest, err := p.Config.GetCredentialPath(genOpts.Name)
 	if err != nil {
-		return errors.Wrap(err, "unable to determine credentials directory")
+		return errors.Wrap(err, "unable to determine credentials path")
 	}
 
 	fmt.Fprintf(p.Out, "Saving credential to %s\n", dest)

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -135,6 +135,9 @@ func (g *CredentialOptions) validateCredName(args []string) error {
 	return nil
 }
 
+// GenerateCredentials builds a new credential set based on the given options. This can be either
+// a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
+// error if unable to generate credentials
 func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
 
 	//TODO make this work for either porter.yaml OR a bundle
@@ -168,13 +171,20 @@ func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
 		fmt.Fprintf(p.Out, "%v", string(data))
 		return nil
 	}
-
+	credentialsDir, err := p.Config.GetCredentialsDir()
+	if err != nil {
+		return errors.Wrap(err, "unable to get credentials directory")
+	}
+	// Make the credentials path if it doesn't exist. MkdirAll does nothing if it already exists
+	// Readable, writable only by the user
+	err = p.Config.FileSystem.MkdirAll(credentialsDir, 0700)
 	dest, err := p.Config.GetCredentialPath(genOpts.Name)
 	if err != nil {
 		return errors.Wrap(err, "unable to determine credentials directory")
 	}
 
 	fmt.Fprintf(p.Out, "Saving credential to %s\n", dest)
+
 	err = p.Context.FileSystem.WriteFile(dest, data, 0600)
 	if err != nil {
 		return errors.Wrapf(err, "couldn't write credential file %s", dest)

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -242,16 +242,23 @@ func TestGenerateNoCredentialDirectory(t *testing.T) {
 		Silent: true,
 	}
 	opts.Name = "name"
+
+	//Check if the credentials directory exists in the FS. It shouldn't.
 	credDir, err := p.Config.GetCredentialsDir()
 	require.NoError(t, err, "should have been able to get credentials directory path")
 	credDirExists, err := p.Porter.Context.FileSystem.DirExists(credDir)
 	require.NoError(t, err, "shouldn't have failed on dir exists")
 	require.False(t, credDirExists, "there should not have been a credential directory for this test")
+
+	//Now generate the credentials. After completion, the directory should now exist. It should be
+	//created if it does not exit
 	err = p.GenerateCredentials(opts)
 	assert.NoError(t, err, "credential generation should have been successful")
 	credDirExists, err = p.Porter.Context.FileSystem.DirExists(credDir)
 	assert.NoError(t, err, "shouldn't have gotten an error checking credential directory after generate")
 	assert.True(t, credDirExists, "should have been a credential directory after the generation")
+
+	//Verify that the credential was actually created.
 	path, err := p.Porter.Config.GetCredentialPath("name")
 	assert.NoError(t, err, "couldn't get credential path")
 	credFileExists, err := p.Porter.Context.FileSystem.Exists(path)
@@ -268,18 +275,26 @@ func TestGenerateCredentialDirectoryExists(t *testing.T) {
 		Silent: true,
 	}
 	opts.Name = "name"
+
+	//Create the credentials directory
 	credDir, err := p.Config.GetCredentialsDir()
 	require.NoError(t, err, "should have been able to get credentials directory path")
 	err = p.Config.FileSystem.MkdirAll(credDir, 0600)
 	require.NoError(t, err, "should have been able to make directory path")
+
+	//Verify the directory does in fact, exist.
 	credDirExists, err := p.Porter.Context.FileSystem.DirExists(credDir)
 	require.NoError(t, err, "shouldn't have failed on dir exists")
 	require.True(t, credDirExists, "there should have been a credential directory for this test")
+
+	//Generate the credential now. The directory does exist, so there should be no error.
 	err = p.GenerateCredentials(opts)
 	assert.NoError(t, err, "credential generation should have been successful")
 	credDirExists, err = p.Porter.Context.FileSystem.DirExists(credDir)
 	assert.NoError(t, err, "shouldn't have gotten an error checking credential directory after generate")
 	assert.True(t, credDirExists, "should have been a credential directory after the generation")
+
+	//Verify we wrote the credential file.
 	path, err := p.Porter.Config.GetCredentialPath("name")
 	assert.NoError(t, err, "couldn't get credential path")
 	credFileExists, err := p.Porter.Context.FileSystem.Exists(path)


### PR DESCRIPTION
This adds a call to MkdirAll with the credentials path before we attempt to write the credential file. This will ensure that the credential directory exists before we try and write the file. If the directory exists already, it's a NO-OP. 

Fixes #377