### PR TITLE
Populate dependencies in bundle.json

### DIFF
--- a/pkg/cnab/config_adapter/adapter_test.go
+++ b/pkg/cnab/config_adapter/adapter_test.go
@@ -37,7 +37,7 @@ func TestPorter_ToBundle(t *testing.T) {
 	assert.Contains(t, bun.Parameters.Fields, "porter-debug", "porter-debug parameter was not defined")
 	assert.Contains(t, bun.Definitions, "porter-debug", "porter-debug definition was not defined")
 
-	assert.Contains(t, bun.Custom, config.CustomBundleKey, "Dependencies was not populated")
+	assert.Contains(t, bun.Custom, config.CustomBundleKey, "Porter stamp was not populated")
 	assert.Contains(t, bun.Custom, extensions.DependenciesKey, "Dependencies was not populated")
 }
 

--- a/pkg/cnab/config_adapter/testdata/porter-with-deps.yaml
+++ b/pkg/cnab/config_adapter/testdata/porter-with-deps.yaml
@@ -1,0 +1,43 @@
+name: HELLO
+version: 0.1.0
+description: "An example Porter configuration"
+invocationImage: porter-hello:latest
+tag: deislabs/porter-hello-bundle:latest
+
+dependencies:
+  - name: mysql
+    tag: "deislabs/azure-mysql:5.7"
+  - name: ad
+    tag: "deislabs/azure-active-directory"
+    prereleases: true
+  - name: storage
+    tag: "deislabs/azure-blob-storage"
+    versions:
+      - 1.x - 2
+      - 2.1 - 3.x
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      arguments:
+        - -c
+        - echo Hello World
+
+upgrade:
+  - exec:
+      description: "World 2.0"
+      command: bash
+      arguments:
+        - -c
+        - echo World 2.0
+
+uninstall:
+  - exec:
+      description: "Uninstall Hello World"
+      command: bash
+      arguments:
+        - -c
+        - echo Goodbye World

--- a/pkg/cnab/config_adapter/testdata/porter.yaml
+++ b/pkg/cnab/config_adapter/testdata/porter.yaml
@@ -1,0 +1,27 @@
+name: hello
+description: "An example Porter configuration"
+version: 0.1.0
+invocationImage: porter-hello:latest
+
+dependencies:
+- name: mysql
+  tag: "deislabs/azure-mysql:5.7"
+
+mixins:
+- exec
+
+install:
+- exec:
+    description: "Say Hello"
+    command: bash
+    arguments:
+    - -c
+    - echo Hello World
+
+uninstall:
+- exec:
+    description: "Say Goodbye"
+    command: bash
+    arguments:
+    - -c
+    - echo Goodbye World

--- a/pkg/cnab/extensions/dependencies.go
+++ b/pkg/cnab/extensions/dependencies.go
@@ -1,0 +1,55 @@
+package extensions
+
+import (
+	"encoding/json"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/pkg/errors"
+)
+
+const (
+	DependenciesKey    = "dependencies"
+	DependenciesSchema = "https://cnab.io/specs/v1/dependencies.schema.json"
+)
+
+// Dependencies describes the set of custom extension metadata associated with the dependencies spec
+// https://github.com/deislabs/cnab-spec/blob/master/500-CNAB-dependencies.md
+type Dependencies struct {
+	// Requires is a list of bundles required by this bundle
+	Requires []Dependency `json:"requires,omitempty" mapstructure:"requires"`
+}
+
+// Dependency describes a dependency on another bundle
+type Dependency struct {
+	// Bundle is the location of the bundle in a registry, for example REGISTRY/NAME:TAG
+	Bundle string `json:"bundle" mapstructure:"bundle"`
+
+	// Version is a set of allowed versions
+	Version *DependencyVersion `json:"version,omitempty" mapstructure:"version"`
+}
+
+// DependencyVersion is a set of allowed versions for a dependency
+type DependencyVersion struct {
+	// Ranges of semantic versions, with or without the leading v prefix, allowed by the dependency
+	Ranges []string `json:"ranges,omitempty" mapstructure:"ranges"`
+
+	// AllowPrereleases specifies if prerelease versions can satisfy the dependency
+	AllowPrereleases bool `json:"prereleases" mapstructure:"prereleases"`
+}
+
+func LoadDependencies(bun *bundle.Bundle) (*Dependencies, error) {
+	data := bun.Custom[DependenciesKey]
+
+	dataB, err := json.Marshal(data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not marshal the untyped dependencies extension data %q", string(dataB))
+	}
+
+	deps := &Dependencies{}
+	err = json.Unmarshal(dataB, deps)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not unmarshal the dependencies extension %q", string(dataB))
+	}
+
+	return deps, nil
+}

