### PR TITLE
removed iex (invoke-expression) from windows install script

### DIFF
--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -7,13 +7,13 @@ mkdir -f $PORTER_HOME
 
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-windows-amd64.exe", "$PORTER_HOME\porter.exe")
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-linux-amd64", "$PORTER_HOME\porter-runtime")
-echo "Installed $(iex "$PORTER_HOME\porter.exe version")"
+echo "Installed $(& $PORTER_HOME\porter.exe version)"
 
 $FEED_URL="$PORTER_URL/atom.xml"
-iex "$PORTER_HOME/porter mixin install exec --version $PORTER_VERSION --feed-url $FEED_URL"
-iex "$PORTER_HOME/porter mixin install kubernetes --version $PORTER_VERSION --feed-url $FEED_URL"
-iex "$PORTER_HOME/porter mixin install helm --version $PORTER_VERSION --feed-url $FEED_URL"
-iex "$PORTER_HOME/porter mixin install azure --version $PORTER_VERSION --feed-url $FEED_URL"
+& $PORTER_HOME/porter mixin install exec --version $PORTER_VERSION --feed-url $FEED_URL
+& $PORTER_HOME/porter mixin install kubernetes --version $PORTER_VERSION --feed-url $FEED_URL
+& $PORTER_HOME/porter mixin install helm --version $PORTER_VERSION --feed-url $FEED_URL
+& $PORTER_HOME/porter mixin install azure --version $PORTER_VERSION --feed-url $FEED_URL
 
 echo "Installation complete."
 echo "Add porter to your path by running:"


### PR DESCRIPTION
updates the Windows/PowerShell install script to remove iex (invoke-expression).

Replace with the call operator &.

iex is considered a code smell, with some well known security implications.