### PR TITLE
Added --tag to upgrade and install

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -191,6 +191,8 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
   porter bundle upgrade --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle upgrade --cred azure --cred kubernetes
   porter bundle upgrade --driver debug
+  porter bundle upgrade --driver debug
+  porter bundle upgrade MyAppFromTag --tag deislabs/porter-kube-bundle:v1.0
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)
@@ -215,6 +217,10 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
+	f.StringVarP(&opts.Tag, "tag", "t", "",
+		"Install from a bundle in an OCI registry specified by the given tag")
+	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
+		"Don't require TLS for the registry")
 
 	return cmd
 }
@@ -245,6 +251,9 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
   porter bundle uninstall --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
   porter bundle uninstall --driver debug
+  porter bundle uninstall --driver debug
+  porter bundle uninstall MyAppFromTag --tag deislabs/porter-kube-bundle:v1.0
+  
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)
@@ -269,6 +278,10 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 		"Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
+	f.StringVarP(&opts.Tag, "tag", "t", "",
+		"Install from a bundle in an OCI registry specified by the given tag")
+	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
+		"Don't require TLS for the registry")
 
 	return cmd
 }

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -191,7 +191,6 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
   porter bundle upgrade --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle upgrade --cred azure --cred kubernetes
   porter bundle upgrade --driver debug
-  porter bundle upgrade --driver debug
   porter bundle upgrade MyAppFromTag --tag deislabs/porter-kube-bundle:v1.0
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -250,7 +249,6 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
   porter bundle uninstall --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
-  porter bundle uninstall --driver debug
   porter bundle uninstall --driver debug
   porter bundle uninstall MyAppFromTag --tag deislabs/porter-kube-bundle:v1.0
   

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/porter/pkg/cache"
 	"github.com/deislabs/porter/pkg/config"
 	execmixin "github.com/deislabs/porter/pkg/exec"
 	"github.com/deislabs/porter/pkg/mixin"
