### PR TITLE
Add ImageMap

### DIFF
--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -11,6 +11,7 @@ Porter generates a bundle from its manifest, porter.yaml. The manifest is made u
 * [Credentials](#credentials)
 * [Bundle Actions](#bundle-actions)
 * [Dependencies](#dependencies)
+* [Image Map](#image-map)
 * [Generated Files](#generated-files)
 
 We have full [examples](https://github.com/deislabs/porter/tree/master/examples) of Porter manifests in the Porter repository.
@@ -159,6 +160,14 @@ dependencies:
 
 * `name`: The name of the bundle.
 * `parameters`: Optionally set default values for parameters in the bundle.
+
+## Image Map
+
+The Image Map is part of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/103-bundle-runtime.md#image-maps).
+The `imageMap` data from the manifest is made available at runtime `/cnab/app/image-map.json` where you may access it
+from a script. 
+
+Note: Neither porter nor the DeisLabs mixins use this information.
 
 ## Generated Files
 

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -41,6 +41,11 @@ type Manifest struct {
 	Parameters   []ParameterDefinition  `yaml:"parameters,omitempty"`
 	Credentials  []CredentialDefinition `yaml:"credentials,omitempty"`
 	Dependencies []*Dependency          `yaml:"dependencies,omitempty"`
+
+	// ImageMap is a map of images referenced in the bundle. The mappings are mounted as a file at runtime to
+	// /cnab/app/image-map.json. This data is not used by porter or any of the deislabs mixins, so only populate when you
+	// plan on manually using this data in your own scripts.
+	ImageMap map[string]MappedImage `yaml:"imageMap,omitempty"`
 }
 
 // ParameterDefinition defines a single parameter for a CNAB bundle
@@ -73,6 +78,22 @@ type Location struct {
 // ParameterMetadata contains metadata for a parameter definition.
 type ParameterMetadata struct {
 	Description string `yaml:"description,omitempty"`
+}
+
+type MappedImage struct {
+	Description   string         `yaml:"description"`
+	ImageType     string         `yaml:"imageType"`
+	Image         string         `yaml:"image"`
+	OriginalImage string         `yaml:"originalImage,omitempty"`
+	Digest        string         `yaml:"digest,omitempty"`
+	Size          uint64         `yaml:"size,omitempty"`
+	MediaType     string         `yaml:"mediaType,omitempty"`
+	Platform      *ImagePlatform `yaml:"platform,omitempty"`
+}
+
+type ImagePlatform struct {
+	Architecture string `yaml:"architecture,omitempty"`
+	OS           string `yaml:"os,omitempty"`
 }
 
 type Dependency struct {

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -233,3 +233,46 @@ func TestPorter_paramRequired(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, p2.Required)
 }
+
+func TestPorter_generateImages(t *testing.T) {
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+
+	configTpl, err := p.Templates.GetManifest()
+	require.Nil(t, err)
+	p.TestConfig.TestContext.AddTestFileContents(configTpl, config.Name)
+
+	err = p.LoadManifest()
+	require.NoError(t, err)
+
+	mappedImage := config.MappedImage{
+		Description:   "un petite server",
+		Image:         "deislabs/myserver:1.0.0",
+		ImageType:     "docker",
+		Digest:        "abc123",
+		Size:          12,
+		MediaType:     "download",
+		OriginalImage: "deis/myserver:1.0.0",
+		Platform: &config.ImagePlatform{
+			OS:           "linux",
+			Architecture: "amd64",
+		},
+	}
+	p.Manifest.ImageMap = map[string]config.MappedImage{
+		"server": mappedImage,
+	}
+
+	images := p.generateBundleImages()
+
+	require.Len(t, images, 1)
+	img := images["server"]
+	assert.Equal(t, mappedImage.Description, img.Description)
+	assert.Equal(t, mappedImage.Image, img.Image)
+	assert.Equal(t, mappedImage.ImageType, img.ImageType)
+	assert.Equal(t, mappedImage.Digest, img.Digest)
+	assert.Equal(t, mappedImage.Size, img.Size)
+	assert.Equal(t, mappedImage.MediaType, img.MediaType)
+	assert.Equal(t, mappedImage.OriginalImage, img.OriginalImage)
+	assert.Equal(t, mappedImage.Platform.OS, img.Platform.OS)
+	assert.Equal(t, mappedImage.Platform.Architecture, img.Platform.Architecture)
+}

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -276,3 +276,30 @@ func TestPorter_generateImages(t *testing.T) {
 	assert.Equal(t, mappedImage.Platform.OS, img.Platform.OS)
 	assert.Equal(t, mappedImage.Platform.Architecture, img.Platform.Architecture)
 }
+
+func TestPorter_generateBundleImages_EmptyPlatform(t *testing.T) {
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+
+	configTpl, err := p.Templates.GetManifest()
+	require.Nil(t, err)
+	p.TestConfig.TestContext.AddTestFileContents(configTpl, config.Name)
+
+	err = p.LoadManifest()
+	require.NoError(t, err)
+
+	mappedImage := config.MappedImage{
+		Description: "un petite server",
+		Image:       "deislabs/myserver:1.0.0",
+		ImageType:   "docker",
+		Platform:    nil,
+	}
+	p.Manifest.ImageMap = map[string]config.MappedImage{
+		"server": mappedImage,
+	}
+
+	images := p.generateBundleImages()
+	require.Len(t, images, 1)
+	img := images["server"]
+	assert.Nil(t, img.Platform)
+}


### PR DESCRIPTION
This adds manual support for image map. The data can be defined in the porter.yaml and porter will populate it in the generated bundle.json file, so that it is made available at runtime per the spec.

However porter and the mixins do not have any explicit behaviors based on the presence of the data. When a user populates the image map, they must also add scripts to the bundle to use it at runtime.