### PR TITLE
ref(*): DRY print options via updated PrintOptions struct

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/deislabs/porter/pkg/porter"
-	"github.com/deislabs/porter/pkg/printer"
 )
 
 func buildBundlesCommand(p *porter.Porter) *cobra.Command {
@@ -106,12 +105,10 @@ Optional output formats include json and yaml.`,
 		Example: `  porter bundle list
   porter bundle list -o json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			opts.Format, err = printer.ParseFormat(opts.RawFormat)
-			return err
+			return opts.ParseFormat()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListBundles(printer.PrintOptions{Format: opts.Format})
+			return p.ListBundles(opts.PrintOptions)
 		},
 	}
 

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/deislabs/porter/pkg/porter"
-	"github.com/deislabs/porter/pkg/printer"
 	"github.com/spf13/cobra"
 )
 
@@ -113,12 +112,10 @@ func buildCredentialsListCommand(p *porter.Porter) *cobra.Command {
 		Long:    `List named sets of credentials defined by the user.`,
 		Example: `  porter credentials list [-o table|json|yaml]`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			opts.Format, err = printer.ParseFormat(opts.RawFormat)
-			return err
+			return opts.ParseFormat()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListCredentials(printer.PrintOptions{Format: opts.Format})
+			return p.ListCredentials(opts.PrintOptions)
 		},
 	}
 

--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -4,7 +4,6 @@ import (
 	"github.com/deislabs/porter/pkg/mixin"
 	"github.com/deislabs/porter/pkg/mixin/feed"
 	"github.com/deislabs/porter/pkg/porter"
-	"github.com/deislabs/porter/pkg/printer"
 	"github.com/spf13/cobra"
 )
 
