### PR TITLE
Fix smart build for credentials generate

### DIFF
--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -155,12 +155,7 @@ func (g *CredentialOptions) Validate(args []string, cxt *context.Context) error 
 		return err
 	}
 
-	err = g.defaultBundleFiles(cxt)
-	if err != nil {
-		return err
-	}
-
-	return g.validateCNABFile(cxt)
+	return g.bundleFileOptions.Validate(cxt)
 }
 
 func (g *CredentialOptions) validateCredName(args []string) error {

--- a/tests/rebuild_test.go
+++ b/tests/rebuild_test.go
@@ -27,7 +27,8 @@ func TestRebuild_InstallNewBundle(t *testing.T) {
 	// Install a bundle without building first
 	installOpts := porter.InstallOptions{}
 	installOpts.Insecure = true
-	installOpts.Validate([]string{}, p.Context)
+	err = installOpts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
 	err = p.InstallBundle(installOpts)
 	assert.NoError(t, err, "install should have succeeded")
 }
@@ -43,7 +44,8 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 	require.NoError(t, err)
 	installOpts := porter.InstallOptions{}
 	installOpts.Insecure = true
-	installOpts.Validate([]string{}, p.Context)
+	err = installOpts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
 	err = p.InstallBundle(installOpts)
 	require.NoError(t, err)
 
@@ -59,7 +61,8 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 	// Upgrade the bundle
 	upgradeOpts := porter.UpgradeOptions{}
 	upgradeOpts.Insecure = true
-	upgradeOpts.Validate([]string{}, p.Context)
+	err = upgradeOpts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
 	err = p.UpgradeBundle(upgradeOpts)
 	require.NoError(t, err, "upgrade should have succeeded")
 
@@ -83,8 +86,9 @@ func TestRebuild_GenerateCredentialsNewBundle(t *testing.T) {
 	credentialOptions := porter.CredentialOptions{}
 	credentialOptions.Insecure = true
 	credentialOptions.Silent = true
-	credentialOptions.Validate([]string{}, p.Context)
-	err := p.GenerateCredentials(credentialOptions)
+	err := credentialOptions.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+	err = p.GenerateCredentials(credentialOptions)
 	assert.NoError(t, err)
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()
@@ -103,8 +107,9 @@ func TestRebuild_GenerateCredentialsExistingBundle(t *testing.T) {
 	credentialOptions := porter.CredentialOptions{}
 	credentialOptions.Insecure = true
 	credentialOptions.Silent = true
-	credentialOptions.Validate([]string{}, p.Context)
-	err := p.GenerateCredentials(credentialOptions)
+	err := credentialOptions.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+	err = p.GenerateCredentials(credentialOptions)
 	require.NoError(t, err)
 
 	// Modify the porter.yaml to trigger a rebuild


### PR DESCRIPTION
When I hooked up smart build I hadn't updated the existing Validate
method to use the new Validate method that handles validating and
defaulting in the proper order for --file and --cnab-file.

I've fixed the integration tests so that they catch the problem now,
they weren't checking the error from Validate.

Fixes #410 