### PR TITLE
feat(*): add applyTo for parameters; update loadParameters logic accordingly

### DIFF
--- a/build/testdata/bundles/terraform/porter.yaml
+++ b/build/testdata/bundles/terraform/porter.yaml
@@ -9,6 +9,9 @@ tag: deislabs/porter-terraform-bundle:v0.1.0
 parameters:
   - name: file_contents
     type: string
+    applyTo:
+      - install
+      - upgrade
 
 install:
   - terraform:

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -139,6 +139,7 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 		p := bundle.ParameterDefinition{
 			Definition:  param.Name,
 			Description: param.Description,
+			ApplyTo:     param.ApplyTo,
 		}
 
 		// If the default is empty, set required to true.
@@ -157,7 +158,11 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 			}
 		}
 
-		(*defs)[param.Name] = d
+		// Only set definition if it doesn't already exist
+		// (Both Params and Outputs may reference same Definition)
+		if _, exists := (*defs)[param.Name]; !exists {
+			(*defs)[param.Name] = d
+		}
 		params.Fields[param.Name] = p
 	}
 	return params
@@ -186,7 +191,11 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 			Path:        filepath.Join(config.BundleOutputsDir, output.Name),
 		}
 
-		(*defs)[output.Name] = d
+		// Only set definition if it doesn't already exist
+		// (Both Params and Outputs may reference same Definition)
+		if _, exists := (*defs)[output.Name]; !exists {
+			(*defs)[output.Name] = d
+		}
 		outputs.Fields[output.Name] = o
 	}
 	return outputs

--- a/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
+++ b/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
@@ -35,6 +35,10 @@ parameters:
     type: boolean
     required: true
     default: true
+  - name: installonly
+    type: boolean
+    applyTo:
+      - install
 
 mixins:
   - exec

--- a/pkg/cnab/provider/install.go
+++ b/pkg/cnab/provider/install.go
@@ -6,6 +6,8 @@ import (
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/pkg/errors"
+
+	"github.com/deislabs/porter/pkg/config"
 )
 
 func (d *Duffle) Install(args ActionArguments) error {
@@ -29,7 +31,7 @@ func (d *Duffle) Install(args ActionArguments) error {
 	}
 	c.Bundle = b
 
-	params, err := d.loadParameters(c, args.Params)
+	params, err := d.loadParameters(c, args.Params, string(config.ActionInstall))
 	if err != nil {
 		return errors.Wrap(err, "invalid parameters")
 	}

--- a/pkg/cnab/provider/invoke.go
+++ b/pkg/cnab/provider/invoke.go
@@ -23,7 +23,7 @@ func (d *Duffle) Invoke(action string, args ActionArguments) error {
 	}
 
 	if len(args.Params) > 0 {
-		claim.Parameters, err = d.loadParameters(&claim, args.Params)
+		claim.Parameters, err = d.loadParameters(&claim, args.Params, action)
 		if err != nil {
 			return errors.Wrap(err, "invalid parameters")
 		}

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -10,7 +10,7 @@ import (
 
 // loadParameters accepts a set of string overrides and combines that with the default parameters to create
 // a full set of parameters.
-func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]string) (map[string]interface{}, error) {
+func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]string, action string) (map[string]interface{}, error) {
 	currentVals := claim.Parameters
 	overrides := make(map[string]interface{}, len(rawOverrides))
 	bun := claim.Bundle
@@ -31,8 +31,47 @@ func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]stri
 			return nil, errors.Wrapf(err, "unable to convert parameter's %s value %s to the destination parameter type %s", key, rawValue, def.Type)
 		}
 
-		overrides[key] = value
+		// If this parameter applies to the current action, set the override accordingly
+		if appliesToAction(action, param) {
+			overrides[key] = value
+		} else {
+			// Otherwise, set to current parameter value on the claim, if exists
+			if _, exists := claim.Parameters[key]; exists {
+				overrides[key] = claim.Parameters[key]
+			}
+			if d.Debug {
+				fmt.Fprintf(d.Err,
+					"override supplied for '%s', but this parameter is not configured to apply for action '%s'; skipping\n",
+					key, action)
+			}
+		}
+	}
+
+	// rawOverrides may supply no entry for a parameter designated as required
+	// *but* should not apply to this action.
+	// When this occurs, we set an override to the current value in the claim such that
+	// bundle.ValuesOrDefaults does not return an error
+	// TODO: will have to refactor loop once required is back as a bool on the ParameterDefinition
+	for _, required := range bun.Parameters.Required {
+		if _, exists := rawOverrides[required]; !exists {
+			if !appliesToAction(action, bun.Parameters.Fields[required]) {
+				overrides[required] = claim.Parameters[required]
+			}
+		}
 	}
 
 	return bundle.ValuesOrDefaults(overrides, currentVals, bun)