@@ -32,9 +31,7 @@ func buildMixinsListCommand(p *porter.Porter) *cobra.Command {
 		Use:   "list",
 		Short: "List installed mixins",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			opts.Format, err = printer.ParseFormat(opts.RawFormat)
-			return err
+			return opts.ParseFormat()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.PrintMixins(opts)

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -22,9 +22,8 @@ import (
 
 // CredentialShowOptions represent options for Porter's credential show command
 type CredentialShowOptions struct {
-	RawFormat string
-	Format    printer.Format
-	Name      string
+	printer.PrintOptions
+	Name string
 }
 
 // CredentialsFile represents a CNAB credentials file and corresponding metadata
@@ -246,13 +245,7 @@ func (o *CredentialShowOptions) Validate(args []string) error {
 		return errors.Errorf("only one positional argument may be specified, the credential name, but multiple were received: %s", args)
 	}
 
-	format, err := printer.ParseFormat(o.RawFormat)
-	if err != nil {
-		return err
-	}
-	o.Format = format
-
-	return nil
+	return o.ParseFormat()
 }
 
 // ShowCredential shows the credential set corresponding to the provided name, using

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -287,8 +287,10 @@ func TestShowCredential_NotFound(t *testing.T) {
 	p.CNAB = &TestCNABProvider{}
 
 	opts := CredentialShowOptions{
-		Format: printer.FormatTable,
-		Name:   "non-existent-cred",
+		PrintOptions: printer.PrintOptions{
+			Format: printer.FormatTable,
+		},
+		Name: "non-existent-cred",
 	}
 
 	err := p.ShowCredential(opts)
@@ -376,8 +378,10 @@ credentials:
 			p.CNAB = &TestCNABProvider{}
 
 			opts := CredentialShowOptions{
-				Format: tc.format,
-				Name:   "kool-kreds",
+				PrintOptions: printer.PrintOptions{
+					Format: tc.format,
+				},
+				Name: "kool-kreds",
 			}
 
 			credsDir, err := p.TestConfig.GetCredentialsDir()

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -13,8 +13,7 @@ import (
 
 // ListOptions represent generic options for use by Porter's list commands
 type ListOptions struct {
-	RawFormat string
-	Format    printer.Format
+	printer.PrintOptions
 }
 
 // CondensedClaim holds a subset of pertinent values to be listed from a claim.Claim

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -18,8 +18,7 @@ type MixinProvider interface {
 
 // PrintMixinsOptions represent options for the PrintMixins function
 type PrintMixinsOptions struct {
-	RawFormat string
-	Format    printer.Format
+	printer.PrintOptions
 }
 
 func (p *Porter) PrintMixins(opts PrintMixinsOptions) error {

--- a/pkg/porter/mixins_test.go
+++ b/pkg/porter/mixins_test.go
@@ -25,7 +25,11 @@ func TestPorter_PrintMixins(t *testing.T) {
 	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(srcMixinsDir, "/helm"), filepath.Join(mixinsDir, "helm"))
 	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(srcMixinsDir, "/exec"), filepath.Join(mixinsDir, "exec"))
 
-	opts := PrintMixinsOptions{Format: printer.FormatTable}
+	opts := PrintMixinsOptions{
+		PrintOptions: printer.PrintOptions{
+			Format: printer.FormatTable,
+		},
+	}
 	err = p.PrintMixins(opts)
 
 	require.Nil(t, err)

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -23,8 +23,7 @@ type OutputShowOptions struct {
 // OutputListOptions represent options for a bundle output list command
 type OutputListOptions struct {
 	sharedOptions
-	RawFormat string
-	Format    printer.Format
+	printer.PrintOptions
 }
 
 // Output represents a bundle output
@@ -93,13 +92,7 @@ func (o *OutputListOptions) Validate(args []string, cxt *context.Context) error 
 		return errors.Wrap(err, "claim name must be provided")
 	}
 
-	parsedFormat, err := printer.ParseFormat(o.RawFormat)
-	if err != nil {
-		return err
-	}
-	o.Format = parsedFormat
-
-	return nil
+	return o.ParseFormat()
 }
 
 // ShowBundleOutput shows a bundle output value, according to the provided options

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -14,8 +14,7 @@ import (
 // ShowOptions represent options for showing a particular claim
 type ShowOptions struct {
 	sharedOptions
-	RawFormat string
-	Format    printer.Format
+	printer.PrintOptions
 }
 
 type ClaimListing struct {
@@ -41,13 +40,7 @@ func (so *ShowOptions) Validate(args []string, cxt *context.Context) error {
 		return errors.Wrap(err, "claim name must be provided")
 	}
 
-	parsedFormat, err := printer.ParseFormat(so.RawFormat)
-	if err != nil {
-		return err
-	}
-	so.Format = parsedFormat
-
-	return nil
+	return so.ParseFormat()
 }
 
 // ShowBundle shows a bundle, or more properly a bundle claim, along with any

--- a/pkg/porter/show_test.go
+++ b/pkg/porter/show_test.go
@@ -25,7 +25,9 @@ func TestPorter_ShowBundle(t *testing.T) {
 		sharedOptions: sharedOptions{
 			Name: "test-bundle",
 		},
-		Format: printer.FormatTable,
+		PrintOptions: printer.PrintOptions{
+			Format: printer.FormatTable,
+		},
 	}
 
 	// Create test claim

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -11,16 +11,18 @@ const (
 	FormatPlaintext Format = "plaintext"
 )
 
-func ParseFormat(v string) (Format, error) {
-	format := Format(v)
+func (p *PrintOptions) ParseFormat() error {
+	format := Format(p.RawFormat)
 	switch format {
 	case FormatTable, FormatJson, FormatYaml, FormatPlaintext:
-		return format, nil
+		p.Format = format
+		return nil
 	default:
-		return "", errors.Errorf("invalid format: %s", v)
+		return errors.Errorf("invalid format: %s", p.RawFormat)
 	}
 }
 
 type PrintOptions struct {
+	RawFormat string
 	Format
 }

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -15,10 +15,14 @@ func TestParseFormat(t *testing.T) {
 
 	for name, valid := range testcases {
 		t.Run(name, func(t *testing.T) {
-			result, err := ParseFormat(name)
+			opts := PrintOptions{
+				RawFormat: name,
+			}
+
+			err := opts.ParseFormat()
 			if valid {
 				require.Nil(t, err)
-				require.Equal(t, name, string(result))
+				require.Equal(t, name, string(opts.Format))
 			} else {
 				require.NotNil(t, err)
 				require.Contains(t, err.Error(), "invalid format")


### PR DESCRIPTION
Refactor stemming from https://github.com/deislabs/porter/pull/451#discussion_r303459986

* DRYs out applicable commands to use an updated `PrintOptions` struct now containing both `RawFormat` and `Format` values