### PR TITLE
ref(brigade.js): update applicable jobs to run via DinD

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -184,6 +184,10 @@ function publish(e, p) {
 
   goPublish.env.AZURE_STORAGE_CONNECTION_STRING = p.secrets.azureStorageConnectionString;
   goPublish.tasks.push(
+    "apk update && apk add py-pip && \
+      apk add --virtual=az-build libffi-dev musl-dev openssl-dev python-dev && \
+      pip install azure-cli && \
+      apk del --purge az-build",
     "make build xbuild-all publish"
   )
 

--- a/brigade.js
+++ b/brigade.js
@@ -181,10 +181,10 @@ function publish(e, p) {
 
   goPublish.env.AZURE_STORAGE_CONNECTION_STRING = p.secrets.azureStorageConnectionString;
   goPublish.tasks.push(
-    "apk update && apk add py-pip && \
-      apk add --virtual=az-build libffi-dev musl-dev openssl-dev python-dev && \
-      pip install azure-cli && \
-      apk del --purge az-build",
+    // Fetch az cli needed for publishing
+    "curl -sLO https://github.com/carolynvs/az-cli/releases/download/v0.3.2/az-linux-amd64 && \
+      chmod +x az-linux-amd64 && \
+      mv az-linux-amd64 /usr/local/bin/az",
     "make build xbuild-all publish"
   )
 


### PR DESCRIPTION
Proposed implementation for https://github.com/deislabs/porter/issues/409

Collabo with @krancour, who was of crucial assistance around some of the finer points of setting up the golang env in the alpine-based `docker:stable-dind` base image.

Uses https://github.com/vdice/go-dind currently, but we can amend/port/etc.  This image currently comes in at `814MB`, so at least chops some weight off of our golang image (the previous `deis/go-dev` image comes in at `1.86GB`)