### PR TITLE
Use operation's options struct instead of print opts

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -108,7 +108,7 @@ Optional output formats include json and yaml.`,
 			return opts.ParseFormat()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListBundles(opts.PrintOptions)
+			return p.ListBundles(opts)
 		},
 	}
 

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -115,7 +115,7 @@ func buildCredentialsListCommand(p *porter.Porter) *cobra.Command {
 			return opts.ParseFormat()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListCredentials(opts.PrintOptions)
+			return p.ListCredentials(opts)
 		},
 	}
 

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -105,8 +105,8 @@ func (p *Porter) readCredential(name, path string) (*credentials.CredentialSet, 
 	return credSet, nil
 }
 
-// ListCredentials lists credentials using the provided printer.PrintOptions
-func (p *Porter) ListCredentials(opts printer.PrintOptions) error {
+// ListCredentials lists saved credential sets.
+func (p *Porter) ListCredentials(opts ListOptions) error {
 	credentialsFiles, err := p.fetchCredentials()
 	if err != nil {
 		return errors.Wrap(err, "unable to fetch credentials")

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -98,9 +98,8 @@ func TestCredentialsList_None(t *testing.T) {
 			p := NewTestPorter(t)
 			p.CNAB = &TestCNABProvider{}
 
-			listOpts := printer.PrintOptions{
-				Format: tc.format,
-			}
+			listOpts := ListOptions{}
+			listOpts.Format = tc.format
 			err := p.ListCredentials(listOpts)
 			if tc.errorMsg != "" {
 				require.Equal(t, err.Error(), tc.errorMsg)
@@ -155,9 +154,8 @@ kool-kreds   now`},
 
 			p.TestConfig.TestContext.AddTestDirectory("testdata/test-creds", credsDir)
 
-			listOpts := printer.PrintOptions{
-				Format: tc.format,
-			}
+			listOpts := ListOptions{}
+			listOpts.Format = tc.format
 			err = p.ListCredentials(listOpts)
 			require.NoError(t, err, "no error should have existed")
 
@@ -192,9 +190,8 @@ good-creds   now`},
 
 			p.TestConfig.TestContext.AddTestDirectory("testdata/good-and-bad-test-creds", credsDir)
 
-			listOpts := printer.PrintOptions{
-				Format: tc.format,
-			}
+			listOpts := ListOptions{}
+			listOpts.Format = tc.format
 			err = p.ListCredentials(listOpts)
 			require.NoError(t, err, "no error should have existed")
 

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -37,8 +37,8 @@ func (l CondensedClaimList) Less(i, j int) bool {
 	return l[i].Modified.Before(l[j].Modified)
 }
 
-// ListBundles lists installed bundles using the printer.Format provided
-func (p *Porter) ListBundles(opts printer.PrintOptions) error {
+// ListBundles lists installed bundles by their claims.
+func (p *Porter) ListBundles(opts ListOptions) error {
 	cp := cnab.NewDuffle(p.Config)
 	claimStore := cp.NewClaimStore()
 	claims, err := claimStore.ReadAll()


### PR DESCRIPTION
In some places we were directly using the printer options instead of the parent operations struct when calling an operation. Eventually the list operation is going to have more parameters, so I wanted to switch to using the operation's struct now and follow the existing pattern of passing the entire operation's struct around instead of individual parameters to operations.