### PR TITLE
Smart rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,13 @@ ifndef HAS_DEP
 endif
 	dep version
 
-test: clean-last-testrun test-unit test-cli
+test: clean-last-testrun test-unit test-integration test-cli
 
 test-unit: build
 	go test ./...
+
+test-integration: build
+	go test -tags=integration ./...
 
 test-cli: clean-last-testrun build init-porter-home-for-ci
 	REGISTRY=$(REGISTRY) KUBECONFIG=$(KUBECONFIG) ./scripts/test/test-cli.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,9 +57,15 @@ steps:
 
 - script: |
     export KUBECONFIG=$DOWNLOADSECUREFILE_SECUREFILEPATH
-    make test-cli
+    make test-integration
   workingDirectory: '$(modulePath)'
   displayName: 'Integration Test'
+
+- script: |
+    export KUBECONFIG=$DOWNLOADSECUREFILE_SECUREFILEPATH
+    make test-cli
+  workingDirectory: '$(modulePath)'
+  displayName: 'CLI Test'
 
 - script: |
     AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING) make publish

--- a/brigade.js
+++ b/brigade.js
@@ -169,9 +169,9 @@ checks = {
   "verify": { runFunc: verify, description: "Verify" },
   "build": { runFunc: build, description: "Build" },
   "crossplatformbuild": { runFunc: xbuild, description: "Cross-Platform Build" },
-  "unitTest": { runFunc: testUnit, description: "Unit Test" },
-  "integrationTest": { runFunc: testIntegration, description: "Integration Test" },
-  "cliTest": { runFunc: testCLI, description: "CLI Test" }
+  "unittest": { runFunc: testUnit, description: "Unit Test" },
+  "integrationtest": { runFunc: testIntegration, description: "Integration Test" },
+  "clitest": { runFunc: testCLI, description: "CLI Test" }
 };
 
 // runCheck can be invoked to (re-)run an individual GitHub Check Run, as opposed to a full suite

--- a/brigade.js
+++ b/brigade.js
@@ -22,8 +22,9 @@ events.on("exec", (e, p) => {
     verify(e, p),
     build(e, p),
     xbuild(e, p),
-    test(e, p),
-    testIntegration(e, p)
+    testUnit(e, p),
+    testIntegration(e, p),
+    testCLI(e, p)
   ]);
 });
 
