### PR TITLE
CNABify Parameters a bit

### DIFF
--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -81,13 +81,25 @@ parameters:
 ```
 
 * `name`: The name of the parameter.
-* `type`: The data type of the parameter: string, int, boolean.
-* `default`: Optional. The default value for the parameter.
+* `type`: The data type of the parameter: string, integer, number, boolean.
 * `destination`: The destination in the bundle to define the parameter.
   * `env`: The name for the environment variable. Defaults to the name of the parameter in upper case.
   * `path`: The path for the file. Required for file paths, there is no default.
-* `sensitive`: Designate this parameter's value as sensitive, for masking in console output.
+* `sensitive`: Optional. Designate this parameter's value as sensitive, for masking in console output.
  
+### Parameter Schema
+
+The [CNAB Spec for parameter definitions](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md#definitions)
+has full support for [json schema](https://json-schema.org). We aren't quite there yet but 
+are working towards it. Here is what Porter supports for defining schema for parameters currently:
+
+* `default`: The default value for the parameter. When a default is not provided, the `required` is defaulted to true.
+* `required`: Specify if the parameter must be specified when the bundle is executed.
+* `enum`: A list of allowed values.
+* [Numeric Range](https://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range) 
+    using `minimum`, `maximum`, `exclusiveMinimum` and `exclusiveMaximum`.
+* String length using `minLength` and `maxLength`.
+
 ## Credentials
 
 Credentials are part of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/802-credential-sets.md) and allow

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -617,15 +617,20 @@ exec /cnab/app/porter-runtime run -f /cnab/app/porter.yaml
             "imageType": "docker"
         }],
     "name": "HELLO",
-    "parameters": {
+    "definitions": {
         "porter-debug": {
-            "destination": {
-                "env": "PORTER_DEBUG"
-            },
-            "metadata": {
-                "description": "Print debug information from Porter when executing the bundle"
-            },
-            "type": "bool"
+          "type": "boolean"
+        }
+    },
+    "parameters": {
+        "fields": {
+            "porter-debug": {
+                "description": "Print debug information from Porter when executing the bundle",
+                "definition": "porter-debug",
+                "destination": {
+                    "env": "PORTER_DEBUG"
+                }
+            }
         }
     },
     "version": "0.1.0"

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -90,13 +90,15 @@ func (c *ManifestConverter) generateBundleParameters() (definition.Definitions, 
 func (c *ManifestConverter) buildDefaultPorterParameters() []config.ParameterDefinition {
 	return []config.ParameterDefinition{
 		{
-			Name: "porter-debug",
+			Name:        "porter-debug",
+			Description: "Print debug information from Porter when executing the bundle",
 			Destination: &config.Location{
 				EnvironmentVariable: "PORTER_DEBUG",
 			},
-			DataType:    "boolean",
-			Default:     false,
-			Description: "Print debug information from Porter when executing the bundle",
+			Schema: config.Schema{
+				DataType: "boolean",
+				Default:  false,
+			},
 		},
 	}
 }

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -52,13 +52,15 @@ func (c *ManifestConverter) generateBundleParameters() (definition.Definitions, 
 	for _, param := range append(c.Manifest.Parameters, c.buildDefaultPorterParameters()...) {
 		fmt.Fprintf(c.Out, "Generating parameter definition %s ====>\n", param.Name)
 		d := &definition.Schema{
-			Type:      param.DataType,
-			Default:   param.Default,
-			Enum:      param.AllowedValues,
-			Minimum:   param.MinValue,
-			Maximum:   param.MaxValue,
-			MinLength: param.MinLength,
-			MaxLength: param.MaxLength,
+			Type:             param.Type,
+			Default:          param.Default,
+			Enum:             param.Enum,
+			Minimum:          param.Minimum,
+			Maximum:          param.Maximum,
+			ExclusiveMinimum: param.ExclusiveMinimum,
+			ExclusiveMaximum: param.ExclusiveMaximum,
+			MinLength:        param.MinLength,
+			MaxLength:        param.MaxLength,
 		}
 		p := bundle.ParameterDefinition{
 			Definition:  param.Name,
@@ -96,8 +98,8 @@ func (c *ManifestConverter) buildDefaultPorterParameters() []config.ParameterDef
 				EnvironmentVariable: "PORTER_DEBUG",
 			},
 			Schema: config.Schema{
-				DataType: "boolean",
-				Default:  false,
+				Type:    "boolean",
+				Default: false,
 			},
 		},
 	}

--- a/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
+++ b/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
@@ -1,0 +1,64 @@
+name: HELLO
+version: 0.1.0
+description: "An example Porter configuration"
+invocationImage: porter-hello:latest
+tag: deislabs/porter-hello-bundle:latest
+
+parameters:
+  - name: ainteger
+    type: integer
+    default: 1
+    required: true
+    minimum: 0
+    maximum: 10
+  - name: anumber
+    type: number
+    default: 0.5
+    required: true
+    exclusiveMinimum: 0
+    exclusiveMaximum: 1
+  - name: astringenum
+    type: string
+    default: blue
+    enum:
+      - blue
+      - red
+      - purple
+      - pink
+    required: true
+  - name: astring
+    type: string
+    required: true
+    minLength: 1
+    maxLength: 10
+  - name: aboolean
+    type: boolean
+    required: true
+    default: true
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      arguments:
+        - -c
+        - echo Hello World
+
+upgrade:
+  - exec:
+      description: "World 2.0"
+      command: bash
+      arguments:
+        - -c
+        - echo World 2.0
+
+uninstall:
+  - exec:
+      description: "Uninstall Hello World"
+      command: bash
+      arguments:
+        - -c
+        - echo Goodbye World

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -50,7 +50,15 @@ type Manifest struct {
 
 // ParameterDefinition defines a single parameter for a CNAB bundle
 type ParameterDefinition struct {
-	Name          string        `yaml:"name"`
+	Name        string    `yaml:"name"`
+	Description string    `yaml:"description,omitempty"`
+	Sensitive   bool      `yaml:"sensitive"`
+	Destination *Location `yaml:"destination,omitempty"`
+
+	Schema `yaml:",inline"`
+}
+
+type Schema struct {
 	DataType      string        `yaml:"type"`
 	Default       interface{}   `yaml:"default,omitempty"`
 	AllowedValues []interface{} `yaml:"allowed,omitempty"`
@@ -59,17 +67,14 @@ type ParameterDefinition struct {
 	MaxValue      *float64      `yaml:"maxValue,omitempty"`
 	MinLength     *float64      `yaml:"minLength,omitempty"`
 	MaxLength     *float64      `yaml:"maxLength,omitempty"`
-	Description   string        `yaml:"description,omitempty"`
-	Destination   *Location     `yaml:"destination,omitempty"`
-	Sensitive     bool          `yaml:"sensitive"`
 }
 
 type CredentialDefinition struct {
-	Name                string `yaml:"name"`
-	Description         string `yaml:"description,omitempty"`
-	Required            bool   `yaml:"required,omitempty"`
 	Path                string `yaml:"path,omitempty"`
 	EnvironmentVariable string `yaml:"env,omitempty"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	Required    bool   `yaml:"required,omitempty"`
 }
 
 type Location struct {

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -70,11 +70,11 @@ type Schema struct {
 }
 
 type CredentialDefinition struct {
-	Path                string `yaml:"path,omitempty"`
-	EnvironmentVariable string `yaml:"env,omitempty"`
 	Name        string `yaml:"name"`
 	Description string `yaml:"description,omitempty"`
 	Required    bool   `yaml:"required,omitempty"`
+
+	Location `yaml:",inline"`
 }
 
 type Location struct {

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -59,14 +59,16 @@ type ParameterDefinition struct {
 }
 
 type Schema struct {
-	DataType      string        `yaml:"type"`
-	Default       interface{}   `yaml:"default,omitempty"`
-	AllowedValues []interface{} `yaml:"allowed,omitempty"`
-	Required      bool          `yaml:"required"`
-	MinValue      *float64      `yaml:"minValue,omitempty"`
-	MaxValue      *float64      `yaml:"maxValue,omitempty"`
-	MinLength     *float64      `yaml:"minLength,omitempty"`
-	MaxLength     *float64      `yaml:"maxLength,omitempty"`
+	Type             string        `yaml:"type"`
+	Default          interface{}   `yaml:"default,omitempty"`
+	Enum             []interface{} `yaml:"enum,omitempty"`
+	Required         bool          `yaml:"required"`
+	Minimum          *float64      `yaml:"minimum,omitempty"`
+	ExclusiveMinimum *float64      `yaml:"exclusiveMinimum,omitempty"`
+	Maximum          *float64      `yaml:"maximum,omitempty"`
+	ExclusiveMaximum *float64      `yaml:"exclusiveMaximum,omitempty"`
+	MinLength        *float64      `yaml:"minLength,omitempty"`
+	MaxLength        *float64      `yaml:"maxLength,omitempty"`
 }
 
 type CredentialDefinition struct {

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -310,8 +310,8 @@ func TestResolveCredential(t *testing.T) {
 	m := &Manifest{
 		Credentials: []CredentialDefinition{
 			{
-				Name:                "password",
-				EnvironmentVariable: "PASSWORD",
+				Name:     "password",
+				Location: Location{EnvironmentVariable: "PASSWORD"},
 			},
 		},
 	}
@@ -617,7 +617,7 @@ func TestManifest_MergeDependency(t *testing.T) {
 				&Step{Data: map[string]interface{}{"helm": map[interface{}]interface{}{"description": "uninstall mysql"}}},
 			},
 			Credentials: []CredentialDefinition{
-				{Name: "kubeconfig", Path: "/root/.kube/config"},
+				{Name: "kubeconfig", Location: Location{Path: "/root/.kube/config"}},
 			},
 		},
 	}
@@ -656,32 +656,32 @@ func TestMergeCredentials(t *testing.T) {
 	}{
 		{
 			name:       "combine path and environment variable",
-			c1:         CredentialDefinition{Name: "foo", Path: "p1"},
-			c2:         CredentialDefinition{Name: "foo", EnvironmentVariable: "v2"},
-			wantResult: CredentialDefinition{Name: "foo", Path: "p1", EnvironmentVariable: "v2"},
+			c1:         CredentialDefinition{Name: "foo", Location: Location{Path: "p1"}},
+			c2:         CredentialDefinition{Name: "foo", Location: Location{EnvironmentVariable: "v2"}},
+			wantResult: CredentialDefinition{Name: "foo", Location: Location{Path: "p1", EnvironmentVariable: "v2"}},
 		},
 		{
 			name:       "same path",
-			c1:         CredentialDefinition{Name: "foo", Path: "p"},
-			c2:         CredentialDefinition{Name: "foo", Path: "p"},
-			wantResult: CredentialDefinition{Name: "foo", Path: "p"},
+			c1:         CredentialDefinition{Name: "foo", Location: Location{Path: "p"}},
+			c2:         CredentialDefinition{Name: "foo", Location: Location{Path: "p"}},
+			wantResult: CredentialDefinition{Name: "foo", Location: Location{Path: "p"}},
 		},
 		{
 			name:      "conflicting path",
-			c1:        CredentialDefinition{Name: "foo", Path: "p1"},
-			c2:        CredentialDefinition{Name: "foo", Path: "p2"},
+			c1:        CredentialDefinition{Name: "foo", Location: Location{Path: "p1"}},
+			c2:        CredentialDefinition{Name: "foo", Location: Location{Path: "p2"}},
 			wantError: "cannot merge credential foo: conflict on path",
 		},
 		{
 			name:       "same environment variable",
-			c1:         CredentialDefinition{Name: "foo", EnvironmentVariable: "v"},
-			c2:         CredentialDefinition{Name: "foo", EnvironmentVariable: "v"},
-			wantResult: CredentialDefinition{Name: "foo", EnvironmentVariable: "v"},
+			c1:         CredentialDefinition{Name: "foo", Location: Location{EnvironmentVariable: "v"}},
+			c2:         CredentialDefinition{Name: "foo", Location: Location{EnvironmentVariable: "v"}},
+			wantResult: CredentialDefinition{Name: "foo", Location: Location{EnvironmentVariable: "v"}},
 		},
 		{
 			name:      "conflicting environment variable",
-			c1:        CredentialDefinition{Name: "foo", EnvironmentVariable: "v1"},
-			c2:        CredentialDefinition{Name: "foo", EnvironmentVariable: "v2"},
+			c1:        CredentialDefinition{Name: "foo", Location: Location{EnvironmentVariable: "v1"}},
+			c2:        CredentialDefinition{Name: "foo", Location: Location{EnvironmentVariable: "v2"}},
 			wantError: "cannot merge credential foo: conflict on environment variable",
 		},
 	}

--- a/workshop/wordpress/porter.yaml
+++ b/workshop/wordpress/porter.yaml
@@ -18,7 +18,7 @@ parameters:
   sensitive: true
   default: "topsecretpassword"
 - name: port
-  type: int
+  type: integer
   default: 30030
 
 install:


### PR DESCRIPTION
Improve json schema support

* allowed values -> enum
* minValue/maxValue -> minimum/maximum
* Added exclusiveMinimum/exclusiveMaximum
* Add tests for manifest->bundle.json parameters definitions
* Added tests for number
* Added documentation on what we support

---

Move parameter schema into a separate type in preparation for later

---

Inline location on credentials. Previously we had duplicated the fields for location but I think it may com in handy to start treating them a bit more similarly, so I put a location on them.

Closes #346 