### PR TITLE
Extract push/pull into a registry interface/pkg

### DIFF
--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -1,0 +1,162 @@
+package cnabtooci
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/deislabs/cnab-go/bundle"
+	portercontext "github.com/deislabs/porter/pkg/context"
+	"github.com/docker/cli/cli/command"
+	dockerconfig "github.com/docker/cli/cli/config"
+	cliflags "github.com/docker/cli/cli/flags"
+	"github.com/docker/cnab-to-oci/remotes"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/term"
+	"github.com/docker/docker/registry"
+	"github.com/pkg/errors"
+)
+
+type Registry struct {
+	*portercontext.Context
+}
+
+func NewRegistry(c *portercontext.Context) *Registry {
+	return &Registry{
+		Context: c,
+	}
+}
+
+// PullBundle pulls a bundle from an OCI registry.
+func (r *Registry) PullBundle(tag string, insecureRegistry bool) (*bundle.Bundle, error) {
+	ref, err := reference.ParseNormalizedNamed(tag)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid bundle tag format, expected REGISTRY/name:tag")
+	}
+
+	var insecureRegistries []string
+	if insecureRegistry {
+		reg := reference.Domain(ref)
+		insecureRegistries = append(insecureRegistries, reg)
+	}
+
+	bun, err := remotes.Pull(context.Background(), ref, r.createResolver(insecureRegistries).Resolver)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to pull remote bundle")
+	}
+	return bun, nil
+}
+
+func (r *Registry) PushBundle(bun *bundle.Bundle, tag string, insecureRegistry bool) error {
+	ref, err := ParseOCIReference(tag) //tag from manifest
+	if err != nil {
+		return errors.Wrap(err, "invalid bundle tag reference. expected value is REGISTRY/bundle:tag")
+	}
+	insecureRegistries := []string{}
+	if insecureRegistry {
+		reg := reference.Domain(ref)
+		insecureRegistries = append(insecureRegistries, reg)
+	}
+
+	resolverConfig := r.createResolver(insecureRegistries)
+
+	err = remotes.FixupBundle(context.Background(), bun, ref, resolverConfig, remotes.WithEventCallback(r.displayEvent))
+	if err != nil {
+		return err
+	}
+	d, err := remotes.Push(context.Background(), bun, ref, resolverConfig.Resolver, true)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(r.Out, "Bundle tag %s pushed successfully, with digest %q\n", ref, d.Digest)
+	return nil
+}
+
+// PushInvocationImage pushes the invocation image from the Docker image cache to the specified location
+// the expected format of the invocationImage is REGISTRY/NAME:TAG.
+// Returns the image digest from the registry.
+func (r *Registry) PushInvocationImage(invocationImage string) (string, error) {
+	cli, err := r.getDockerClient()
+	if err != nil {
+		return "", err
+	}
+
+	ctx := context.Background()
+
+	ref, err := ParseOCIReference(invocationImage)
+	if err != nil {
+		return "", err
+	}
+	// Resolve the Repository name from fqn to RepositoryInfo
+	repoInfo, err := registry.ParseRepositoryInfo(ref)
+	if err != nil {
+		return "", err
+	}
+	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
+	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+	if err != nil {
+		return "", err
+	}
+	options := types.ImagePushOptions{
+		All:          true,
+		RegistryAuth: encodedAuth,
+	}
+
+	fmt.Fprintln(r.Out, "Pushing CNAB invocation image...")
+	pushResponse, err := cli.Client().ImagePush(ctx, invocationImage, options)
+	if err != nil {
+		return "", errors.Wrap(err, "docker push failed")
+	}
+	defer pushResponse.Close()
+
+	termFd, _ := term.GetFdInfo(r.Out)
+	// Setting this to false here because Moby os.Exit(1) all over the place and this fails on WSL (only)
+	// when Term is true.
+	isTerm := false
+	err = jsonmessage.DisplayJSONMessagesStream(pushResponse, r.Out, termFd, isTerm, nil)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "denied") {
+			return "", errors.Wrap(err, "docker push authentication failed")
+		}
+		return "", errors.Wrap(err, "failed to stream docker push stdout")
+	}
+	dist, err := cli.Client().DistributionInspect(ctx, invocationImage, encodedAuth)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to inspect docker image")
+	}
+	return string(dist.Descriptor.Digest), nil
+}
+
+func (r *Registry) createResolver(insecureRegistries []string) remotes.ResolverConfig {
+	return remotes.NewResolverConfigFromDockerConfigFile(dockerconfig.LoadDefaultConfigFile(r.Out), insecureRegistries...)
+}
+
+func (r *Registry) displayEvent(ev remotes.FixupEvent) {
+	switch ev.EventType {
+	case remotes.FixupEventTypeCopyImageStart:
+		fmt.Fprintf(r.Out, "Starting to copy image %s...\n", ev.SourceImage)
+	case remotes.FixupEventTypeCopyImageEnd:
+		if ev.Error != nil {
+			fmt.Fprintf(r.Out, "Failed to copy image %s: %s\n", ev.SourceImage, ev.Error)
+		} else {
+			fmt.Fprintf(r.Out, "Completed image %s copy\n", ev.SourceImage)
+		}
+	}
+}
+
+func (r *Registry) getDockerClient() (*command.DockerCli, error) {
+	cli, err := command.NewDockerCli()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create new docker client")
+	}
+	if err := cli.Initialize(cliflags.NewClientOptions()); err != nil {
+		return nil, err
+	}
+	return cli, nil
+}
+
+func ParseOCIReference(ociRef string) (reference.Named, error) {
+	return reference.ParseNormalizedNamed(ociRef)
+}

--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -4,6 +4,7 @@ package porter
 
 import (
 	"github.com/deislabs/porter/pkg/cache"
+	cnabtooci "github.com/deislabs/porter/pkg/cnab/cnab-to-oci"
 	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
 	"github.com/deislabs/porter/pkg/config"
 	mixinprovider "github.com/deislabs/porter/pkg/mixin/provider"
@@ -13,6 +14,7 @@ import (
 type Porter struct {
 	*config.Config
 	Cache     cache.BundleCache
+	Registry  Registry
 	Templates *Templates
 	Mixins    MixinProvider
 	CNAB      CNABProvider
@@ -25,6 +27,7 @@ func New() *Porter {
 	return &Porter{
 		Config:    c,
 		Cache:     cache,
+		Registry:  cnabtooci.NewRegistry(c.Context),
 		Templates: NewTemplates(),
 		Mixins:    mixinprovider.NewFileSystem(c),
 		CNAB:      cnabprovider.NewDuffle(c),

--- a/pkg/porter/registry.go
+++ b/pkg/porter/registry.go
@@ -1,0 +1,19 @@
+package porter
+
+import (
+	"github.com/deislabs/cnab-go/bundle"
+)
+
+// Registry handles talking with an OCI registry.
+type Registry interface {
+	// PullBundle pulls a bundle from an OCI registry.
+	PullBundle(tag string, insecureRegistry bool) (*bundle.Bundle, error)
+
+	// PushBundle pushes a bundle to an OCI registry.
+	PushBundle(bun *bundle.Bundle, tag string, insecureRegistry bool) error
+
+	// PushInvocationImage pushes the invocation image from the Docker image cache to the specified location
+	// the expected format of the invocationImage is REGISTRY/NAME:TAG.
+	// Returns the image digest from the registry.
+	PushInvocationImage(invocationImage string) (string, error)
+}


### PR DESCRIPTION
I needed the logic for pull in a reusable function that I could test in preparation for the dependencies feature. So I've taken PullBundle and its mate PublishBundle and extracted them into an interface, Registry.