### PR TITLE
Move shared code to BundleLifecycleOptions

### DIFF
--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -3,8 +3,6 @@ package porter
 import (
 	"fmt"
 
-	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
-	"github.com/deislabs/porter/pkg/context"
 	"github.com/pkg/errors"
 )
 
@@ -12,39 +10,6 @@ import (
 // Porter handles defaulting any missing values.
 type InstallOptions struct {
 	BundleLifecycleOpts
-}
-
-func (o *InstallOptions) Validate(args []string, cxt *context.Context) error {
-	if o.Tag != "" {
-		err := o.validateTag()
-		if err != nil {
-			return err
-		}
-	}
-	return o.sharedOptions.Validate(args, cxt)
-}
-
-// ToDuffleArgs converts this instance of user-provided installation options
-// to duffle installation arguments.
-func (o *InstallOptions) ToDuffleArgs() cnabprovider.ActionArguments {
-	args := cnabprovider.ActionArguments{
-		Claim:                 o.Name,
-		BundleIdentifier:      o.CNABFile,
-		BundleIsFile:          true,
-		Insecure:              o.Insecure,
-		Params:                make(map[string]string, len(o.combinedParameters)),
-		CredentialIdentifiers: make([]string, len(o.CredentialIdentifiers)),
-		Driver:                o.Driver,
-	}
-
-	// Do a safe copy so that modifications to the duffle args aren't also made to the
-	// original options, which is confusing to debug
-	for k, v := range o.combinedParameters {
-		args.Params[k] = v
-	}
-	copy(args.CredentialIdentifiers, o.CredentialIdentifiers)
-
-	return args
 }
 
 // InstallBundle accepts a set of pre-validated InstallOptions and uses

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -2,9 +2,7 @@ package porter
 
 import (
 	"fmt"
-	"strings"
 
-	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
 	"github.com/deislabs/porter/pkg/context"
 	"github.com/pkg/errors"
 )
@@ -22,15 +20,7 @@ func (o *InvokeOptions) Validate(args []string, cxt *context.Context) error {
 		return errors.New("--action is required")
 	}
 
-	o.Action = strings.ToLower(o.Action)
-
-	if o.Tag != "" {
-		err := o.validateTag()
-		if err != nil {
-			return err
-		}
-	}
-	return o.sharedOptions.Validate(args, cxt)
+	return o.BundleLifecycleOpts.Validate(args, cxt)
 }
 
 // InvokeBundle accepts a set of pre-validated InvokeOptions and uses
@@ -53,18 +43,4 @@ func (p *Porter) InvokeBundle(opts InvokeOptions) error {
 
 	fmt.Fprintf(p.Out, "invoking custom action %s on %s...\n", opts.Action, opts.Name)
 	return p.CNAB.Invoke(opts.Action, opts.ToDuffleArgs())
-}
-
-// ToDuffleArgs converts this instance of user-provided options
-// to duffle arguments.
-func (o *InvokeOptions) ToDuffleArgs() cnabprovider.ActionArguments {
-	return cnabprovider.ActionArguments{
-		Claim:                 o.Name,
-		BundleIdentifier:      o.CNABFile,
-		BundleIsFile:          true,
-		Insecure:              o.Insecure,
-		Params:                o.combineParameters(),
-		CredentialIdentifiers: o.CredentialIdentifiers,
-		Driver:                o.Driver,
-	}
 }

--- a/pkg/porter/invoke_test.go
+++ b/pkg/porter/invoke_test.go
@@ -1,0 +1,18 @@
+package porter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvokeOptions_Validate_ActionRequired(t *testing.T) {
+	p := NewTestPorter(t)
+	opts := InvokeOptions{}
+
+	err := opts.Validate(nil, p.Context)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--action is required")
+}

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -3,8 +3,6 @@ package porter
 import (
 	"fmt"
 
-	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
-	"github.com/deislabs/porter/pkg/context"
 	"github.com/pkg/errors"
 )
 
@@ -12,16 +10,6 @@ import (
 // Porter handles defaulting any missing values.
 type UninstallOptions struct {
 	BundleLifecycleOpts
-}
-
-func (o *UninstallOptions) Validate(args []string, cxt *context.Context) error {
-	if o.Tag != "" {
-		err := o.validateTag()
-		if err != nil {
-			return err
-		}
-	}
-	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UninstallBundle accepts a set of pre-validated UninstallOptions and uses
@@ -44,18 +32,4 @@ func (p *Porter) UninstallBundle(opts UninstallOptions) error {
 
 	fmt.Fprintf(p.Out, "uninstalling %s...\n", opts.Name)
 	return p.CNAB.Uninstall(opts.ToDuffleArgs())
-}
-
-// ToDuffleArgs converts this instance of user-provided options
-// to duffle arguments.
-func (o *UninstallOptions) ToDuffleArgs() cnabprovider.ActionArguments {
-	return cnabprovider.ActionArguments{
-		Claim:                 o.Name,
-		BundleIdentifier:      o.CNABFile,
-		BundleIsFile:          true,
-		Insecure:              o.Insecure,
-		Params:                o.combineParameters(),
-		CredentialIdentifiers: o.CredentialIdentifiers,
-		Driver:                o.Driver,
-	}
 }

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -3,8 +3,6 @@ package porter
 import (
 	"fmt"
 
-	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
-	"github.com/deislabs/porter/pkg/context"
 	"github.com/pkg/errors"
 )
 
@@ -12,16 +10,6 @@ import (
 // Porter handles defaulting any missing values.
 type UpgradeOptions struct {
 	BundleLifecycleOpts
-}
-
-func (o *UpgradeOptions) Validate(args []string, cxt *context.Context) error {
-	if o.Tag != "" {
-		err := o.validateTag()
-		if err != nil {
-			return err
-		}
-	}
-	return o.sharedOptions.Validate(args, cxt)
 }
 
 // UpgradeBundle accepts a set of pre-validated UpgradeOptions and uses
@@ -44,18 +32,4 @@ func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
 
 	fmt.Fprintf(p.Out, "upgrading %s...\n", opts.Name)
 	return p.CNAB.Upgrade(opts.ToDuffleArgs())
-}
-
-// ToDuffleArgs converts this instance of user-provided options
-// to duffle arguments.
-func (o *UpgradeOptions) ToDuffleArgs() cnabprovider.ActionArguments {
-	return cnabprovider.ActionArguments{
-		Claim:                 o.Name,
-		BundleIdentifier:      o.CNABFile,
-		BundleIsFile:          true,
-		Insecure:              o.Insecure,
-		Params:                o.combineParameters(),
-		CredentialIdentifiers: o.CredentialIdentifiers,
-		Driver:                o.Driver,
-	}
 }


### PR DESCRIPTION
Install, Upgrade, Uninstall and Invoke all used the same code for Validate and ToDuffleArgs. I've moved that duplicated code to BundleLifecycleOptions.