### PR TITLE
fix(config.go): ensure porter home path is absolute

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,7 @@ func New() *Config {
 	}
 }
 
-// GetHomeDir determines the path to the porter home directory.
+// GetHomeDir determines the absolute path to the porter home directory.
 func (c *Config) GetHomeDir() (string, error) {
 	if c.porterHome != "" {
 		return c.porterHome, nil
@@ -76,7 +76,15 @@ func (c *Config) GetHomeDir() (string, error) {
 		home = filepath.Dir(porterPath)
 	}
 
-	c.porterHome = home
+	// As a relative path may be supplied via EnvHOME,
+	// we want to return the absolute path for programmatic usage elsewhere,
+	// for instance, in setting up volume mounts for outputs
+	absoluteHome, err := filepath.Abs(home)
+	if err != nil {
+		return "", errors.Wrap(err, "could not get the absolute path for the porter home directory")
+	}
+
+	c.porterHome = absoluteHome
 	return c.porterHome, nil
 }
 

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -1,0 +1,43 @@
+// +build integration
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deislabs/porter/pkg/config"
+	"github.com/deislabs/porter/pkg/porter"
+)
+
+func TestInstall_relativePathPorterHome(t *testing.T) {
+	p := porter.NewTestPorter(t)
+
+	// Crux for this test: set Porter's home dir to a relative path
+	homeDir, err := p.Config.GetHomeDir()
+	require.NoError(t, err)
+	curDir, err := os.Getwd()
+	require.NoError(t, err)
+	relDir, err := filepath.Rel(curDir, homeDir)
+	require.NoError(t, err)
+	os.Setenv(config.EnvHOME, relDir)
+
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+	p.Debug = false
+
+	// Bring in a porter manifest that has an install action defined
+	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundle-with-custom-action.yaml"), "porter.yaml")
+
+	installOpts := porter.InstallOptions{}
+	installOpts.Insecure = true
+	err = installOpts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+
+	// Install the bundle, assert no error occurs due to Porter home as relative path
+	err = p.InstallBundle(installOpts)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
- Ensures GetPorterHome() returns the absolute path to porter home

Fixes https://github.com/deislabs/porter/issues/460