### PR TITLE
fix(adapter.go): don't add empty outputs section to generated bundle

### DIFF
--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -169,34 +169,38 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 }
 
 func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) *bundle.OutputsDefinition {
-	outputs := &bundle.OutputsDefinition{
-		Fields: make(map[string]bundle.OutputDefinition, len(c.Manifest.Outputs)),
-	}
+	var outputs *bundle.OutputsDefinition
 
-	for _, output := range c.Manifest.Outputs {
-		fmt.Fprintf(c.Out, "Generating output definition %s ====>\n", output.Name)
-		d := &definition.Schema{
-			Type:      output.Type,
-			Default:   output.Default,
-			Enum:      output.Enum,
-			Minimum:   output.Minimum,
-			Maximum:   output.Maximum,
-			MinLength: output.MinLength,
-			MaxLength: output.MaxLength,
-		}
-		o := bundle.OutputDefinition{
-			Definition:  output.Name,
-			Description: output.Description,
-			ApplyTo:     output.ApplyTo,
-			Path:        filepath.Join(config.BundleOutputsDir, output.Name),
+	if len(c.Manifest.Outputs) > 0 {
+		outputs = &bundle.OutputsDefinition{
+			Fields: make(map[string]bundle.OutputDefinition, len(c.Manifest.Outputs)),
 		}
 
-		// Only set definition if it doesn't already exist
-		// (Both Params and Outputs may reference same Definition)
-		if _, exists := (*defs)[output.Name]; !exists {
-			(*defs)[output.Name] = d
+		for _, output := range c.Manifest.Outputs {
+			fmt.Fprintf(c.Out, "Generating output definition %s ====>\n", output.Name)
+			d := &definition.Schema{
+				Type:      output.Type,
+				Default:   output.Default,
+				Enum:      output.Enum,
+				Minimum:   output.Minimum,
+				Maximum:   output.Maximum,
+				MinLength: output.MinLength,
+				MaxLength: output.MaxLength,
+			}
+			o := bundle.OutputDefinition{
+				Definition:  output.Name,
+				Description: output.Description,
+				ApplyTo:     output.ApplyTo,
+				Path:        filepath.Join(config.BundleOutputsDir, output.Name),
+			}
+
+			// Only set definition if it doesn't already exist
+			// (Both Params and Outputs may reference same Definition)
+			if _, exists := (*defs)[output.Name]; !exists {
+				(*defs)[output.Name] = d
+			}
+			outputs.Fields[output.Name] = o
 		}
-		outputs.Fields[output.Name] = o
 	}
 	return outputs
 }

--- a/pkg/cnab/config_adapter/adapter_test.go
+++ b/pkg/cnab/config_adapter/adapter_test.go
@@ -40,6 +40,8 @@ func TestManifestConverter_ToBundle(t *testing.T) {
 
 	assert.Contains(t, bun.Custom, config.CustomBundleKey, "Porter stamp was not populated")
 	assert.Contains(t, bun.Custom, extensions.DependenciesKey, "Dependencies was not populated")
+
+	assert.Nil(t, bun.Outputs, "expected outputs section not to exist in generated bundle")
 }
 
 func makefloat64(v float64) *float64 {


### PR DESCRIPTION
Fixes https://github.com/deislabs/porter/issues/482