### PR TITLE
Improve unit test setup of porter home

### DIFF
--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/deislabs/porter/pkg/context"
@@ -29,6 +30,13 @@ func (c *TestConfig) SetupPorterHome() {
 	home := "/root/.porter"
 	os.Setenv(EnvHOME, home)
 
-	// Copy bin dir contents to the home directory
-	c.TestContext.AddTestDirectory(c.TestContext.FindBinDir(), home)
+	// Fake out the porter home directory
+	c.FileSystem.Create(filepath.Join(home, "porter"))
+	c.FileSystem.Create(filepath.Join(home, "porter-runtime"))
+
+	mixinsDir, _ := c.GetMixinsDir()
+	c.FileSystem.Create(filepath.Join(mixinsDir, "exec/exec"))
+	c.FileSystem.Create(filepath.Join(mixinsDir, "exec/exec-runtime"))
+	c.FileSystem.Create(filepath.Join(mixinsDir, "helm/helm"))
+	c.FileSystem.Create(filepath.Join(mixinsDir, "helm/helm-runtime"))
 }


### PR DESCRIPTION
Don't copy the binaries from the real bin on the local file system.
Instead just touch the files that we expect to exist, since they aren't
going to be executed anyway.

This avoid problems where a dirty dev bin/ directory causes unit tests
to fail because of unexpected directories and files existing when they
shouldn't.