@@ -32,8 +33,9 @@ events.on("exec", (e, p) => {
 events.on("push", (e, p) => {
   if (e.revision.ref.startsWith("refs/tags/")) {
     Group.runEach([
-      test(e, p),
+      testUnit(e, p),
       testIntegration(e, p),
+      testCLI(e, p),
       publish(e, p),
     ])
   }
@@ -41,8 +43,9 @@ events.on("push", (e, p) => {
 
 events.on("publish", (e, p) => {
   Group.runEach([
-    test(e, p),
+    testUnit(e, p),
     testIntegration(e, p),
+    testCLI(e, p),
     publish(e, p),
   ])
 });
@@ -81,8 +84,8 @@ function xbuild(e, p) {
   return goBuild;
 }
 
-function test(e, p) {
-  var goTest = new GoJob(`${projectName}-test`);
+function testUnit(e, p) {
+  var goTest = new GoJob(`${projectName}-testUnit`);
 
   goTest.tasks.push(
     "make test-unit"
@@ -94,7 +97,7 @@ function test(e, p) {
 // TODO: we could refactor so that this job shares a mount with the build job above,
 // to remove the need of re-building before running test-cli
 function testIntegration(e, p) {
-  var goTest = new GoJob(`${projectName}-integrationtest`);
+  var goTest = new GoJob(`${projectName}-testIntegration`);
   // Enable docker so that the daemon can be used for duffle commands invoked by test-cli
   goTest.docker.enabled = true;
 
@@ -112,7 +115,32 @@ function testIntegration(e, p) {
     `docker login ${p.secrets.dockerhubRegistry} \
       -u ${p.secrets.dockerhubUsername} \
       -p ${p.secrets.dockerhubPassword}`,
-    `REGISTRY=${p.secrets.dockerhubOrg} make test-cli`
+    `REGISTRY=${p.secrets.dockerhubOrg} make test-integration`
+  );
+
+  return goTest;
+}
+
+function testCLI(e, p) {
+  var goTest = new GoJob(`${projectName}-testCLI`);
+  // Enable docker so that the daemon can be used for duffle commands invoked by test-cli
+  goTest.docker.enabled = true;
+
+  goTest.env.kubeconfig = {
+    secretKeyRef: {
+      name: "porter-kubeconfig",
+      key: "kubeconfig"
+    }
+  };
+
+  // Setup kubeconfig, docker login, run tests
+  goTest.tasks.push(
+      "mkdir -p ${HOME}/.kube",
+      'echo "${kubeconfig}" > ${HOME}/.kube/config',
+      `docker login ${p.secrets.dockerhubRegistry} \
+      -u ${p.secrets.dockerhubUsername} \
+      -p ${p.secrets.dockerhubPassword}`,
+      `REGISTRY=${p.secrets.dockerhubOrg} make test-cli`
   );
 
   return goTest;
@@ -141,8 +169,9 @@ checks = {
   "verify": { runFunc: verify, description: "Verify" },
   "build": { runFunc: build, description: "Build" },
   "crossplatformbuild": { runFunc: xbuild, description: "Cross-Platform Build" },
-  "test": { runFunc: test, description: "Test" },
-  "integrationtest": { runFunc: testIntegration, description: "Integration Test" }
+  "unitTest": { runFunc: testUnit, description: "Unit Test" },
+  "integrationTest": { runFunc: testIntegration, description: "Integration Test" },
+  "cliTest": { runFunc: testCLI, description: "CLI Test" }
 };
 
 // runCheck can be invoked to (re-)run an individual GitHub Check Run, as opposed to a full suite
@@ -164,8 +193,9 @@ function runCheck(e, p) {
 function runSuite(e, p) {
   if (e.revision.ref == "master" ) {
     Group.runEach([
-      checkRun(e, p, test, "Test"),
+      checkRun(e, p, testUnit(), "Unit Test"),
       checkRun(e, p, testIntegration, "Integration Test"),
+      checkRun(e, p, testCLI(), "CLI Test"),
       checkRun(e, p, publish, "Publish")
     ])
   } else {

--- a/brigade.js
+++ b/brigade.js
@@ -85,7 +85,7 @@ function xbuild(e, p) {
 }
 
 function testUnit(e, p) {
-  var goTest = new GoJob(`${projectName}-testUnit`);
+  var goTest = new GoJob(`${projectName}-testunit`);
 
   goTest.tasks.push(
     "make test-unit"
@@ -97,7 +97,7 @@ function testUnit(e, p) {
 // TODO: we could refactor so that this job shares a mount with the build job above,
 // to remove the need of re-building before running test-cli
 function testIntegration(e, p) {
-  var goTest = new GoJob(`${projectName}-testIntegration`);
+  var goTest = new GoJob(`${projectName}-testintegration`);
   // Enable docker so that the daemon can be used for duffle commands invoked by test-cli
   goTest.docker.enabled = true;
 
@@ -122,7 +122,7 @@ function testIntegration(e, p) {
 }
 
 function testCLI(e, p) {
-  var goTest = new GoJob(`${projectName}-testCLI`);
+  var goTest = new GoJob(`${projectName}-testcli`);
   // Enable docker so that the daemon can be used for duffle commands invoked by test-cli
   goTest.docker.enabled = true;
 
@@ -193,9 +193,9 @@ function runCheck(e, p) {
 function runSuite(e, p) {
   if (e.revision.ref == "master" ) {
     Group.runEach([
-      checkRun(e, p, testUnit(), "Unit Test"),
+      checkRun(e, p, testUnit, "Unit Test"),
       checkRun(e, p, testIntegration, "Integration Test"),
-      checkRun(e, p, testCLI(), "CLI Test"),
+      checkRun(e, p, testCLI, "CLI Test"),
       checkRun(e, p, publish, "Publish")
     ])
   } else {

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -294,7 +294,7 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
   porter bundle publish --insecure
 		`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(p)
+			return opts.Validate(p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.Publish(opts)

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -147,14 +147,16 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles")
 	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the CNAB definition to install. Defaults to the bundle in the current directory.")
+		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
 		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
 	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
-	f.StringVarP(&opts.Driver, "driver", "d", "docker",
+	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
 	f.StringVarP(&opts.Tag, "tag", "t", "",
 		"Install from a bundle in an OCI registry specified by the given tag")
@@ -202,14 +204,16 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles")
 	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the CNAB definition to upgrade. Defaults to the bundle in the current directory.")
+		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
 		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
 	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
-	f.StringVarP(&opts.Driver, "driver", "d", "docker",
+	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
 
 	return cmd
@@ -254,14 +258,16 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles")
 	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the CNAB definition to uninstall. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.")
+		"Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
 		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
 	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
 		"Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
-	f.StringVarP(&opts.Driver, "driver", "d", "docker",
+	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
 
 	return cmd

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -95,7 +95,9 @@ will then provide it to the bundle in the correct location. `,
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles.")
 	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the CNAB definition to install. Defaults to the bundle in the current directory.")
+		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
 	f.BoolVar(&opts.DryRun, "dry-run", false,
 		"Generate credential but do not save it.")
 	return cmd

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,6 +80,10 @@ func (c *Config) GetHomeDir() (string, error) {
 	return c.porterHome, nil
 }
 
+func (c *Config) SetHomeDir(home string) {
+	c.porterHome = home
+}
+
 func (c *Config) GetPorterPath() (string, error) {
 	home, err := c.GetHomeDir()
 	if err != nil {

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,7 +27,7 @@ func NewTestConfig(t *testing.T) *TestConfig {
 func (c *TestConfig) SetupPorterHome() {
 	// Set up the test porter home directory
 	home := "/root/.porter"
-	os.Setenv(EnvHOME, home)
+	c.SetHomeDir(home)
 
 	// Fake out the porter home directory
 	c.FileSystem.Create(filepath.Join(home, "porter"))
@@ -39,4 +38,11 @@ func (c *TestConfig) SetupPorterHome() {
 	c.FileSystem.Create(filepath.Join(mixinsDir, "exec/exec-runtime"))
 	c.FileSystem.Create(filepath.Join(mixinsDir, "helm/helm"))
 	c.FileSystem.Create(filepath.Join(mixinsDir, "helm/helm-runtime"))
+}
+
+// InitializePorterHome initializes the filesystem with the supporting files in the PORTER_HOME directory.
+func (c *TestConfig) SetupIntegrationTest(home string) {
+	c.SetHomeDir(home)
+	// Copy bin dir contents to the home directory
+	c.TestContext.AddTestDirectory(c.TestContext.FindBinDir(), home)
 }

--- a/pkg/config/stamp.go
+++ b/pkg/config/stamp.go
@@ -44,7 +44,7 @@ func (c *Config) digestManifest(m *Manifest) (string, error) {
 	return hex.EncodeToString(digest[:]), nil
 }
 
-func (c *Config) LoadStamp(bun bundle.Bundle) (*Stamp, error) {
+func (c *Config) LoadStamp(bun *bundle.Bundle) (*Stamp, error) {
 	data := bun.Custom[CustomBundleKey]
 
 	dataB, err := json.Marshal(data)

--- a/pkg/config/stamp_test.go
+++ b/pkg/config/stamp_test.go
@@ -24,7 +24,7 @@ func TestConfig_ComputeManifestDigest(t *testing.T) {
 func TestConfig_LoadStamp(t *testing.T) {
 	c := NewTestConfig(t)
 
-	bun := bundle.Bundle{
+	bun := &bundle.Bundle{
 		Custom: map[string]interface{}{
 			CustomBundleKey: map[string]interface{}{
 				"manifestDigest": simpleManifestDigest,
@@ -40,7 +40,7 @@ func TestConfig_LoadStamp(t *testing.T) {
 func TestConfig_LoadStamp_Invalid(t *testing.T) {
 	c := NewTestConfig(t)
 
-	bun := bundle.Bundle{
+	bun := &bundle.Bundle{
 		Custom: map[string]interface{}{
 			CustomBundleKey: []string{
 				simpleManifestDigest,

--- a/pkg/mixin/provider/filesystem_test.go
+++ b/pkg/mixin/provider/filesystem_test.go
@@ -16,10 +16,8 @@ import (
 
 func TestFileSystem_GetMixins(t *testing.T) {
 	// Do this in a temp directory so that we can control which mixins show up in the list
-	os.Setenv(config.EnvHOME, os.TempDir())
-	defer os.Unsetenv(config.EnvHOME)
-
 	c := config.NewTestConfig(t)
+	c.SetHomeDir(os.TempDir())
 	c.FileSystem = &afero.Afero{Fs: afero.NewOsFs()} // Hit the real file system for this test
 
 	mixinsDir, err := c.GetMixinsDir()
@@ -57,8 +55,7 @@ func TestFileSystem_GetSchema(t *testing.T) {
 
 	// bin is my home now
 	binDir := c.TestContext.FindBinDir()
-	os.Setenv(config.EnvHOME, binDir)
-	defer os.Unsetenv(config.EnvHOME)
+	c.SetHomeDir(binDir)
 
 	p := NewFileSystem(c.Config)
 	mixins, err := p.List()

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -31,7 +31,7 @@ type BuildOptions struct {
 func (p *Porter) Build(opts BuildOptions) error {
 	opts.Apply(p.Context)
 
-	err := p.Config.LoadManifest()
+	err := p.LoadManifest()
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -188,19 +188,19 @@ func TestPorter_buildBundle(t *testing.T) {
 	bundleBytes, err := p.FileSystem.ReadFile("cnab/bundle.json")
 	require.NoError(t, err)
 
-	var bundle bundle.Bundle
-	err = json.Unmarshal(bundleBytes, &bundle)
+	bun := &bundle.Bundle{}
+	err = json.Unmarshal(bundleBytes, bun)
 	require.NoError(t, err)
 
-	assert.Equal(t, bundle.Name, "HELLO")
-	assert.Equal(t, bundle.Version, "0.1.0")
-	assert.Equal(t, bundle.Description, "An example Porter configuration")
+	assert.Equal(t, bun.Name, "HELLO")
+	assert.Equal(t, bun.Version, "0.1.0")
+	assert.Equal(t, bun.Description, "An example Porter configuration")
 
-	stamp, err := p.LoadStamp(bundle)
+	stamp, err := p.LoadStamp(bun)
 	require.NoError(t, err)
 	assert.Equal(t, "06a51d04297375bf111ab15e579b8a7ab72e2661018c4d08d1d3f38198028e49", stamp.ManifestDigest)
 
-	debugParam, ok := bundle.Parameters["porter-debug"]
+	debugParam, ok := bun.Parameters["porter-debug"]
 	require.True(t, ok)
 	assert.Equal(t, "PORTER_DEBUG", debugParam.Destination.EnvironmentVariable)
 	assert.Equal(t, "bool", debugParam.DataType)

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -23,15 +23,20 @@ type CNABProvider interface {
 
 const DefaultDriver = "docker"
 
+type bundleFileOptions struct {
+	// File path to the porter manifest. Defaults to the bundle in the current directory.
+	File string
+
+	// CNABFile is the path to the bundle.json file. Cannot be specified at the same time as the porter manifest.
+	CNABFile string
+}
+
 // sharedOptions are common options that apply to multiple CNAB actions.
 type sharedOptions struct {
-	bundleRequired bool
+	bundleFileOptions
 
 	// Name of the claim. Defaults to the name of the bundle.
 	Name string
-
-	// File path to the CNAB bundle. Defaults to the bundle in the current directory.
-	File string
 
 	// Insecure bundles allowed.
 	Insecure bool
@@ -67,16 +72,22 @@ func (o *sharedOptions) Validate(args []string, cxt *context.Context) error {
 		return err
 	}
 
-	err = o.validateBundlePath(cxt)
+	err = o.validateBundleFiles(cxt)
 	if err != nil {
 		return err
 	}
 
-	err = o.validateParams()
+	err = o.defaultBundleFiles(cxt)
 	if err != nil {
 		return err
 	}
 
+	err = o.validateParams(cxt)
+	if err != nil {
+		return err
+	}
+
+	o.defaultDriver()
 	err = o.validateDriver()
 	if err != nil {
 		return err
@@ -96,93 +107,103 @@ func (o *sharedOptions) validateClaimName(args []string) error {
 	return nil
 }
 
-// validateBundlePath gets the absolute path to the bundle file.
-func (o *sharedOptions) validateBundlePath(cxt *context.Context) error {
-	err := o.defaultBundleFile(cxt)
+// defaultBundleFiles defaults the porter manifest and the bundle.json files.
+func (o *sharedOptions) defaultBundleFiles(cxt *context.Context) error {
+	if o.File == "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "could not get current working directory")
+		}
+
+		manifestExists, err := cxt.FileSystem.Exists(filepath.Join(pwd, config.Name))
+		if err != nil {
+			return errors.Wrap(err, "could not check if porter manifest exists in current directory")
+		}
+
+		if manifestExists {
+			o.File = config.Name
+			o.CNABFile = "cnab/bundle.json"
+		}
+	}
+
+	if o.File != "" {
+		bundleDir := filepath.Dir(o.File)
+		o.CNABFile = filepath.Join(bundleDir, "cnab/bundle.json")
+	}
+
+	return nil
+}
+
+func (o *sharedOptions) validateBundleFiles(cxt *context.Context) error {
+	if o.File != "" && o.CNABFile != "" {
+		return errors.New("cannot specify both --file and --cnab-file")
+	}
+
+	err := o.validateManifest(cxt)
 	if err != nil {
 		return err
 	}
 
-	err = o.prepareBundleFile()
+	err = o.validateBundleJson(cxt)
 	if err != nil {
 		return err
 	}
 
-	if !o.bundleRequired && o.File == "" {
+	return nil
+}
+
+func (o *sharedOptions) validateManifest(cxt *context.Context) error {
+	if o.File == "" {
 		return nil
 	}
 
 	// Verify the file can be accessed
-	if _, err := os.Stat(o.File); err != nil {
-		return errors.Wrapf(err, "unable to access bundle file %s", o.File)
+	if _, err := cxt.FileSystem.Stat(o.File); err != nil {
+		return errors.Wrapf(err, "unable to access --file %s", o.File)
 	}
 
 	return nil
 }
 
-// defaultBundleFile defaults the bundle file to the bundle in the current directory
-// when none is set.
-func (o *sharedOptions) defaultBundleFile(cxt *context.Context) error {
-	if o.File != "" {
+// validateBundleJson converts the bundle file path to an absolute filepath and verifies that it exists.
+func (o *sharedOptions) validateBundleJson(cxt *context.Context) error {
+	if o.CNABFile == "" {
 		return nil
 	}
 
-	// We are looking both for a bundle.json OR a porter manifest
-	// If we can't find a bundle.json, but we found manifest, tell them to run porter build first
-	pwd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "could not get current working directory")
-	}
-	foundCNAB, _ := cxt.FileSystem.Exists(filepath.Join(pwd, "cnab/bundle.json"))
-	if foundCNAB {
-		o.File = "cnab/bundle.json"
-	}
-	foundManifest, _ := cxt.FileSystem.Exists(filepath.Join(pwd, config.Name))
+	originalPath := o.CNABFile
+	if !filepath.IsAbs(o.CNABFile) {
+		// Convert to an absolute filepath because duffle needs it that way
+		pwd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "could not get current working directory")
+		}
 
-	if !o.bundleRequired && o.File == "" {
-		return nil
+		f := filepath.Join(pwd, o.CNABFile)
+		f, err = filepath.Abs(f)
+		if err != nil {
+			return errors.Wrapf(err, "could not get absolute path for --cnab-file %s", o.CNABFile)
+		}
+
+		o.CNABFile = f
 	}
 
-	if o.File == "" && foundManifest {
-		return errors.New("first run 'porter build' and then run 'porter install'")
+	// Verify the file can be accessed
+	if _, err := cxt.FileSystem.Stat(o.CNABFile); err != nil {
+		// warn about the original relative path
+		return errors.Wrapf(err, "unable to access --cnab-file %s", originalPath)
 	}
 
 	return nil
 }
 
-// prepareBundleFile converts the bundle file path to an absolute filepath.
-func (o *sharedOptions) prepareBundleFile() error {
-	if !o.bundleRequired && o.File == "" {
-		return nil
-	}
-
-	if filepath.IsAbs(o.File) {
-		return nil
-	}
-
-	// Convert to an absolute filepath
-	pwd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "could not get current working directory")
-	}
-
-	f := filepath.Join(pwd, o.File)
-	f, err = filepath.Abs(f)
-	if err != nil {
-		return errors.Wrapf(err, "could not get absolute path for bundle file %s", f)
-	}
-
-	o.File = f
-	return nil
-}
-
-func (o *sharedOptions) validateParams() error {
+func (o *sharedOptions) validateParams(cxt *context.Context) error {
 	err := o.parseParams()
 	if err != nil {
 		return err
 	}
 
-	err = o.parseParamFiles()
+	err = o.parseParamFiles(cxt)
 	if err != nil {
 		return err
 	}
@@ -203,11 +224,11 @@ func (o *sharedOptions) parseParams() error {
 }
 
 // parseParamFiles parses the variable assignments in ParamFiles.
-func (o *sharedOptions) parseParamFiles() error {
+func (o *sharedOptions) parseParamFiles(cxt *context.Context) error {
 	o.parsedParamFiles = make([]map[string]string, 0, len(o.ParamFiles))
 
 	for _, path := range o.ParamFiles {
-		err := o.parseParamFile(path)
+		err := o.parseParamFile(path, cxt)
 		if err != nil {
 			return err
 		}
@@ -216,8 +237,8 @@ func (o *sharedOptions) parseParamFiles() error {
 	return nil
 }
 
-func (o *sharedOptions) parseParamFile(path string) error {
-	f, err := os.Open(path)
+func (o *sharedOptions) parseParamFile(path string, cxt *context.Context) error {
+	f, err := cxt.FileSystem.Open(path)
 	if err != nil {
 		return errors.Wrapf(err, "could not read param file %s", path)
 	}
@@ -258,6 +279,13 @@ func (o *sharedOptions) combineParameters() map[string]string {
 	}
 
 	return final
+}
+
+// Validate that the provided driver is supported
+func (o *sharedOptions) defaultDriver() {
+	if o.Driver == "" {
+		o.Driver = DefaultDriver
+	}
 }
 
 // Validate that the provided driver is supported

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -108,7 +108,7 @@ func (o *sharedOptions) validateClaimName(args []string) error {
 }
 
 // defaultBundleFiles defaults the porter manifest and the bundle.json files.
-func (o *sharedOptions) defaultBundleFiles(cxt *context.Context) error {
+func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
 	if o.File == "" {
 		pwd, err := os.Getwd()
 		if err != nil {
@@ -134,17 +134,17 @@ func (o *sharedOptions) defaultBundleFiles(cxt *context.Context) error {
 	return nil
 }
 
-func (o *sharedOptions) validateBundleFiles(cxt *context.Context) error {
+func (o *bundleFileOptions) validateBundleFiles(cxt *context.Context) error {
 	if o.File != "" && o.CNABFile != "" {
 		return errors.New("cannot specify both --file and --cnab-file")
 	}
 
-	err := o.validateManifest(cxt)
+	err := o.validateFile(cxt)
 	if err != nil {
 		return err
 	}
 
-	err = o.validateBundleJson(cxt)
+	err = o.validateCNABFile(cxt)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (o *sharedOptions) validateBundleFiles(cxt *context.Context) error {
 	return nil
 }
 
-func (o *sharedOptions) validateManifest(cxt *context.Context) error {
+func (o *bundleFileOptions) validateFile(cxt *context.Context) error {
 	if o.File == "" {
 		return nil
 	}
@@ -165,8 +165,8 @@ func (o *sharedOptions) validateManifest(cxt *context.Context) error {
 	return nil
 }
 
-// validateBundleJson converts the bundle file path to an absolute filepath and verifies that it exists.
-func (o *sharedOptions) validateBundleJson(cxt *context.Context) error {
+// validateCNABFile converts the bundle file path to an absolute filepath and verifies that it exists.
+func (o *bundleFileOptions) validateCNABFile(cxt *context.Context) error {
 	if o.CNABFile == "" {
 		return nil
 	}

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -31,6 +31,20 @@ type bundleFileOptions struct {
 	CNABFile string
 }
 
+func (o *bundleFileOptions) Validate(cxt *context.Context) error {
+	err := o.validateBundleFiles(cxt)
+	if err != nil {
+		return err
+	}
+
+	err = o.defaultBundleFiles(cxt)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
 // sharedOptions are common options that apply to multiple CNAB actions.
 type sharedOptions struct {
 	bundleFileOptions
@@ -72,12 +86,7 @@ func (o *sharedOptions) Validate(args []string, cxt *context.Context) error {
 		return err
 	}
 
-	err = o.validateBundleFiles(cxt)
-	if err != nil {
-		return err
-	}
-
-	err = o.defaultBundleFiles(cxt)
+	err = o.bundleFileOptions.Validate(cxt)
 	if err != nil {
 		return err
 	}
@@ -124,9 +133,7 @@ func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
 			o.File = config.Name
 			o.CNABFile = "cnab/bundle.json"
 		}
-	}
-
-	if o.File != "" {
+	} else {
 		bundleDir := filepath.Dir(o.File)
 		o.CNABFile = filepath.Join(bundleDir, "cnab/bundle.json")
 	}

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -21,6 +21,8 @@ type CNABProvider interface {
 	Uninstall(arguments cnabprovider.UninstallArguments) error
 }
 
+const DefaultDriver = "docker"
+
 // sharedOptions are common options that apply to multiple CNAB actions.
 type sharedOptions struct {
 	bundleRequired bool

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -1,0 +1,89 @@
+package porter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/deislabs/porter/pkg/context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedOptions_defaultBundleFiles(t *testing.T) {
+	cxt := context.NewTestContext(t)
+
+	pwd, _ := os.Getwd()
+	_, err := cxt.FileSystem.Create(filepath.Join(pwd, "porter.yaml"))
+	require.NoError(t, err)
+
+	opts := sharedOptions{}
+	err = opts.defaultBundleFiles(cxt.Context)
+	require.NoError(t, err)
+
+	assert.Equal(t, "porter.yaml", opts.File)
+	assert.Equal(t, "cnab/bundle.json", opts.CNABFile)
+}
+
+func TestSharedOptions_defaultBundleFiles_AltManifest(t *testing.T) {
+	cxt := context.NewTestContext(t)
+
+	opts := sharedOptions{
+		bundleFileOptions: bundleFileOptions{
+			File: "mybun/porter.yaml",
+		},
+	}
+	err := opts.defaultBundleFiles(cxt.Context)
+	require.NoError(t, err)
+
+	assert.Equal(t, "mybun/cnab/bundle.json", opts.CNABFile)
+}
+
+func TestSharedOptions_validateBundleJson(t *testing.T) {
+	pwd, _ := os.Getwd()
+
+	cxt := context.NewTestContext(t)
+
+	cxt.FileSystem.Create("/mybun1/bundle.json")
+	cxt.FileSystem.Create(filepath.Join(pwd, "bundle1.json"))
+
+	testcases := []struct {
+		name           string
+		cnabFile       string
+		wantBundleJson string
+		wantError      string
+	}{
+		{name: "absolute file exists", cnabFile: "/mybun1/bundle.json", wantBundleJson: "/mybun1/bundle.json", wantError: ""},
+		{name: "relative file exists", cnabFile: "bundle1.json", wantBundleJson: filepath.Join(pwd, "bundle1.json"), wantError: ""},
+		{name: "absolute file does not exist", cnabFile: "/mybun2/bundle.json", wantError: "unable to access --cnab-file /mybun2/bundle.json"},
+		{name: "relative file does not", cnabFile: "bundle2.json", wantError: "unable to access --cnab-file bundle2.json"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := sharedOptions{
+				bundleFileOptions: bundleFileOptions{
+					CNABFile: tc.cnabFile,
+				},
+			}
+
+			err := opts.validateBundleJson(cxt.Context)
+
+			if tc.wantError == "" {
+				require.NoError(t, err)
+				assert.Equal(t, opts.CNABFile, tc.wantBundleJson)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantError)
+			}
+		})
+	}
+}
+
+func TestSharedOptions_defaultDriver(t *testing.T) {
+	opts := sharedOptions{}
+
+	opts.defaultDriver()
+
+	assert.Equal(t, DefaultDriver, opts.Driver)
+}

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -67,7 +67,7 @@ func TestSharedOptions_validateBundleJson(t *testing.T) {
 				},
 			}
 
-			err := opts.validateBundleJson(cxt.Context)
+			err := opts.validateCNABFile(cxt.Context)
 
 			if tc.wantError == "" {
 				require.NoError(t, err)

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -140,8 +140,11 @@ func (g *CredentialOptions) validateCredName(args []string) error {
 // a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
 // error if unable to generate credentials
 func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
+	err := p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
+	if err != nil {
+		return err
+	}
 
-	//TODO make this work for either porter.yaml OR a bundle
 	bundle, err := p.CNAB.LoadBundle(opts.CNABFile, opts.Insecure)
 	if err != nil {
 		return err

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -124,7 +124,7 @@ func (g *CredentialOptions) Validate(args []string, cxt *context.Context) error 
 		return err
 	}
 
-	return g.validateBundleJson(cxt)
+	return g.validateCNABFile(cxt)
 }
 
 func (g *CredentialOptions) validateCredName(args []string) error {

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -141,7 +141,7 @@ func (g *CredentialOptions) validateCredName(args []string) error {
 func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
 
 	//TODO make this work for either porter.yaml OR a bundle
-	bundle, err := p.CNAB.LoadBundle(opts.File, opts.Insecure)
+	bundle, err := p.CNAB.LoadBundle(opts.CNABFile, opts.Insecure)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -119,11 +119,12 @@ func (g *CredentialOptions) Validate(args []string, cxt *context.Context) error 
 		return err
 	}
 
-	err = g.validateBundlePath(cxt)
+	err = g.defaultBundleFiles(cxt)
 	if err != nil {
 		return err
 	}
-	return nil
+
+	return g.validateBundleJson(cxt)
 }
 
 func (g *CredentialOptions) validateCredName(args []string) error {

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -18,7 +18,7 @@ type TestPorter struct {
 	TestConfig *config.TestConfig
 
 	// original directory where the test was being executed
-	testDir string
+	TestDir string
 
 	// tempDirectories that need to be cleaned up at the end of the testRun
 	cleanupDirs []string
@@ -52,7 +52,7 @@ func (p *TestPorter) SetupIntegrationTest() {
 	require.NoError(t, err)
 	p.cleanupDirs = append(p.cleanupDirs, homeDir)
 
-	p.testDir, _ = os.Getwd()
+	p.TestDir, _ = os.Getwd()
 	err = os.Chdir(bundleDir)
 	require.NoError(t, err)
 }
@@ -64,7 +64,7 @@ func (p *TestPorter) CleanupIntegrationTest() {
 		p.FileSystem.RemoveAll(dir)
 	}
 
-	os.Chdir(p.testDir)
+	os.Chdir(p.TestDir)
 }
 
 // TODO: use this later to not actually execute a mixin during a unit test

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -1,16 +1,27 @@
 package porter
 
 import (
+	"io/ioutil"
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/deislabs/porter/pkg/config"
-	"github.com/deislabs/porter/pkg/exec"
+	execmixin "github.com/deislabs/porter/pkg/exec"
 	"github.com/deislabs/porter/pkg/mixin"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
 )
 
 type TestPorter struct {
 	*Porter
 	TestConfig *config.TestConfig
+
+	// original directory where the test was being executed
+	testDir string
+
+	// tempDirectories that need to be cleaned up at the end of the testRun
+	cleanupDirs []string
 }
 
 // NewTestPorter initializes a porter test client, with the output buffered, and an in-memory file system.
@@ -25,6 +36,37 @@ func NewTestPorter(t *testing.T) *TestPorter {
 	}
 }
 
+func (p *TestPorter) SetupIntegrationTest() {
+	t := p.TestConfig.TestContext.T
+
+	p.FileSystem = &afero.Afero{Fs: afero.NewOsFs()}
+	p.NewCommand = exec.Command
+
+	// Set up porter and the bundle inside of a temp directory
+	homeDir, err := ioutil.TempDir("", "porter")
+	require.NoError(t, err)
+	p.cleanupDirs = append(p.cleanupDirs, homeDir)
+	p.TestConfig.SetupIntegrationTest(homeDir)
+
+	bundleDir, err := ioutil.TempDir("", "bundle")
+	require.NoError(t, err)
+	p.cleanupDirs = append(p.cleanupDirs, homeDir)
+
+	p.testDir, _ = os.Getwd()
+	err = os.Chdir(bundleDir)
+	require.NoError(t, err)
+}
+
+func (p *TestPorter) CleanupIntegrationTest() {
+	os.Unsetenv(config.EnvHOME)
+
+	for _, dir := range p.cleanupDirs {
+		p.FileSystem.RemoveAll(dir)
+	}
+
+	os.Chdir(p.testDir)
+}
+
 // TODO: use this later to not actually execute a mixin during a unit test
 type TestMixinProvider struct {
 }
@@ -37,7 +79,7 @@ func (p *TestMixinProvider) List() ([]mixin.Metadata, error) {
 }
 
 func (p *TestMixinProvider) GetSchema(m mixin.Metadata) (string, error) {
-	t := exec.NewSchemaBox()
+	t := execmixin.NewSchemaBox()
 	return t.FindString("exec.json")
 }
 

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -21,8 +21,6 @@ func (o *InstallOptions) Validate(args []string, cxt *context.Context) error {
 		if err != nil {
 			return err
 		}
-	} else {
-		o.bundleRequired = true
 	}
 	return o.sharedOptions.Validate(args, cxt)
 }
@@ -80,6 +78,11 @@ func (p *Porter) InstallBundle(opts InstallOptions) error {
 		}
 	}
 	err := p.applyDefaultOptions(&opts.sharedOptions)
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -42,7 +42,7 @@ func (o *InstallOptions) ToDuffleArgs() cnabprovider.InstallArguments {
 	args := cnabprovider.InstallArguments{
 		ActionArguments: cnabprovider.ActionArguments{
 			Claim:                 o.Name,
-			BundleIdentifier:      o.File,
+			BundleIdentifier:      o.CNABFile,
 			BundleIsFile:          true,
 			Insecure:              o.Insecure,
 			Params:                make(map[string]string, len(o.combinedParameters)),

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -3,6 +3,7 @@ package porter
 import (
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,8 +14,14 @@ func TestPorter_applyDefaultOptions(t *testing.T) {
 	err := p.Create()
 	require.NoError(t, err)
 
-	opts := &InstallOptions{}
-	err = opts.validateParams()
+	opts := &InstallOptions{
+		sharedOptions: sharedOptions{
+			bundleFileOptions: bundleFileOptions{
+				File: "porter.yaml",
+			},
+		},
+	}
+	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
 	p.Debug = true
@@ -32,7 +39,7 @@ func TestPorter_applyDefaultOptions_NoManifest(t *testing.T) {
 	p := NewTestPorter(t)
 
 	opts := &InstallOptions{}
-	err := opts.validateParams()
+	err := opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
 	err = p.applyDefaultOptions(&opts.sharedOptions)
@@ -47,8 +54,14 @@ func TestPorter_applyDefaultOptions_DebugOff(t *testing.T) {
 	err := p.Create()
 	require.NoError(t, err)
 
-	opts := InstallOptions{}
-	err = opts.validateParams()
+	opts := &InstallOptions{
+		sharedOptions: sharedOptions{
+			bundleFileOptions: bundleFileOptions{
+				File: "porter.yaml",
+			},
+		},
+	}
+	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
 	p.Debug = false
@@ -69,10 +82,13 @@ func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
 
 	opts := InstallOptions{
 		sharedOptions: sharedOptions{
+			bundleFileOptions: bundleFileOptions{
+				File: "porter.yaml",
+			},
 			Params: []string{"porter-debug=false"},
 		},
 	}
-	err = opts.validateParams()
+	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
 	p.Debug = true
@@ -85,13 +101,14 @@ func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
 }
 
 func TestInstallOptions_validateParams(t *testing.T) {
+	p := NewTestPorter(t)
 	opts := InstallOptions{
 		sharedOptions: sharedOptions{
 			Params: []string{"A=1", "B=2"},
 		},
 	}
 
-	err := opts.validateParams()
+	err := opts.validateParams(p.Context)
 	require.NoError(t, err)
 
 	assert.Len(t, opts.Params, 2)
@@ -125,6 +142,9 @@ func TestInstallOptions_validateClaimName(t *testing.T) {
 }
 
 func TestInstallOptions_combineParameters(t *testing.T) {
+	p := NewTestPorter(t)
+	p.FileSystem = &afero.Afero{Fs: afero.NewOsFs()}
+
 	opts := InstallOptions{
 		sharedOptions: sharedOptions{
 			ParamFiles: []string{
@@ -135,7 +155,7 @@ func TestInstallOptions_combineParameters(t *testing.T) {
 		},
 	}
 
-	err := opts.validateParams()
+	err := opts.validateParams(p.Context)
 	require.NoError(t, err)
 
 	gotParams := opts.combineParameters()
@@ -158,7 +178,8 @@ func TestInstallOptions_validateDriver(t *testing.T) {
 		wantDriver string
 		wantError  string
 	}{
-		{"valid driver provided", "debug", "debug", ""},
+		{"debug", "debug", "debug", ""},
+		{"docker", "docker", "docker", ""},
 		{"invalid driver provided", "dbeug", "", "unsupported driver provided: dbeug"},
 	}
 

--- a/pkg/porter/options.go
+++ b/pkg/porter/options.go
@@ -4,14 +4,18 @@ package porter
 // based on values that beyond just what was supplied by the user
 // such as information in the manifest itself.
 func (p *Porter) applyDefaultOptions(opts *sharedOptions) error {
+	if opts.File != "" {
+		err := p.LoadManifestFrom(opts.File)
+		if err != nil {
+			return err
+		}
+	}
+
 	//
 	// Default the claim name to the bundle name
 	//
-	if opts.Name == "" {
-		err := p.Config.LoadManifest()
-		if err == nil {
-			opts.Name = p.Manifest.Name
-		}
+	if opts.Name == "" && p.Manifest != nil {
+		opts.Name = p.Manifest.Name
 	}
 
 	//

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -26,7 +26,7 @@ import (
 // PublishOptions are options that may be specified when publishing a bundle.
 // Porter handles defaulting any missing values.
 type PublishOptions struct {
-	File             string
+	bundleFileOptions
 	InsecureRegistry bool
 }
 
@@ -56,11 +56,16 @@ func (p PublishOptions) Validate(porter *Porter) error {
 // and then regenerates the bundle.json. Finally it [TODO] publishes the manifest to an OCI registry.
 func (p *Porter) Publish(opts PublishOptions) error {
 	var err error
-	if opts.File != "" {
+	if opts.File != "" { // TODO: Extract validation from sharedOptions so that we aren't diverging logic from the other commands like we are here. Normally file is always populated by Validate.
 		err = p.Config.LoadManifestFrom(opts.File)
 	} else {
 		err = p.Config.LoadManifest()
 	}
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -2,6 +2,7 @@ package porter
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,10 +15,10 @@ func TestPublish_PorterYamlExists(t *testing.T) {
 	p.TestConfig.SetupPorterHome()
 	pwd, err := os.Getwd()
 	require.NoError(t, err, "should not have gotten an error obtaining current working directory")
-	t.Log(p.TestConfig.TestContext.FindBinDir())
-	p.TestConfig.TestContext.AddTestDirectory("testdata", pwd)
+
+	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", filepath.Join(pwd, "porter.yaml"))
 	opts := PublishOptions{}
-	err = opts.Validate(p.Porter)
+	err = opts.Validate(p.Context)
 	require.NoError(t, err, "validating should not have failed")
 
 }
@@ -26,12 +27,12 @@ func TestPublish_PorterYamlDoesNotExist(t *testing.T) {
 	p := NewTestPorter(t)
 	p.TestConfig.SetupPorterHome()
 	opts := PublishOptions{}
-	err := opts.Validate(p.Porter)
+	err := opts.Validate(p.Context)
 	require.Error(t, err, "validation should have failed")
 	assert.EqualError(
 		t,
 		err,
-		"could not find porter.yaml. run `porter create` and `porter build` to create a new bundle before publishing",
+		"could not find porter.yaml in the current directory, make sure you are in the right directory or specify the porter manifest with --file",
 		"porter.yaml not present so should have failed validation",
 	)
 }

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -21,7 +21,7 @@ func (p *Porter) EnsureBundleIsUpToDate(opts bundleFileOptions) error {
 
 	if !upToDate {
 		fmt.Fprintln(p.Out, "Building bundle ===>")
-		return p.Build()
+		return p.Build(BuildOptions{})
 	}
 	return nil
 }

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -1,0 +1,52 @@
+package porter
+
+import (
+	"fmt"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/pkg/errors"
+)
+
+// EnsureBundleIsUpToDate ensures that the bundle is up to date with the porter manifest,
+// if it is out-of-date, performs a build of the bundle.
+func (p *Porter) EnsureBundleIsUpToDate(opts bundleFileOptions) error {
+	if opts.File == "" {
+		return nil
+	}
+
+	upToDate, err := p.IsBundleUpToDate(opts)
+	if err != nil {
+		fmt.Fprintln(p.Err, "warning", err)
+	}
+
+	if !upToDate {
+		fmt.Fprintln(p.Out, "Building bundle ===>")
+		return p.Build()
+	}
+	return nil
+}
+
+// IsBundleUpToDate checks the hash of the manifest against the hash in cnab/bundle.json.
+func (p *Porter) IsBundleUpToDate(opts bundleFileOptions) (bool, error) {
+	if exists, _ := p.FileSystem.Exists(opts.CNABFile); exists {
+		bunData, err := p.FileSystem.ReadFile(opts.CNABFile)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not read data from %s", opts.CNABFile)
+		}
+
+		bun, err := bundle.Unmarshal(bunData)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not marshal data from %s", opts.CNABFile)
+		}
+
+		oldStamp, err := p.LoadStamp(bun)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not load stamp from %s", opts.CNABFile)
+		}
+
+		newStamp := p.GenerateStamp(p.Manifest)
+		return oldStamp.ManifestDigest == newStamp.ManifestDigest, nil
+	}
+
+	return false, nil
+}

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -33,7 +33,7 @@ func (o *UninstallOptions) ToDuffleArgs() cnabprovider.UninstallArguments {
 	return cnabprovider.UninstallArguments{
 		ActionArguments: cnabprovider.ActionArguments{
 			Claim:                 o.Name,
-			BundleIdentifier:      o.File,
+			BundleIdentifier:      o.CNABFile,
 			BundleIsFile:          true,
 			Insecure:              o.Insecure,
 			Params:                o.combineParameters(),

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -14,14 +14,21 @@ type UninstallOptions struct {
 }
 
 func (o *UninstallOptions) Validate(args []string, cxt *context.Context) error {
-	o.bundleRequired = false
 	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UninstallBundle accepts a set of pre-validated UninstallOptions and uses
 // them to uninstall a bundle.
 func (p *Porter) UninstallBundle(opts UninstallOptions) error {
-	p.applyDefaultOptions(&opts.sharedOptions)
+	err := p.applyDefaultOptions(&opts.sharedOptions)
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
+	if err != nil {
+		return err
+	}
 
 	fmt.Fprintf(p.Out, "uninstalling %s...\n", opts.Name)
 	return p.CNAB.Uninstall(opts.ToDuffleArgs())

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -33,7 +33,7 @@ func (o *UpgradeOptions) ToDuffleArgs() cnabprovider.UpgradeArguments {
 	return cnabprovider.UpgradeArguments{
 		ActionArguments: cnabprovider.ActionArguments{
 			Claim:                 o.Name,
-			BundleIdentifier:      o.File,
+			BundleIdentifier:      o.CNABFile,
 			BundleIsFile:          true,
 			Insecure:              o.Insecure,
 			Params:                o.combineParameters(),

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -14,14 +14,21 @@ type UpgradeOptions struct {
 }
 
 func (o *UpgradeOptions) Validate(args []string, cxt *context.Context) error {
-	o.bundleRequired = false
 	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UpgradeBundle accepts a set of pre-validated UpgradeOptions and uses
 // them to upgrade a bundle.
 func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
-	p.applyDefaultOptions(&opts.sharedOptions)
+	err := p.applyDefaultOptions(&opts.sharedOptions)
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
+	if err != nil {
+		return err
+	}
 
 	fmt.Fprintf(p.Out, "upgrading %s...\n", opts.Name)
 	return p.CNAB.Upgrade(opts.ToDuffleArgs())

--- a/tests/rebuild_test.go
+++ b/tests/rebuild_test.go
@@ -1,0 +1,71 @@
+// +build integration
+
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deislabs/porter/pkg/config"
+	"github.com/deislabs/porter/pkg/porter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestRebuild_InstallNewBundle(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+	p.Debug = false
+
+	// Create a bundle
+	err := p.Create()
+	require.NoError(t, err)
+
+	// Install a bundle without building first
+	installOpts := porter.InstallOptions{}
+	installOpts.Insecure = true
+	installOpts.Validate([]string{}, p.Context)
+	err = p.InstallBundle(installOpts)
+	assert.NoError(t, err, "install should have succeeded")
+}
+
+func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+	p.Debug = false
+
+	// Install a bundle
+	err := p.Create()
+	require.NoError(t, err)
+	installOpts := porter.InstallOptions{}
+	installOpts.Insecure = true
+	installOpts.Validate([]string{}, p.Context)
+	err = p.InstallBundle(installOpts)
+	require.NoError(t, err)
+
+	// Modify the porter.yaml to trigger a rebuild
+	m, err := p.ReadManifest(config.Name)
+	require.NoError(t, err)
+	m.Version = "0.2.0"
+	data, err := yaml.Marshal(m)
+	require.NoError(t, err)
+	err = p.FileSystem.WriteFile(config.Name, data, 0644)
+	require.NoError(t, err)
+
+	// Upgrade the bundle
+	upgradeOpts := porter.UpgradeOptions{}
+	upgradeOpts.Insecure = true
+	upgradeOpts.Validate([]string{}, p.Context)
+	err = p.UpgradeBundle(upgradeOpts)
+	require.NoError(t, err, "upgrade should have succeeded")
+
+	gotOutput := p.TestConfig.TestContext.GetOutput()
+	buildCount := strings.Count(gotOutput, "Building bundle ===>")
+	assert.Equal(t, 2, buildCount, "expected a rebuild before upgrade")
+
+	// Verify that the bundle's version matches the updated version in the porter.yaml
+	// TODO: separate ListBundle's printing from fetching claims
+}

--- a/tests/rebuild_test.go
+++ b/tests/rebuild_test.go
@@ -3,6 +3,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -68,4 +69,24 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 
 	// Verify that the bundle's version matches the updated version in the porter.yaml
 	// TODO: separate ListBundle's printing from fetching claims
+}
+
+func TestRebuild_GenerateCredentialsNewBundle(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+	p.Debug = false
+
+	// Create a bundle that uses credentials
+	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundle-with-credentials.yaml"), "porter.yaml")
+
+	credentialOptions := porter.CredentialOptions{}
+	credentialOptions.Insecure = true
+	credentialOptions.Silent = true
+	credentialOptions.Validate([]string{}, p.Context)
+	err := p.GenerateCredentials(credentialOptions)
+	assert.NoError(t, err)
+
+	gotOutput := p.TestConfig.TestContext.GetOutput()
+	assert.Contains(t, gotOutput, "Building bundle ===>", "expected a rebuild before generating credentials")
 }

--- a/tests/testdata/bundle-with-credentials.yaml
+++ b/tests/testdata/bundle-with-credentials.yaml
@@ -1,0 +1,38 @@
+name: mybun
+version: 0.1.0
+description: "An example Porter configuration"
+invocationImage: porter-hello:latest
+tag: deislabs/porter-hello-bundle:latest
+
+credentials:
+  - name: kubeconfig
+    source:
+      path: /root/.kube/config
+
+mixins:
+  - exec
+
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      arguments:
+        - -c
+        - echo Hello World
+
+upgrade:
+  - exec:
+      description: "World 2.0"
+      command: bash
+      arguments:
+        - -c
+        - echo World 2.0
+
+uninstall:
+  - exec:
+      description: "Uninstall Hello World"
+      command: bash
+      arguments:
+        - -c
+        - echo Goodbye World


### PR DESCRIPTION
Introduce --cnab-file flag

All commands that supported a --file flag now have a --cnab-file flag,
and --file is now just for specifying the porter.yaml file. When they
need to work with a non-porter bundle, they use the --cnab-file flag to
pass in a bundle.json file.

---

Check hash and rebuild bundle if necessary

When the hash of the porter manifest doesn't match the hash found in the
bundle.json, rebuild the bundle before performing an action that uses
the bundle.json file.

---

Add programmatic integration test for rebuild

This is the start of testing with Go instead of Bash. What do you think?