### PR TITLE
fix(Makefile): rm copying bin/bundles into porter home on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,6 @@ endif
 
 install:
 	mkdir -p $(HOME)/.porter
-	cp -R bin/bundles $(HOME)/.porter/
 	cp -R bin/mixins $(HOME)/.porter/
 	cp bin/porter* $(HOME)/.porter/
 	ln -f -s $(HOME)/.porter/porter /usr/local/bin/porter


### PR DESCRIPTION
This fixes an error encountered in CI whilst attempting to publish bundles.  The job to do so first runs `make build install` to install porter, but the `install` command was attempting to copy in `bin/bundles` which was not populated:

```
...
mkdir -p /root/.porter
cp -R bin/bundles /root/.porter/
cp: can't stat 'bin/bundles': No such file or directory
make: *** [Makefile:155: install] Error 1
```

The bug was intro'd via myself in a recent PR 😅, wherein I tried to select only the subdirs of `bin` that should be copied over, having realized that with the previous method (`cp -R bin/*`), we were copying `credentials`, `claims` and other subdirs generated by cli tests, etc., into our local home, which we might not want.