--- a/pkg/cnab/extensions/dependencies.go
+++ b/pkg/cnab/extensions/dependencies.go
@@ -38,7 +38,10 @@ type DependencyVersion struct {
 }
 
 func LoadDependencies(bun *bundle.Bundle) (*Dependencies, error) {
-	data := bun.Custom[DependenciesKey]
+	data, ok := bun.Custom[DependenciesKey]
+	if !ok {
+		return nil, nil
+	}
 
 	dataB, err := json.Marshal(data)
 	if err != nil {

--- a/pkg/cnab/extensions/dependencies_test.go
+++ b/pkg/cnab/extensions/dependencies_test.go
@@ -1,0 +1,33 @@
+package extensions
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadDependencyProperties(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/bundle.json")
+	require.NoError(t, err, "cannot read bundle file")
+
+	bun, err := bundle.Unmarshal(data)
+	require.NoError(t, err, "could not unmarshal the bundle")
+
+	deps, err := LoadDependencies(bun)
+
+	assert.NotNil(t, deps, "Dependencies was not populated")
+	assert.Len(t, deps.Requires, 2, "Dependencies.Requires is the wrong length")
+
+	dep := deps.Requires[0]
+	assert.Equal(t, "somecloud/blob-storage", dep.Bundle, "Dependency.Bundle is incorrect")
+	assert.Nil(t, dep.Version, "Dependency.Version should be nil")
+
+	dep = deps.Requires[1]
+	assert.Equal(t, "somecloud/mysql", dep.Bundle, "Dependency.Bundle is incorrect")
+	assert.True(t, dep.Version.AllowPrereleases, "Dependency.Bundle.Version.AllowPrereleases should be true")
+	assert.Equal(t, []string{"5.7.x"}, dep.Version.Ranges, "Dependency.Bundle.Version.Ranges is incorrect")
+
+}

--- a/pkg/cnab/extensions/testdata/bundle.json
+++ b/pkg/cnab/extensions/testdata/bundle.json
@@ -1,0 +1,98 @@
+{
+  "name": "foo",
+  "version": "1.0",
+  "schemaVersion": "99.99",
+  "invocationImages": [
+    {
+      "imageType": "docker",
+      "image": "technosophos/helloworld:0.1.0"
+    }
+  ],
+  "images": {
+    "image1":{
+      "description": "image1",
+      "image": "urn:image1uri",
+      "refs": [
+        {
+          "path": "image1path",
+          "field": "image.1.field"
+        }
+      ]
+    },
+    "image2":{
+      "name": "image2",
+      "uri": "urn:image2uri",
+      "refs": [
+        {
+          "path": "image2path",
+          "field": "image.2.field"
+        }
+      ]
+    }
+  },
+  "credentials": {
+    "foo": {
+      "path": "pfoo"
+    },
+    "bar": {
+      "env": "ebar"
+    },
+    "quux": {
+      "path": "pquux",
+      "env": "equux"
+    }
+  },
+  "requiredExtensions" : {
+    "dependencies": "https://cnab.io/specs/v1/dependencies.schema.json"
+  },
+  "custom": {
+    "com.example.duffle-bag": {
+      "icon": "https://example.com/icon.png",
+      "iconType": "PNG"
+    },
+    "com.example.backup-preferences": {
+      "enabled": true,
+      "frequency": "daily"
+    },
+    "dependencies": {
+      "requires": [
+        {
+          "bundle": "somecloud/blob-storage"
+        },
+        {
+          "bundle": "somecloud/mysql",
+          "version": {
+            "prereleases": true,
+            "ranges": ["5.7.x"]
+          }
+        }
+      ]
+    }
+  },
+  "definitions" : {
+    "complexThing" : {
+      "type" : "object",
+      "properties" : {
+        "host" : {
+          "default" : "localhost",
+          "type" : "string",
+          "minLength" : 3,
+          "maxLength" : 10
+        },
+        "port" : {
+          "type" : "integer",
+          "minimum": 8000
+        }
+      },
+      "required" : ["port"]
+    }
+  },
+  "parameters" : {
+    "serverConfig" : {
+      "definition" : "complexThing",
+      "destination" : {
+        "path": "/cnab/is/go"
+      }
+    }
+  }
+}

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -134,6 +134,15 @@ func (d *Dependency) Validate() error {
 	if d.Name == "" {
 		return errors.New("dependency name is required")
 	}
+
+	if d.Tag == "" {
+		return errors.New("dependency tag is required")
+	}
+
+	if strings.Contains(d.Tag, ":") && len(d.Versions) > 0 {
+		return errors.New("dependency tag can only specify REGISTRY/NAME when version ranges are specified")
+	}
+
 	return nil
 }
 

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -102,7 +102,11 @@ type ImagePlatform struct {
 }
 
 type Dependency struct {
-	Name       string            `yaml:"name"`
+	Name             string   `yaml:"name"`
+	Tag              string   `yaml:"tag"`
+	Versions         []string `yaml:"versions"`
+	AllowPrereleases bool     `yaml:"prereleases"`
+
 	Parameters map[string]string `yaml:"parameters,omitempty"`
 }
 

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -640,3 +640,29 @@ func TestReadManifest_Validate_BundleOutput_Error(t *testing.T) {
 
 	require.Error(t, c.LoadManifest())
 }
+
+func TestDependency_Validate(t *testing.T) {
+	testcases := []struct {
+		name      string
+		dep       Dependency
+		wantError string
+	}{
+		{"version in tag", Dependency{Name: "mysql", Tag: "deislabs/azure-mysql:5.7"}, ""},
+		{"version ranges", Dependency{Name: "mysql", Tag: "deislabs/azure-mysql", Versions: []string{"5.7.x-6"}}, ""},
+		{"missing name", Dependency{Name: "", Tag: "deislabs/azure-mysql:5.7"}, "dependency name is required"},
+		{"missing tag", Dependency{Name: "mysql", Tag: ""}, "dependency tag is required"},
+		{"version double specified", Dependency{Name: "mysql", Tag: "deislabs/azure-mysql:5.7", Versions: []string{"5.7.x-6"}}, "dependency tag can only specify REGISTRY/NAME when version ranges are specified"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.dep.Validate()
+
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Contains(t, err.Error(), tc.wantError)
+			}
+		})
+	}
+}