+}
+
+// TODO: pilfered from cnab-go.  PR to export func?
+func appliesToAction(action string, parameter bundle.ParameterDefinition) bool {
+	if len(parameter.ApplyTo) == 0 {
+		return true
+	}
+	for _, act := range parameter.ApplyTo {
+		if action == act {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cnab/provider/parameters_test.go
+++ b/pkg/cnab/provider/parameters_test.go
@@ -1,0 +1,203 @@
+package cnabprovider
+
+import (
+	"testing"
+
+	"github.com/deislabs/cnab-go/bundle/definition"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/claim"
+
+	"github.com/deislabs/porter/pkg/config"
+)
+
+func Test_loadParameters_paramNotDefined(t *testing.T) {
+	c := config.NewTestConfig(t)
+	d := NewDuffle(c.Config)
+
+	claim, err := claim.New("test")
+	require.NoError(t, err)
+
+	claim.Bundle = &bundle.Bundle{
+		Parameters: &bundle.ParametersDefinition{
+			Fields: map[string]bundle.ParameterDefinition{},
+		},
+	}
+
+	overrides := map[string]string{
+		"foo": "bar",
+	}
+
+	_, err = d.loadParameters(claim, overrides, "action")
+	require.EqualError(t, err, "parameter foo not defined in bundle")
+}
+
+func Test_loadParameters_definitionNotDefined(t *testing.T) {
+	c := config.NewTestConfig(t)
+	d := NewDuffle(c.Config)
+
+	claim, err := claim.New("test")
+	require.NoError(t, err)
+
+	claim.Bundle = &bundle.Bundle{
+		Parameters: &bundle.ParametersDefinition{
+			Fields: map[string]bundle.ParameterDefinition{
+				"foo": bundle.ParameterDefinition{
+					Definition: "foo",
+				},
+			},
+		},
+	}
+
+	overrides := map[string]string{
+		"foo": "bar",
+	}
+
+	_, err = d.loadParameters(claim, overrides, "action")
+	require.EqualError(t, err, "definition foo not defined in bundle")
+}
+
+func Test_loadParameters_applyToClaimDefaults(t *testing.T) {
+	c := config.NewTestConfig(t)
+	d := NewDuffle(c.Config)
+
+	claim, err := claim.New("test")
+	require.NoError(t, err)
+
+	// Here we set default values, but we expect the corresponding
+	// claim values to take precedence when loadParameters is called
+	claim.Bundle = &bundle.Bundle{
+		Definitions: definition.Definitions{
+			"foo": &definition.Schema{
+				Type:    "string",
+				Default: "default-foo-value",
+			},
+			"bar": &definition.Schema{
+				Type:    "integer",
+				Default: "default-bar-value",
+			},
+			"true": &definition.Schema{
+				Type:    "boolean",
+				Default: "default-true-value",
+			},
+		},
+		Parameters: &bundle.ParametersDefinition{
+			Fields: map[string]bundle.ParameterDefinition{
+				"foo": bundle.ParameterDefinition{
+					Definition: "foo",
+					ApplyTo: []string{
+						"action",
+					},
+				},
+				"bar": bundle.ParameterDefinition{
+					Definition: "bar",
+				},
+				"true": bundle.ParameterDefinition{
+					Definition: "true",
+					ApplyTo: []string{
+						"different-action",
+					},
+				},
+			},
+		},
+	}
+
+	claim.Parameters = map[string]interface{}{
+		"foo":  "foo",
+		"bar":  123,
+		"true": true,
+	}
+
+	overrides := map[string]string{
+		"foo":  "FOO",
+		"bar":  "456",
+		"true": "false",
+	}
+
+	params, err := d.loadParameters(claim, overrides, "action")
+	require.NoError(t, err)
+
+	require.Equal(t, "FOO", params["foo"], "expected param 'foo' to be updated")
+	require.Equal(t, 456, params["bar"], "expected param 'bar' to be updated")
+	require.Equal(t, true, params["true"], "expected param 'true' to represent the preexisting claim value")
+}
+
+func Test_loadParameters_applyToBundleDefaults(t *testing.T) {
+	c := config.NewTestConfig(t)
+	d := NewDuffle(c.Config)
+
+	claim, err := claim.New("test")
+	require.NoError(t, err)
+
+	claim.Bundle = &bundle.Bundle{
+		Definitions: definition.Definitions{
+			"foo": &definition.Schema{
+				Type:    "string",
+				Default: "foo-default",
+			},
+		},
+		Parameters: &bundle.ParametersDefinition{
+			Fields: map[string]bundle.ParameterDefinition{
+				"foo": bundle.ParameterDefinition{
+					Definition: "foo",
+					ApplyTo: []string{
+						"different-action",
+					},
+				},
+			},
+		},
+	}
+
+	claim.Parameters = map[string]interface{}{}
+
+	overrides := map[string]string{
+		"foo": "FOO",
+	}
+
+	params, err := d.loadParameters(claim, overrides, "action")
+	require.NoError(t, err)
+
+	require.Equal(t, "foo-default", params["foo"], "expected param 'foo' to be the bundle default")
+}
+
+func Test_loadParameters_requiredButDoesNotApply(t *testing.T) {
+	c := config.NewTestConfig(t)
+	d := NewDuffle(c.Config)
+
+	claim, err := claim.New("test")
+	require.NoError(t, err)
+
+	claim.Bundle = &bundle.Bundle{
+		Definitions: definition.Definitions{
+			"foo": &definition.Schema{
+				Type: "string",
+			},
+		},
+		Parameters: &bundle.ParametersDefinition{
+			Fields: map[string]bundle.ParameterDefinition{
+				"foo": bundle.ParameterDefinition{
+					Definition: "foo",
+					ApplyTo: []string{
+						"different-action",
+					},
+				},
+			},
+			Required: []string{
+				"foo",
+			},
+		},
+	}
+
+	claim.Parameters = map[string]interface{}{
+		"foo": "foo-claim-value",
+	}
+
+	overrides := map[string]string{}
+
+	params, err := d.loadParameters(claim, overrides, "action")
+	require.NoError(t, err)
+
+	require.Equal(t, "foo-claim-value", params["foo"], "expected param 'foo' to be the bundle default")
+}

--- a/pkg/cnab/provider/uninstall.go
+++ b/pkg/cnab/provider/uninstall.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/pkg/errors"
+
+	"github.com/deislabs/porter/pkg/config"
 )
 
 func (d *Duffle) Uninstall(args ActionArguments) error {
@@ -27,7 +29,7 @@ func (d *Duffle) Uninstall(args ActionArguments) error {
 	}
 
 	if len(args.Params) > 0 {
-		claim.Parameters, err = d.loadParameters(&claim, args.Params)
+		claim.Parameters, err = d.loadParameters(&claim, args.Params, string(config.ActionUninstall))
 		if err != nil {
 			return errors.Wrap(err, "invalid parameters")
 		}

--- a/pkg/cnab/provider/upgrade.go
+++ b/pkg/cnab/provider/upgrade.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/pkg/errors"
+
+	"github.com/deislabs/porter/pkg/config"
 )
 
 func (d *Duffle) Upgrade(args ActionArguments) error {
@@ -27,7 +29,7 @@ func (d *Duffle) Upgrade(args ActionArguments) error {
 	}
 
 	if len(args.Params) > 0 {
-		claim.Parameters, err = d.loadParameters(&claim, args.Params)
+		claim.Parameters, err = d.loadParameters(&claim, args.Params, string(config.ActionUpgrade))
 		if err != nil {
 			return errors.Wrap(err, "invalid parameters")
 		}

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -56,10 +56,14 @@ type Manifest struct {
 
 // ParameterDefinition defines a single parameter for a CNAB bundle
 type ParameterDefinition struct {
-	Name        string    `yaml:"name"`
+	Name      string `yaml:"name"`
+	Sensitive bool   `yaml:"sensitive"`
+
+	// These could be swapped out with an inline bundle.ParameterDefinition
+	// from cnab-go, e.g. bundle.ParameterDefinition `yaml:",inline"`
 	Description string    `yaml:"description,omitempty"`
-	Sensitive   bool      `yaml:"sensitive"`
 	Destination *Location `yaml:"destination,omitempty"`
+	ApplyTo     []string  `yaml:"applyTo,omitempty"`
 
 	Schema `yaml:",inline"`
 }

--- a/scripts/test/test-terraform.sh
+++ b/scripts/test/test-terraform.sh
@@ -50,6 +50,6 @@ ${PORTER_HOME}/porter bundle output show file_contents | grep -q "bar!"
 
 cat ${PORTER_HOME}/claims/porter-terraform.json
 
-${PORTER_HOME}/porter uninstall --insecure --debug --param file_contents='bar!'
+${PORTER_HOME}/porter uninstall --insecure --debug
 
 ${PORTER_HOME}/porter publish


### PR DESCRIPTION
- adds `applyTo` to the Parameter definition, per the CNAB Spec
- updates `loadParameters` in `pkg/cnab/provider/parameters.go` accordingly
- adds `loadParameters` unit tests
- fixes subtle bug around populating the bundle.json's Definitions struct; adds test (there were cases where we were overriding a pre-existing Definition if used by both an Output and a Parameter)

Depends on https://github.com/deislabs/porter/pull/473 (Would like to get 473 in first and then rebase accordingly)

Closes https://github.com/deislabs/porter/issues/439