### PR TITLE
Remove old dependency implementation

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -39,18 +39,3 @@ func TestConfig_GetHomeDirFromSymlink(t *testing.T) {
 	// and on Windows, that means flipping the afero `/` to `\`.
 	assert.Equal(t, filepath.Join("/root", ".porter"), home)
 }
-
-
-func TestConfig_GetBundleDir(t *testing.T) {
-	c := NewTestConfig(t)
-
-	c.TestContext.AddTestFile("testdata/porter.yaml", Name)
-	c.TestContext.AddTestDirectory("testdata/bundles", "bundles")
-
-	err := c.LoadManifest()
-	require.NoError(t, err)
-
-	result, err := c.GetBundleDir("mysql")
-	require.NoError(t, err)
-	assert.Equal(t, "bundles/mysql", result)
-}

--- a/pkg/config/testdata/porter.yaml
+++ b/pkg/config/testdata/porter.yaml
@@ -5,9 +5,6 @@ dependencies:
 - name: mysql
   parameters:
     database-name: wordpress
-  connections:
-  - source: bundle.dependencies.mysql.outputs.host
-    destination: bundle.credentials.dbhost
 
 install:
   - exec:

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -198,14 +198,6 @@ func (p *Porter) prepareDockerFilesystem() error {
 	p.FileSystem.RemoveAll(build.LOCAL_CNAB)
 	p.FileSystem.Remove("Dockerfile")
 
-	fmt.Fprintf(p.Out, "Copying dependencies ===> \n")
-	for _, dep := range p.Manifest.Dependencies {
-		err := p.copyDependency(dep.Name)
-		if err != nil {
-			return err
-		}
-	}
-
 	fmt.Fprintf(p.Out, "Copying porter runtime ===> \n")
 
 	runTmpl, err := p.Templates.GetRunScript()
@@ -241,17 +233,6 @@ func (p *Porter) prepareDockerFilesystem() error {
 	}
 
 	return nil
-}
-
-func (p *Porter) copyDependency(bundle string) error {
-	fmt.Fprintf(p.Out, "Copying bundle dependency %s ===> \n", bundle)
-	bundleDir, err := p.GetBundleDir(bundle)
-	if err != nil {
-		return err
-	}
-
-	err = p.Context.CopyDirectory(bundleDir, filepath.Join(build.LOCAL_APP, "bundles"), true)
-	return errors.Wrapf(err, "could not copy bundle directory contents for %s", bundle)
 }
 
 func (p *Porter) copyMixin(mixin string) error {

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -9,5 +9,6 @@ ${PORTER_HOME}/porter help
 ${PORTER_HOME}/porter version
 
 ${DIR}/test-hello.sh
-${DIR}/test-wordpress.sh
+# TODO: Temporarily disable the wordpress test because it relies on dependencies which are being rewritten
+#${DIR}/test-wordpress.sh
 ${DIR}/test-terraform.sh


### PR DESCRIPTION
This removes the old dependency implementation that relied upon merging
the manifests from dependencies with the current manifest. It is going
to be quickly replaced with executing dependencies in their own bundle
runtime and relying upon outputs.

Closes #431 