### PR TITLE
Fix credentials generate smart build

### DIFF
--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -140,7 +140,12 @@ func (g *CredentialOptions) validateCredName(args []string) error {
 // a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
 // error if unable to generate credentials
 func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
-	err := p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
+	err := p.applyDefaultOptions(&opts.sharedOptions)
+	if err != nil {
+		return err
+	}
+
+	err = p.EnsureBundleIsUpToDate(opts.bundleFileOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/options.go
+++ b/pkg/porter/options.go
@@ -22,6 +22,9 @@ func (p *Porter) applyDefaultOptions(opts *sharedOptions) error {
 	// Default the porter-debug param to --debug
 	//
 	if _, set := opts.combinedParameters["porter-debug"]; !set && p.Debug {
+		if opts.combinedParameters == nil {
+			opts.combinedParameters = make(map[string]string)
+		}
 		opts.combinedParameters["porter-debug"] = "true"
 	}
 


### PR DESCRIPTION
I forgot to load the manifest first before calling the logic to do the
smart build. The integration test didn't catch it because the manifest
doesn't get nuked between calls. So I need to do more work to get the
integration tests to match how the CLI works.