@@ -30,6 +32,7 @@ func NewTestPorter(t *testing.T) *TestPorter {
 	p := New()
 	p.Config = tc.Config
 	p.Mixins = &TestMixinProvider{}
+	p.Cache = cache.New(tc.Config)
 	return &TestPorter{
 		Porter:     p,
 		TestConfig: tc,
@@ -89,4 +92,23 @@ func (p *TestMixinProvider) GetVersion(m mixin.Metadata) (string, error) {
 
 func (p *TestMixinProvider) Install(o mixin.InstallOptions) (mixin.Metadata, error) {
 	return mixin.Metadata{Name: "exec", Dir: "~/.porter/mixins/exec"}, nil
+}
+
+// If you seek a mock cache for testing, use this
+type mockCache struct {
+	findBundleMock        func(string) (string, bool, error)
+	storeBundleMock       func(string, *bundle.Bundle) (string, error)
+	getBundleCacheDirMock func() (string, error)
+}
+
+func (b *mockCache) FindBundle(tag string) (string, bool, error) {
+	return b.findBundleMock(tag)
+}
+
+func (b *mockCache) StoreBundle(tag string, bun *bundle.Bundle) (string, error) {
+	return b.storeBundleMock(tag, bun)
+}
+
+func (b *mockCache) GetCacheDir() (string, error) {
+	return b.GetCacheDir()
 }

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -83,9 +83,8 @@ func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
 	opts := InstallOptions{
 		sharedOptions: sharedOptions{
 			bundleFileOptions: bundleFileOptions{
-				File: "porter.yaml",
+				Params: []string{"porter-debug=false"},
 			},
-			Params: []string{"porter-debug=false"},
 		},
 	}
 	err = opts.Validate([]string{}, p.Context)
@@ -103,8 +102,10 @@ func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
 func TestInstallOptions_validateParams(t *testing.T) {
 	p := NewTestPorter(t)
 	opts := InstallOptions{
-		sharedOptions: sharedOptions{
-			Params: []string{"A=1", "B=2"},
+		BundleLifecycleOpts: BundleLifecycleOpts{
+			sharedOptions: sharedOptions{
+				Params: []string{"A=1", "B=2"},
+			},
 		},
 	}
 
@@ -146,12 +147,14 @@ func TestInstallOptions_combineParameters(t *testing.T) {
 	p.FileSystem = &afero.Afero{Fs: afero.NewOsFs()}
 
 	opts := InstallOptions{
-		sharedOptions: sharedOptions{
-			ParamFiles: []string{
-				"testdata/install/base-params.txt",
-				"testdata/install/dev-params.txt",
+		BundleLifecycleOpts{
+			sharedOptions: sharedOptions{
+				ParamFiles: []string{
+					"testdata/install/base-params.txt",
+					"testdata/install/dev-params.txt",
+				},
+				Params: []string{"A=true", "E=puppies", "E=kitties"},
 			},
-			Params: []string{"A=true", "E=puppies", "E=kitties"},
 		},
 	}
 
@@ -186,8 +189,10 @@ func TestInstallOptions_validateDriver(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := InstallOptions{
-				sharedOptions: sharedOptions{
-					Driver: tc.driver,
+				BundleLifecycleOpts{
+					sharedOptions: sharedOptions{
+						Driver: tc.driver,
+					},
 				},
 			}
 			err := opts.validateDriver()
@@ -200,26 +205,4 @@ func TestInstallOptions_validateDriver(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestInstallOptions_validtag(t *testing.T) {
-	opts := InstallOptions{
-		BundlePullOptions: BundlePullOptions{
-			Tag: "deislabs/kubetest:1.0",
-		},
-	}
-
-	err := opts.validateTag()
-	assert.NoError(t, err, "valid tag should not produce an error")
-}
-
-func TestInstallOptions_invalidtag(t *testing.T) {
-	opts := InstallOptions{
-		BundlePullOptions: BundlePullOptions{
-			Tag: "deislabs/kubetest:1.0:ahjdljahsdj",
-		},
-	}
-
-	err := opts.validateTag()
-	assert.Error(t, err, "invalid tag should produce an error")
 }

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -15,9 +15,11 @@ func TestPorter_applyDefaultOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := &InstallOptions{
-		sharedOptions: sharedOptions{
-			bundleFileOptions: bundleFileOptions{
-				File: "porter.yaml",
+		BundleLifecycleOpts{
+			sharedOptions: sharedOptions{
+				bundleFileOptions: bundleFileOptions{
+					File: "porter.yaml",
+				},
 			},
 		},
 	}
@@ -55,9 +57,11 @@ func TestPorter_applyDefaultOptions_DebugOff(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := &InstallOptions{
-		sharedOptions: sharedOptions{
-			bundleFileOptions: bundleFileOptions{
-				File: "porter.yaml",
+		BundleLifecycleOpts{
+			sharedOptions: sharedOptions{
+				bundleFileOptions: bundleFileOptions{
+					File: "porter.yaml",
+				},
 			},
 		},
 	}
@@ -81,9 +85,10 @@ func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := InstallOptions{
-		sharedOptions: sharedOptions{
-			bundleFileOptions: bundleFileOptions{
-				Params: []string{"porter-debug=false"},
+		BundleLifecycleOpts{
+			sharedOptions: sharedOptions{
+				bundleFileOptions: bundleFileOptions{},
+				Params:            []string{"porter-debug=false"},
 			},
 		},
 	}

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -56,15 +56,8 @@ func TestPorter_applyDefaultOptions_DebugOff(t *testing.T) {
 	err := p.Create()
 	require.NoError(t, err)
 
-	opts := &InstallOptions{
-		BundleLifecycleOpts{
-			sharedOptions: sharedOptions{
-				bundleFileOptions: bundleFileOptions{
-					File: "porter.yaml",
-				},
-			},
-		},
-	}
+	opts := &InstallOptions{}
+	opts.File = "porter.yaml"
 	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
@@ -84,14 +77,9 @@ func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
 	err := p.Create()
 	require.NoError(t, err)
 
-	opts := InstallOptions{
-		BundleLifecycleOpts{
-			sharedOptions: sharedOptions{
-				bundleFileOptions: bundleFileOptions{},
-				Params:            []string{"porter-debug=false"},
-			},
-		},
-	}
+	opts := InstallOptions{}
+	opts.Params = []string{"porter-debug=false"}
+
 	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
@@ -106,13 +94,8 @@ func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
 
 func TestInstallOptions_validateParams(t *testing.T) {
 	p := NewTestPorter(t)
-	opts := InstallOptions{
-		BundleLifecycleOpts: BundleLifecycleOpts{
-			sharedOptions: sharedOptions{
-				Params: []string{"A=1", "B=2"},
-			},
-		},
-	}
+	opts := InstallOptions{}
+	opts.Params = []string{"A=1", "B=2"}
 
 	err := opts.validateParams(p.Context)
 	require.NoError(t, err)

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -1,0 +1,32 @@
+package porter
+
+import (
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/pkg/errors"
+)
+
+type BundleLifecycleOpts struct {
+	sharedOptions
+	BundlePullOptions
+}
+
+// populateOptsFromBundlePull handles calling the bundle pull operation and updating
+// the shared options like name and bundle file path. This is used by install, upgrade
+// and uninstall
+func (opts *BundleLifecycleOpts) populateOptsFromBundlePull(p *Porter) error {
+	bundlePath, err := p.PullBundle(opts.BundlePullOptions)
+	if err != nil {
+		return errors.Wrapf(err, "unable to pull bundle %s", opts.Tag)
+	}
+	opts.File = bundlePath
+	rdr, err := p.Config.FileSystem.Open(bundlePath)
+	if err != nil {
+		return errors.Wrap(err, "unable to open bundle file")
+	}
+	defer rdr.Close()
+	bun, err := bundle.ParseReader(rdr)
+	if opts.Name == "" {
+		opts.Name = bun.Name
+	}
+	return nil
+}

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -1,0 +1,86 @@
+package porter
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundlePullUpdateOpts_bundleCached(t *testing.T) {
+
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+
+	home, err := p.TestConfig.GetHomeDir()
+	t.Logf("home dir is: %s", home)
+	cacheDir, err := p.Cache.GetCacheDir()
+	require.NoError(t, err, "should have had a porter cache dir")
+	t.Logf("cache dir is: %s", cacheDir)
+	p.TestConfig.TestContext.AddTestDirectory("testdata/cache", cacheDir)
+	fullPath := filepath.Join(cacheDir, "887e7e65e39277f8744bd00278760b06/cnab/bundle.json")
+	fileExists, err := p.TestConfig.TestContext.FileSystem.Exists(fullPath)
+	require.True(t, fileExists, "this test requires that the file exist")
+
+	cache := mockCache{
+		findBundleMock: func(tag string) (string, bool, error) {
+			return fullPath, true, nil
+		},
+	}
+	p.Porter.Cache = &cache
+	_, ok, err := p.Cache.FindBundle("deislabs/kubekahn:1.0")
+	assert.True(t, ok, "should have found the bundle...")
+	b := &BundleLifecycleOpts{
+		BundlePullOptions: BundlePullOptions{
+			Tag: "deislabs/kubekahn:1.0",
+		},
+	}
+	err = b.populateOptsFromBundlePull(p.Porter)
+	assert.NoError(t, err, "pulling bundle should not have resulted in an error")
+	assert.Equal(t, "mysql", b.Name, "name should have matched testdata bundle")
+	assert.Equal(t, fullPath, b.File, "the prepare method should have set the file to the fullpath")
+}
+
+func TestBundlePullUpdateOpts_pullError(t *testing.T) {
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+
+	cache := mockCache{
+		findBundleMock: func(tag string) (string, bool, error) {
+			return "", false, nil
+		},
+	}
+	p.Porter.Cache = &cache
+
+	b := &BundleLifecycleOpts{
+		BundlePullOptions: BundlePullOptions{
+			Tag: "deislabs/kubekahn:latest",
+		},
+	}
+	err := b.populateOptsFromBundlePull(p.Porter)
+	assert.Error(t, err, "pulling bundle should have resulted in an error")
+	assert.Contains(t, err.Error(), "unable to pull bundle deislabs/kubekahn:latest")
+
+}
+
+func TestBundlePullUpdateOpts_cacheLies(t *testing.T) {
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+
+	cache := mockCache{
+		findBundleMock: func(tag string) (string, bool, error) {
+			return "/opt/not/here/bundle.json", true, nil
+		},
+	}
+	p.Porter.Cache = &cache
+	b := &BundleLifecycleOpts{
+		BundlePullOptions: BundlePullOptions{
+			Tag: "deislabs/kubekahn:latest",
+		},
+	}
+	err := b.populateOptsFromBundlePull(p.Porter)
+	assert.Error(t, err, "pulling bundle should have resulted in an error")
+	assert.Contains(t, err.Error(), "unable to open bundle file")
+
+}

--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -12,7 +12,7 @@ import (
 // Porter is the logic behind the porter client.
 type Porter struct {
 	*config.Config
-	Cache     *cache.Cache
+	Cache     cache.BundleCache
 	Templates *Templates
 	Mixins    MixinProvider
 	CNAB      CNABProvider

--- a/pkg/porter/pull.go
+++ b/pkg/porter/pull.go
@@ -14,6 +14,15 @@ type BundlePullOptions struct {
 	Force            bool
 }
 
+func (b BundlePullOptions) validateTag() error {
+	_, err := parseOCIReference(b.Tag)
+	if err != nil {
+		return errors.Wrap(err, "invalid value for --tag, specified value should be of the form REGISTRY/bundle:tag")
+	}
+	return nil
+
+}
+
 // PullBundle looks for a given bundle tag in the bundle cache. If it is not found, it is
 // pulled and stored in the cache. The path to the cached bundle is returned.
 func (p *Porter) PullBundle(opts BundlePullOptions) (string, error) {

--- a/pkg/porter/pull_test.go
+++ b/pkg/porter/pull_test.go
@@ -1,0 +1,25 @@
+package porter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBundlePullOptions_validtag(t *testing.T) {
+	opts := BundlePullOptions{
+		Tag: "deislabs/kubetest:1.0",
+	}
+
+	err := opts.validateTag()
+	assert.NoError(t, err, "valid tag should not produce an error")
+}
+
+func TestBundlePullOptions_invalidtag(t *testing.T) {
+	opts := BundlePullOptions{
+		Tag: "deislabs/kubetest:1.0:ahjdljahsdj",
+	}
+
+	err := opts.validateTag()
+	assert.Error(t, err, "invalid tag should produce an error")
+}

--- a/pkg/porter/testdata/cache/887e7e65e39277f8744bd00278760b06/cnab/bundle.json
+++ b/pkg/porter/testdata/cache/887e7e65e39277f8744bd00278760b06/cnab/bundle.json
@@ -1,0 +1,56 @@
+{
+    "credentials": {
+        "kubeconfig": {
+            "path": "/root/.kube/config"
+        }
+    },
+    "description": "",
+    "images": null,
+    "invocationImages": [{
+        "digest": "sha256:f858bc025ad34099fe67ebe6152e03b4c91b34cc7a77d1aa10aaf1dc1389c2c2",
+        "image": "jeremyrickard/porter-mysql@sha256:f858bc025ad34099fe67ebe6152e03b4c91b34cc7a77d1aa10aaf1dc1389c2c2",
+        "imageType": "docker"
+    }],
+    "name": "mysql",
+    "parameters": {
+        "database-name": {
+            "defaultValue": "mydb",
+            "destination": {
+                "env": "DATABASE_NAME"
+            },
+            "type": "string"
+        },
+        "mysql-name": {
+            "defaultValue": "porter-ci-mysql",
+            "destination": {
+                "env": "MYSQL-NAME"
+            },
+            "type": "string"
+        },
+        "mysql-user": {
+            "destination": {
+                "env": "MYSQL_USER"
+            },
+            "required": true,
+            "type": "string"
+        },
+        "namespace": {
+            "defaultValue": "",
+            "destination": {
+                "env": "NAMESPACE"
+            },
+            "type": "string"
+        },
+        "porter-debug": {
+            "defaultValue": false,
+            "destination": {
+                "env": "PORTER_DEBUG"
+            },
+            "metadata": {
+                "description": "Print debug information from Porter when executing the bundle"
+            },
+            "type": "bool"
+        }
+    },
+    "version": "0.1.0"
+}

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -5,21 +5,35 @@ import (
 
 	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
 	"github.com/deislabs/porter/pkg/context"
+	"github.com/pkg/errors"
 )
 
 // UninstallOptions that may be specified when uninstalling a bundle.
 // Porter handles defaulting any missing values.
 type UninstallOptions struct {
-	sharedOptions
+	BundleLifecycleOpts
 }
 
 func (o *UninstallOptions) Validate(args []string, cxt *context.Context) error {
+	if o.Tag != "" {
+		err := o.validateTag()
+		if err != nil {
+			return err
+		}
+	}
 	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UninstallBundle accepts a set of pre-validated UninstallOptions and uses
 // them to uninstall a bundle.
 func (p *Porter) UninstallBundle(opts UninstallOptions) error {
+	if opts.Tag != "" {
+		o := &opts
+		err := o.populateOptsFromBundlePull(p)
+		if err != nil {
+			return errors.Wrap(err, "unable to pull bundle before uninstalling")
+		}
+	}
 	err := p.applyDefaultOptions(&opts.sharedOptions)
 	if err != nil {
 		return err

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -5,21 +5,35 @@ import (
 
 	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
 	"github.com/deislabs/porter/pkg/context"
+	"github.com/pkg/errors"
 )
 
 // UpgradeOptions that may be specified when uninstalling a bundle.
 // Porter handles defaulting any missing values.
 type UpgradeOptions struct {
-	sharedOptions
+	BundleLifecycleOpts
 }
 
 func (o *UpgradeOptions) Validate(args []string, cxt *context.Context) error {
+	if o.Tag != "" {
+		err := o.validateTag()
+		if err != nil {
+			return err
+		}
+	}
 	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UpgradeBundle accepts a set of pre-validated UpgradeOptions and uses
 // them to upgrade a bundle.
 func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
+	if opts.Tag != "" {
+		o := &opts
+		err := o.populateOptsFromBundlePull(p)
+		if err != nil {
+			return errors.Wrap(err, "unable to pull bundle before upgrade")
+		}
+	}
 	err := p.applyDefaultOptions(&opts.sharedOptions)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds --tag to upgrade and install. Since the functionality is used in a couple
places and Install/Upgrade/Delete currently have their own Opts that embed the same things,
I actually just made a new struct called LifecycleOpts that has a logic to deal with tag
if it's present (fetch the bundle, update the opts to use it)

Also refactored cache a little bit to make it easier to use a Mock and not actually use the
cache during a unit test