### PR TITLE
ci(*): publish test and example bundles

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -4,6 +4,7 @@ mixins:
 name: mysql
 version: 0.1.0
 invocationImage: porter-mysql:latest
+tag: deislabs/porter-mysql-bundle:v0.1.0
 
 credentials:
 - name: kubeconfig

--- a/build/testdata/bundles/terraform/porter.yaml
+++ b/build/testdata/bundles/terraform/porter.yaml
@@ -4,6 +4,7 @@ mixins:
 name: porter-terraform
 version: 0.1.0
 invocationImage: porter-terraform:latest
+tag: deislabs/porter-terraform-bundle:v0.1.0
 
 parameters:
   - name: file_contents

--- a/build/testdata/bundles/wordpress/porter.yaml
+++ b/build/testdata/bundles/wordpress/porter.yaml
@@ -5,6 +5,7 @@ mixins:
 name: wordpress
 version: 0.1.0
 invocationImage: porter-wordpress:latest
+tag: deislabs/porter-wordpress-bundle:v0.1.0
 
 dependencies:
 - name: mysql

--- a/examples/aks-spring-music/porter.yaml
+++ b/examples/aks-spring-music/porter.yaml
@@ -1,9 +1,9 @@
 name: spring-music-bundle
 version: 0.1.0
 description: "Spring Music Demo app with Azure Cosmos DB"
-invocationImage: jeremyrickard/spring-music-installer:v314
+invocationImage: deislabs/spring-music-installer:latest
 dockerfile: cnab/app/Dockerfile.base
-tag: jeremyrickard/spring-music-bundle:v314
+tag: deislabs/spring-music-bundle:v0.1.0
 
 mixins:
   - exec

--- a/examples/azure-ark/porter.yaml
+++ b/examples/azure-ark/porter.yaml
@@ -6,7 +6,7 @@ name: porter-azure-ark
 description: "A Porter example using Azure Storage and Ark"
 version: 0.1.0
 invocationImage: deislabs/porter-azure-ark:latest
-tag: deislabs/porter-azure-ark-bundle:latest
+tag: deislabs/porter-azure-ark-bundle:v0.1.0
 
 credentials:
 - name: SUBSCRIPTION_ID

--- a/examples/azure-mysql-wordpress/porter.yaml
+++ b/examples/azure-mysql-wordpress/porter.yaml
@@ -5,7 +5,7 @@ mixins:
 name: porter-azure-wordpress 
 version: 0.1.0
 invocationImage: deislabs/porter-azure-wordpress:latest
-tag: deislabs/porter-azure-wordpress-bundle:latest
+tag: deislabs/porter-azure-wordpress-bundle:v0.1.0
 
 credentials:
 - name: SUBSCRIPTION_ID

--- a/examples/kubernetes-mixin-example/porter.yaml
+++ b/examples/kubernetes-mixin-example/porter.yaml
@@ -10,7 +10,7 @@ name: PORTER_KUBE
 version: 0.1.0
 description: "An example Porter bundle with Kubernetes"
 invocationImage: deislabs/porter-kubernetes:latest
-tag: deislabs/porter-kube-bundle:1.0
+tag: deislabs/porter-kube-bundle:v0.1.0
 
 install:
   - kubernetes:

--- a/scripts/test/test-hello.sh
+++ b/scripts/test/test-hello.sh
@@ -12,7 +12,10 @@ trap popd EXIT
 
 # Verify our default template bundle
 ${PORTER_HOME}/porter create
+
+# Substitute REGISTRY in for invocation image and bundle tag
 sed -i "s/porter-hello:latest/${REGISTRY}\/porter-hello:latest/g" porter.yaml
+sed -i "s/deislabs\/porter-hello-bundle/${REGISTRY}\/porter-hello-bundle/g" porter.yaml
 
 ${PORTER_HOME}/porter build
 ${PORTER_HOME}/porter install --insecure --debug
@@ -20,3 +23,6 @@ cat ${PORTER_HOME}/claims/HELLO.json
 ${PORTER_HOME}/porter upgrade --insecure --debug
 cat ${PORTER_HOME}/claims/HELLO.json
 ${PORTER_HOME}/porter uninstall --insecure --debug
+
+# Publish bundle
+${PORTER_HOME}/porter publish

--- a/scripts/test/test-terraform.sh
+++ b/scripts/test/test-terraform.sh
@@ -15,7 +15,10 @@ cp -r ${REPO_DIR}/build/testdata/bundles/terraform/cnab .
 
 # Copy in the terraform porter manifest
 cp ${REPO_DIR}/build/testdata/bundles/terraform/porter.yaml .
+
+# Substitute REGISTRY in for invocation image and bundle tag
 sed -i "s/porter-terraform:latest/${REGISTRY}\/porter-terraform:latest/g" porter.yaml
+sed -i "s/deislabs\/porter-terraform-bundle/${REGISTRY}\/porter-terraform-bundle/g" porter.yaml
 
 porter_output=$(mktemp)
 
@@ -31,12 +34,13 @@ fi
 # TODO: enable when status supported
 # ${PORTER_HOME}/porter status --debug | grep -q 'content = foo!'
 
-# TODO: enable when upgrade supported
-# ${PORTER_HOME}/porter upgrade --insecure --debug --param file_contents='bar!'
+${PORTER_HOME}/porter upgrade --insecure --debug --param file_contents='bar!'
 
 # TODO: enable when status supported
 # ${PORTER_HOME}/porter status --debug | grep -q 'content = bar!'
 
 cat ${PORTER_HOME}/claims/porter-terraform.json
 
-${PORTER_HOME}/porter uninstall --insecure --debug --param file_contents='foo!'
+${PORTER_HOME}/porter uninstall --insecure --debug --param file_contents='bar!'
+
+${PORTER_HOME}/porter publish

--- a/scripts/test/test-wordpress.sh
+++ b/scripts/test/test-wordpress.sh
@@ -14,7 +14,10 @@ trap popd EXIT
 
 # Verify a bundle with dependencies
 cp ${REPO_DIR}/build/testdata/bundles/wordpress/porter.yaml .
+
+# Substitute REGISTRY in for invocation image and bundle tag
 sed -i "s/porter-wordpress:latest/${REGISTRY}\/porter-wordpress:latest/g" porter.yaml
+sed -i "s/deislabs\/porter-wordpress-bundle/${REGISTRY}\/porter-wordpress-bundle/g" porter.yaml
 
 ${PORTER_HOME}/porter build
 
@@ -40,3 +43,6 @@ cat ${PORTER_HOME}/claims/wordpress.json
 
 ${PORTER_HOME}/porter uninstall --insecure --cred ci --debug
 kubectl delete ns $NAMESPACE
+
+# Publish bundle
+${PORTER_HOME}/porter publish


### PR DESCRIPTION
Proposed implementation for https://github.com/deislabs/porter/issues/396

Note that I started off misinterpreting the original issue - I was thinking about the test bundles that we test in CI.  So, the first commit comprises changes to publish the test bundles while the second commit adds logic for publishing the example bundles.  We can either go with both or I can remove that first commit if we'd rather not publish the test variants.