### PR TITLE
Adding Dockerfile for the workshop

### DIFF
--- a/workshop/docker-image/Dockerfile.workshop
+++ b/workshop/docker-image/Dockerfile.workshop
@@ -1,0 +1,14 @@
+FROM docker:dind
+
+RUN apk add bash \
+            git \
+            curl \ 
+            bash-completion \ 
+            jq \
+            ca-certificates && \
+    curl https://deislabs.blob.core.windows.net/porter/latest/install-linux.sh | bash && \
+    mkdir -p /workshop 
+
+ENV PATH="$PATH:/root/.porter"
+
+WORKDIR /workshop

--- a/workshop/docker-image/Dockerfile.workshop
+++ b/workshop/docker-image/Dockerfile.workshop
@@ -1,5 +1,7 @@
 FROM docker:dind
 
+ENV HELM_VER 2.12.3 
+
 RUN apk add bash \
             git \
             curl \ 
@@ -7,6 +9,11 @@ RUN apk add bash \
             jq \
             ca-certificates && \
     curl https://deislabs.blob.core.windows.net/porter/latest/install-linux.sh | bash && \
+    curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
+    tar -xzf helm.tgz && \
+    mv linux-amd64/helm /usr/local/bin && \
+    rm helm.tgz && \
+    helm init --client-only && \
     mkdir -p /workshop 
 
 ENV PATH="$PATH:/root/.porter"


### PR DESCRIPTION
Adding a Dockerfile for the workshop so people don't need to install anything. This also fixes the issue that some people dont want to login to DockerHub with paly with Docker as it is not secure. 

To run the image `docker run -d --privileged --name workshop <img name>/workshop && docker exec -it workshop sh`

This will give the users a full isolated Docker engine and Porter.