--- a/pkg/config/testdata/porter.yaml
+++ b/pkg/config/testdata/porter.yaml
@@ -3,6 +3,7 @@ mixins:
 
 dependencies:
 - name: mysql
+  tag: "deislabs/azure-mysql:5.7"
   parameters:
     database-name: wordpress
 

--- a/pkg/porter/dependencies/dependencies.go
+++ b/pkg/porter/dependencies/dependencies.go
@@ -1,0 +1,24 @@
+package dependencies
+
+import (
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/porter/pkg/cnab/extensions"
+	"github.com/pkg/errors"
+)
+
+func BuildDependencyQueue(bun *bundle.Bundle) ([]extensions.Dependency, error) {
+	deps, err := extensions.LoadDependencies(bun)
+	if deps == nil {
+		return []extensions.Dependency{}, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "error executing dependencies for %s", bun.Name)
+	}
+
+	q := make([]extensions.Dependency, 0, len(deps.Requires))
+	for _, dep := range deps.Requires {
+		q = append(q, dep)
+	}
+
+	return q, nil
+}

--- a/pkg/porter/dependencies/dependencies_test.go
+++ b/pkg/porter/dependencies/dependencies_test.go
@@ -1,0 +1,7 @@
+package dependencies
+
+import "testing"
+
+func TestBuildDependencyQueue(t *testing.T) {
+
+}


### PR DESCRIPTION
Writes any dependencies in porter.yaml to bundle.json when the bundle is built. 

There are three forms of specifying a dependency:

1. You can just say exactly which bundle, including the tag, that you depend upon, `deislabs/azure-mysql:5.7`
2. You can rely on a named bundle, but not say which version, `deislabs/azure-mysql`. Basically any version of the bundle is ok. You can specify if prereleases are allowed or not (default is false).
3. You can specify a set of version ranges to allow `deisalbs/azure-mysql` + `5.7 - 6.x, 7.1 - 7.5.x`

Closes #429 