### PR TITLE
Ref(*): use cnab go schema

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -222,7 +222,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:9f60acd7d2ca0060ebd9064d616b4a09c8906aff099897273fffb2ec81f04815"
+  digest = "1:fbc17e2e9d067056cd4948987ebc510c14d09e1889d9a1cf43aa9d1d4f27fac8"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -234,8 +234,7 @@
     "utils/crud",
   ]
   pruneopts = "NT"
-  revision = "d0e47f49ea9a4ef8aedf1043b11ffa7506fc10d7"
-  version = "v0.2.0-beta1"
+  revision = "44f18fa40b9ce9acd04c73373b9991a7e5b5a9d5"
 
 [[projects]]
   digest = "1:4f1e6f901178a2f34620772c5431e8cbf157db97e6dc6c663d8ea760e265920c"
@@ -1480,6 +1479,7 @@
     "github.com/docker/go-metrics",
     "github.com/ghodss/yaml",
     "github.com/gobuffalo/packr/v2",
+    "github.com/gobuffalo/packr/v2/file/resolver",
     "github.com/hashicorp/go-multierror",
     "github.com/mmcdole/gofeed/atom",
     "github.com/olekukonko/tablewriter",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -222,7 +222,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:fbc17e2e9d067056cd4948987ebc510c14d09e1889d9a1cf43aa9d1d4f27fac8"
+  digest = "1:1262059b93a03512c45efcc15f5e4ce6683f619613305eb0739f7e6e80fdc4a1"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -234,7 +234,8 @@
     "utils/crud",
   ]
   pruneopts = "NT"
-  revision = "44f18fa40b9ce9acd04c73373b9991a7e5b5a9d5"
+  revision = "a0a0201df5945d48a40c46e1d33b70350aae62d5"
+  source = "github.com/vdice/cnab-go"
 
 [[projects]]
   digest = "1:4f1e6f901178a2f34620772c5431e8cbf157db97e6dc6c663d8ea760e265920c"
@@ -1479,7 +1480,6 @@
     "github.com/docker/go-metrics",
     "github.com/ghodss/yaml",
     "github.com/gobuffalo/packr/v2",
-    "github.com/gobuffalo/packr/v2/file/resolver",
     "github.com/hashicorp/go-multierror",
     "github.com/mmcdole/gofeed/atom",
     "github.com/olekukonko/tablewriter",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,14 +3,18 @@
   name = "github.com/deislabs/duffle"
   version = "=0.2.0-beta.1"
 
+# TODO: update to actual release of deislabs/cnab-go; rm source
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  revision = "44f18fa40b9ce9acd04c73373b9991a7e5b5a9d5"
+  source = "github.com/vdice/cnab-go"
+  revision = "a0a0201df5945d48a40c46e1d33b70350aae62d5"
 
+# TODO: update to actual release of deislabs/cnab-go; rm source
 # override currently needed or else cnab-to-oci dep causes issues
 [[override]]
   name = "github.com/deislabs/cnab-go"
-  revision = "44f18fa40b9ce9acd04c73373b9991a7e5b5a9d5"
+  source = "github.com/vdice/cnab-go"
+  revision = "a0a0201df5945d48a40c46e1d33b70350aae62d5"
 
 # Using master until there is a release of cnab-to-oci
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,12 +5,12 @@
 
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  version = "0.2.0-beta.1"
+  revision = "44f18fa40b9ce9acd04c73373b9991a7e5b5a9d5"
 
 # override currently needed or else cnab-to-oci dep causes issues
 [[override]]
   name = "github.com/deislabs/cnab-go"
-  version = "0.2.0-beta.1"
+  revision = "44f18fa40b9ce9acd04c73373b9991a7e5b5a9d5"
 
 # Using master until there is a release of cnab-to-oci
 [[constraint]]

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -190,7 +190,7 @@ func (c *ManifestConverter) buildDefaultPorterParameters() []config.ParameterDef
 	return []config.ParameterDefinition{
 		{
 			Name: "porter-debug",
-			Destination: &bundle.Location{
+			Destination: &config.Location{
 				EnvironmentVariable: "PORTER_DEBUG",
 			},
 			Schema: definition.Schema{

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -126,13 +126,13 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 		fmt.Fprintf(c.Out, "Generating parameter definition %s ====>\n", param.Name)
 		p := bundle.Parameter{
 			Definition:  param.Name,
-			Description: param.Parameter.Description,
 			ApplyTo:     param.ApplyTo,
+			Description: param.Description,
 		}
 
 		// If the default is empty, set required to true.
 		if param.Default == nil {
-			param.Parameter.Required = true
+			p.Required = true
 		}
 
 		if param.Destination != nil {
@@ -149,7 +149,8 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 		// Only set definition if it doesn't already exist
 		// (Both Params and Outputs may reference same Definition)
 		if _, exists := (*defs)[param.Name]; !exists {
-			(*defs)[param.Name] = &param.Schema
+			def := param.Schema
+			(*defs)[param.Name] = &def
 		}
 		params[param.Name] = p
 	}
@@ -176,7 +177,8 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 			// Only set definition if it doesn't already exist
 			// (Both Params and Outputs may reference same Definition)
 			if _, exists := (*defs)[output.Name]; !exists {
-				(*defs)[output.Name] = &output.Schema
+				def := output.Schema
+				(*defs)[output.Name] = &def
 			}
 			outputs.Fields[output.Name] = o
 		}
@@ -188,15 +190,13 @@ func (c *ManifestConverter) buildDefaultPorterParameters() []config.ParameterDef
 	return []config.ParameterDefinition{
 		{
 			Name: "porter-debug",
-			Parameter: bundle.Parameter{
-				Description: "Print debug information from Porter when executing the bundle",
-				Destination: &bundle.Location{
-					EnvironmentVariable: "PORTER_DEBUG",
-				},
+			Destination: &bundle.Location{
+				EnvironmentVariable: "PORTER_DEBUG",
 			},
 			Schema: definition.Schema{
-				Type:    "boolean",
-				Default: false,
+				Description: "Print debug information from Porter when executing the bundle",
+				Type:        "boolean",
+				Default:     false,
 			},
 		},
 	}

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -119,32 +119,20 @@ func (c *ManifestConverter) generateDefaultAction(action string) bundle.Action {
 	}
 }
 
-func (c *ManifestConverter) generateBundleParameters(defs *definition.Definitions) *bundle.ParametersDefinition {
-	params := &bundle.ParametersDefinition{
-		Fields: make(map[string]bundle.ParameterDefinition, len(c.Manifest.Parameters)),
-	}
+func (c *ManifestConverter) generateBundleParameters(defs *definition.Definitions) map[string]bundle.Parameter {
+	params := make(map[string]bundle.Parameter, len(c.Manifest.Parameters))
+
 	for _, param := range append(c.Manifest.Parameters, c.buildDefaultPorterParameters()...) {
 		fmt.Fprintf(c.Out, "Generating parameter definition %s ====>\n", param.Name)
-		d := &definition.Schema{
-			Type:             param.Type,
-			Default:          param.Default,
-			Enum:             param.Enum,
-			Minimum:          param.Minimum,
-			Maximum:          param.Maximum,
-			ExclusiveMinimum: param.ExclusiveMinimum,
-			ExclusiveMaximum: param.ExclusiveMaximum,
-			MinLength:        param.MinLength,
-			MaxLength:        param.MaxLength,
-		}
-		p := bundle.ParameterDefinition{
+		p := bundle.Parameter{
 			Definition:  param.Name,
-			Description: param.Description,
+			Description: param.Parameter.Description,
 			ApplyTo:     param.ApplyTo,
 		}
 
 		// If the default is empty, set required to true.
 		if param.Default == nil {
-			params.Required = append(params.Required, param.Name)
+			param.Parameter.Required = true
 		}
 
 		if param.Destination != nil {
@@ -161,9 +149,9 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 		// Only set definition if it doesn't already exist
 		// (Both Params and Outputs may reference same Definition)
 		if _, exists := (*defs)[param.Name]; !exists {
-			(*defs)[param.Name] = d
+			(*defs)[param.Name] = &param.Schema
 		}
-		params.Fields[param.Name] = p
+		params[param.Name] = p
 	}
 	return params
 }
@@ -178,15 +166,6 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 
 		for _, output := range c.Manifest.Outputs {
 			fmt.Fprintf(c.Out, "Generating output definition %s ====>\n", output.Name)
-			d := &definition.Schema{
-				Type:      output.Type,
-				Default:   output.Default,
-				Enum:      output.Enum,
-				Minimum:   output.Minimum,
-				Maximum:   output.Maximum,
-				MinLength: output.MinLength,
-				MaxLength: output.MaxLength,
-			}
 			o := bundle.OutputDefinition{
 				Definition:  output.Name,
 				Description: output.Description,
@@ -197,7 +176,7 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 			// Only set definition if it doesn't already exist
 			// (Both Params and Outputs may reference same Definition)
 			if _, exists := (*defs)[output.Name]; !exists {
-				(*defs)[output.Name] = d
+				(*defs)[output.Name] = &output.Schema
 			}
 			outputs.Fields[output.Name] = o
 		}
@@ -208,12 +187,14 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 func (c *ManifestConverter) buildDefaultPorterParameters() []config.ParameterDefinition {
 	return []config.ParameterDefinition{
 		{
-			Name:        "porter-debug",
-			Description: "Print debug information from Porter when executing the bundle",
-			Destination: &config.Location{
-				EnvironmentVariable: "PORTER_DEBUG",
+			Name: "porter-debug",
+			Parameter: bundle.Parameter{
+				Description: "Print debug information from Porter when executing the bundle",
+				Destination: &bundle.Location{
+					EnvironmentVariable: "PORTER_DEBUG",
+				},
 			},
-			Schema: config.Schema{
+			Schema: definition.Schema{
 				Type:    "boolean",
 				Default: false,
 			},

--- a/pkg/cnab/config_adapter/adapter_test.go
+++ b/pkg/cnab/config_adapter/adapter_test.go
@@ -35,7 +35,7 @@ func TestManifestConverter_ToBundle(t *testing.T) {
 	assert.NotNil(t, stamp)
 
 	assert.Contains(t, bun.Actions, "status", "custom action 'status' was not populated")
-	assert.Contains(t, bun.Parameters.Fields, "porter-debug", "porter-debug parameter was not defined")
+	assert.Contains(t, bun.Parameters, "porter-debug", "porter-debug parameter was not defined")
 	assert.Contains(t, bun.Definitions, "porter-debug", "porter-debug definition was not defined")
 
 	assert.Contains(t, bun.Custom, config.CustomBundleKey, "Porter stamp was not populated")
@@ -65,11 +65,11 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 
 	testcases := []struct {
 		propname  string
-		wantParam bundle.ParameterDefinition
+		wantParam bundle.Parameter
 		wantDef   definition.Schema
 	}{
 		{"ainteger",
-			bundle.ParameterDefinition{
+			bundle.Parameter{
 				Definition: "ainteger",
 				Destination: &bundle.Location{
 					EnvironmentVariable: "AINTEGER",
@@ -83,7 +83,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 			},
 		},
 		{"anumber",
-			bundle.ParameterDefinition{
+			bundle.Parameter{
 				Definition: "anumber",
 				Destination: &bundle.Location{
 					EnvironmentVariable: "ANUMBER",
@@ -98,7 +98,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 		},
 		{
 			"astringenum",
-			bundle.ParameterDefinition{
+			bundle.Parameter{
 				Definition: "astringenum",
 				Destination: &bundle.Location{
 					EnvironmentVariable: "ASTRINGENUM",
@@ -112,7 +112,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 		},
 		{
 			"astring",
-			bundle.ParameterDefinition{
+			bundle.Parameter{
 				Definition: "astring",
 				Destination: &bundle.Location{
 					EnvironmentVariable: "ASTRING",
@@ -126,7 +126,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 		},
 		{
 			"aboolean",
-			bundle.ParameterDefinition{
+			bundle.Parameter{
 				Definition: "aboolean",
 				Destination: &bundle.Location{
 					EnvironmentVariable: "ABOOLEAN",
@@ -139,7 +139,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 		},
 		{
 			"installonly",
-			bundle.ParameterDefinition{
+			bundle.Parameter{
 				Definition: "installonly",
 				Destination: &bundle.Location{
 					EnvironmentVariable: "INSTALLONLY",
@@ -156,7 +156,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.propname, func(t *testing.T) {
-			param, ok := params.Fields[tc.propname]
+			param, ok := params[tc.propname]
 			require.True(t, ok, "parameter definition was not generated")
 
 			def, ok := defs[tc.propname]
@@ -183,7 +183,7 @@ func TestManifestConverter_buildDefaultPorterParameters(t *testing.T) {
 	defs := make(definition.Definitions, len(c.Manifest.Parameters))
 	params := a.generateBundleParameters(&defs)
 
-	debugParam, ok := params.Fields["porter-debug"]
+	debugParam, ok := params["porter-debug"]
 	assert.True(t, ok, "porter-debug parameter was not defined")
 	assert.Equal(t, "porter-debug", debugParam.Definition)
 	assert.Equal(t, "PORTER_DEBUG", debugParam.Destination.EnvironmentVariable)
@@ -280,20 +280,20 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 	outputDefinitions := []config.OutputDefinition{
 		{
 			Name:        "output1",
-			Description: "Description of output1",
 			ApplyTo: []string{
 				"install",
 				"upgrade",
 			},
-			Schema: config.Schema{
+			Schema: definition.Schema{
 				Type: "string",
+				Description: "Description of output1",
 			},
 		},
 		{
 			Name:        "output2",
-			Description: "Description of output2",
-			Schema: config.Schema{
+			Schema: definition.Schema{
 				Type: "boolean",
+				Description: "Description of output2",
 			},
 		},
 	}
@@ -352,21 +352,21 @@ func TestManifestConverter_generateBundleOutputs_preexistingDefinition(t *testin
 	outputDefinitions := []config.OutputDefinition{
 		{
 			Name:        "output1",
-			Description: "Description of output1",
 			ApplyTo: []string{
 				"install",
 				"upgrade",
 			},
-			Schema: config.Schema{
+			Schema: definition.Schema{
 				Type:    "string",
 				Default: "default-output",
+				Description: "Description of output1",
 			},
 		},
 		{
 			Name:        "output2",
-			Description: "Description of output2",
-			Schema: config.Schema{
+			Schema: definition.Schema{
 				Type: "boolean",
+				Description: "Description of output2",
 			},
 		},
 	}

--- a/pkg/cnab/config_adapter/adapter_test.go
+++ b/pkg/cnab/config_adapter/adapter_test.go
@@ -117,6 +117,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 				Destination: &bundle.Location{
 					EnvironmentVariable: "ASTRING",
 				},
+				Required: true,
 			},
 			definition.Schema{
 				Type:      "string",
@@ -147,6 +148,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 				ApplyTo: []string{
 					"install",
 				},
+				Required: true,
 			},
 			definition.Schema{
 				Type: "boolean",
@@ -328,9 +330,11 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 	wantDefinitions := definition.Definitions{
 		"output1": &definition.Schema{
 			Type: "string",
+			Description: "Description of output1",
 		},
 		"output2": &definition.Schema{
 			Type: "boolean",
+			Description: "Description of output2",
 		},
 	}
 
@@ -412,6 +416,7 @@ func TestManifestConverter_generateBundleOutputs_preexistingDefinition(t *testin
 		},
 		"output2": &definition.Schema{
 			Type: "boolean",
+			Description: "Description of output2",
 		},
 	}
 

--- a/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
+++ b/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
@@ -8,13 +8,11 @@ parameters:
   - name: ainteger
     type: integer
     default: 1
-    required: true
     minimum: 0
     maximum: 10
   - name: anumber
     type: number
     default: 0.5
-    required: true
     exclusiveMinimum: 0
     exclusiveMaximum: 1
   - name: astringenum
@@ -25,15 +23,12 @@ parameters:
       - red
       - purple
       - pink
-    required: true
   - name: astring
     type: string
-    required: true
     minLength: 1
     maxLength: 10
   - name: aboolean
     type: boolean
-    required: true
     default: true
   - name: installonly
     type: boolean

--- a/pkg/cnab/extensions/testdata/bundle.json
+++ b/pkg/cnab/extensions/testdata/bundle.json
@@ -42,9 +42,9 @@
       "env": "equux"
     }
   },
-  "requiredExtensions": {
-    "dependencies": "https://cnab.io/specs/v1/dependencies.schema.json"
-  },
+  "requiredExtensions": [
+    "https://cnab.io/specs/v1/dependencies.schema.json"
+  ],
   "custom": {
     "com.example.duffle-bag": {
       "icon": "https://example.com/icon.png",

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -11,7 +11,6 @@ import (
 // loadParameters accepts a set of string overrides and combines that with the default parameters to create
 // a full set of parameters.
 func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]string, action string) (map[string]interface{}, error) {
-	currentVals := claim.Parameters
 	overrides := make(map[string]interface{}, len(rawOverrides))
 	bun := claim.Bundle
 
@@ -61,7 +60,7 @@ func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]stri
 		}
 	}
 
-	return bundle.ValuesOrDefaults(overrides, currentVals, bun)
+	return bundle.ValuesOrDefaults(overrides, bun)
 }
 
 // TODO: pilfered from cnab-go.  PR to export func?

--- a/pkg/cnab/provider/parameters_test.go
+++ b/pkg/cnab/provider/parameters_test.go
@@ -21,9 +21,7 @@ func Test_loadParameters_paramNotDefined(t *testing.T) {
 	require.NoError(t, err)
 
 	claim.Bundle = &bundle.Bundle{
-		Parameters: &bundle.ParametersDefinition{
-			Fields: map[string]bundle.ParameterDefinition{},
-		},
+		Parameters: map[string]bundle.Parameter{},
 	}
 
 	overrides := map[string]string{
@@ -42,11 +40,9 @@ func Test_loadParameters_definitionNotDefined(t *testing.T) {
 	require.NoError(t, err)
 
 	claim.Bundle = &bundle.Bundle{
-		Parameters: &bundle.ParametersDefinition{
-			Fields: map[string]bundle.ParameterDefinition{
-				"foo": bundle.ParameterDefinition{
-					Definition: "foo",
-				},
+		Parameters: map[string]bundle.Parameter{
+			"foo": bundle.Parameter{
+				Definition: "foo",
 			},
 		},
 	}
@@ -83,22 +79,20 @@ func Test_loadParameters_applyToClaimDefaults(t *testing.T) {
 				Default: "default-true-value",
 			},
 		},
-		Parameters: &bundle.ParametersDefinition{
-			Fields: map[string]bundle.ParameterDefinition{
-				"foo": bundle.ParameterDefinition{
-					Definition: "foo",
-					ApplyTo: []string{
-						"action",
-					},
+		Parameters: map[string]bundle.Parameter{
+			"foo": bundle.Parameter{
+				Definition: "foo",
+				ApplyTo: []string{
+					"action",
 				},
-				"bar": bundle.ParameterDefinition{
-					Definition: "bar",
-				},
-				"true": bundle.ParameterDefinition{
-					Definition: "true",
-					ApplyTo: []string{
-						"different-action",
-					},
+			},
+			"bar": bundle.Parameter{
+				Definition: "bar",
+			},
+			"true": bundle.Parameter{
+				Definition: "true",
+				ApplyTo: []string{
+					"different-action",
 				},
 			},
 		},
@@ -138,13 +132,11 @@ func Test_loadParameters_applyToBundleDefaults(t *testing.T) {
 				Default: "foo-default",
 			},
 		},
-		Parameters: &bundle.ParametersDefinition{
-			Fields: map[string]bundle.ParameterDefinition{
-				"foo": bundle.ParameterDefinition{
-					Definition: "foo",
-					ApplyTo: []string{
-						"different-action",
-					},
+		Parameters: map[string]bundle.Parameter{
+			"foo": bundle.Parameter{
+				Definition: "foo",
+				ApplyTo: []string{
+					"different-action",
 				},
 			},
 		},
@@ -175,17 +167,13 @@ func Test_loadParameters_requiredButDoesNotApply(t *testing.T) {
 				Type: "string",
 			},
 		},
-		Parameters: &bundle.ParametersDefinition{
-			Fields: map[string]bundle.ParameterDefinition{
-				"foo": bundle.ParameterDefinition{
-					Definition: "foo",
-					ApplyTo: []string{
-						"different-action",
-					},
+		Parameters: map[string]bundle.Parameter{
+			"foo": bundle.Parameter{
+				Definition: "foo",
+				ApplyTo: []string{
+					"different-action",
 				},
-			},
-			Required: []string{
-				"foo",
+				Required: true,
 			},
 		},
 	}

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -13,6 +13,9 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/bundle/definition"
 )
 
 type Manifest struct {
@@ -59,26 +62,9 @@ type ParameterDefinition struct {
 	Name      string `yaml:"name"`
 	Sensitive bool   `yaml:"sensitive"`
 
-	// These could be swapped out with an inline bundle.ParameterDefinition
-	// from cnab-go, e.g. bundle.ParameterDefinition `yaml:",inline"`
-	Description string    `yaml:"description,omitempty"`
-	Destination *Location `yaml:"destination,omitempty"`
-	ApplyTo     []string  `yaml:"applyTo,omitempty"`
+	bundle.Parameter `yaml:",inline"`
 
-	Schema `yaml:",inline"`
-}
-
-type Schema struct {
-	Type             string        `yaml:"type"`
-	Default          interface{}   `yaml:"default,omitempty"`
-	Enum             []interface{} `yaml:"enum,omitempty"`
-	Required         bool          `yaml:"required"`
-	Minimum          *float64      `yaml:"minimum,omitempty"`
-	ExclusiveMinimum *float64      `yaml:"exclusiveMinimum,omitempty"`
-	Maximum          *float64      `yaml:"maximum,omitempty"`
-	ExclusiveMaximum *float64      `yaml:"exclusiveMaximum,omitempty"`
-	MinLength        *float64      `yaml:"minLength,omitempty"`
-	MaxLength        *float64      `yaml:"maxLength,omitempty"`
+	definition.Schema `yaml:",inline"`
 }
 
 type CredentialDefinition struct {
@@ -86,12 +72,7 @@ type CredentialDefinition struct {
 	Description string `yaml:"description,omitempty"`
 	Required    bool   `yaml:"required,omitempty"`
 
-	Location `yaml:",inline"`
-}
-
-type Location struct {
-	Path                string `yaml:"path,omitempty"`
-	EnvironmentVariable string `yaml:"env,omitempty"`
+	bundle.Location `yaml:",inline"`
 }
 
 type MappedImage struct {
@@ -121,12 +102,11 @@ type CustomActionDefinition struct {
 
 // OutputDefinition defines a single output for a CNAB
 type OutputDefinition struct {
-	Name        string   `yaml:"name"`
-	ApplyTo     []string `yaml:"applyTo,omitempty"`
-	Description string   `yaml:"description,omitempty"`
-	Sensitive   bool     `yaml:"sensitive"`
+	Name      string   `yaml:"name"`
+	ApplyTo   []string `yaml:"applyTo,omitempty"`
+	Sensitive bool     `yaml:"sensitive"`
 
-	Schema `yaml:",inline"`
+	definition.Schema `yaml:",inline"`
 }
 
 func (od *OutputDefinition) Validate() error {

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/bundle/definition"
 )
 
@@ -64,9 +63,9 @@ type ParameterDefinition struct {
 
 	// These fields represent a subset of bundle.Parameter as defined in deislabs/cnab-go,
 	// minus the 'Description' field (definition.Schema's will be used)
-	Definition  string           `yaml:"definition"`
-	ApplyTo     []string         `yaml:"applyTo,omitempty"`
-	Destination *bundle.Location `yaml:"destination,omitempty"`
+	Definition  string    `yaml:"definition"`
+	ApplyTo     []string  `yaml:"applyTo,omitempty"`
+	Destination *Location `yaml:"destination,omitempty"`
 
 	definition.Schema `yaml:",inline"`
 }
@@ -76,7 +75,14 @@ type CredentialDefinition struct {
 	Description string `yaml:"description,omitempty"`
 	Required    bool   `yaml:"required,omitempty"`
 
-	bundle.Location `yaml:",inline"`
+	Location `yaml:",inline"`
+}
+
+// TODO: use cnab-go's bundle.Location instead, once yaml tags have been added
+// Location represents a Parameter or Credential location in an InvocationImage
+type Location struct {
+	Path                string `yaml:"path,omitempty"`
+	EnvironmentVariable string `yaml:"env,omitempty"`
 }
 
 type MappedImage struct {

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -62,7 +62,11 @@ type ParameterDefinition struct {
 	Name      string `yaml:"name"`
 	Sensitive bool   `yaml:"sensitive"`
 
-	bundle.Parameter `yaml:",inline"`
+	// These fields represent a subset of bundle.Parameter as defined in deislabs/cnab-go,
+	// minus the 'Description' field (definition.Schema's will be used)
+	Definition  string           `yaml:"definition"`
+	ApplyTo     []string         `yaml:"applyTo,omitempty"`
+	Destination *bundle.Location `yaml:"destination,omitempty"`
 
 	definition.Schema `yaml:",inline"`
 }

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -314,7 +313,7 @@ func TestResolveCredential(t *testing.T) {
 		Credentials: []CredentialDefinition{
 			{
 				Name:     "password",
-				Location: bundle.Location{EnvironmentVariable: "PASSWORD"},
+				Location: Location{EnvironmentVariable: "PASSWORD"},
 			},
 		},
 	}

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
@@ -312,7 +314,7 @@ func TestResolveCredential(t *testing.T) {
 		Credentials: []CredentialDefinition{
 			{
 				Name:     "password",
-				Location: Location{EnvironmentVariable: "PASSWORD"},
+				Location: bundle.Location{EnvironmentVariable: "PASSWORD"},
 			},
 		},
 	}
@@ -602,15 +604,15 @@ func TestReadManifest_Validate_BundleOutput(t *testing.T) {
 
 	wantOutputs := []OutputDefinition{
 		{
-			Name:        "mysql-root-password",
-			Description: "The root MySQL password",
-			Schema: Schema{
-				Type: "string",
+			Name: "mysql-root-password",
+			Schema: definition.Schema{
+				Type:        "string",
+				Description: "The root MySQL password",
 			},
 		},
 		{
 			Name: "mysql-password",
-			Schema: Schema{
+			Schema: definition.Schema{
 				Type: "string",
 			},
 			ApplyTo: []string{

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -209,7 +209,7 @@ func TestPorter_buildBundle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "79e453dce77f9d7cbf96f580ac7cd0b34fa9bf2e28b9d89f4688502833e8e2ea", stamp.ManifestDigest)
 
-	debugParam, ok := bun.Parameters.Fields["porter-debug"]
+	debugParam, ok := bun.Parameters["porter-debug"]
 	require.True(t, ok, "porter-debug parameter was not defined")
 	assert.Equal(t, "PORTER_DEBUG", debugParam.Destination.EnvironmentVariable)
 	debugDef, ok := bun.Definitions["porter-debug"]
@@ -236,6 +236,6 @@ func TestPorter_paramRequired(t *testing.T) {
 	err = json.Unmarshal(bundleBytes, &bundle)
 	require.NoError(t, err)
 
-	require.NotContains(t, bundle.Parameters.Required, "command")
-	require.Contains(t, bundle.Parameters.Required, "command2")
+	require.False(t, bundle.Parameters["command"].Required, "expected command param to not be required")
+	require.True(t, bundle.Parameters["command2"].Required, "expected command2 param to be required")
 }

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -142,7 +142,7 @@ func (e *dependencyExecutioner) prepareDependency(dep *queuedDependency) error {
 
 	// Make a lookup of which parameters are defined in the dependent bundle
 	depParams := map[string]struct{}{}
-	for paramName := range depBun.Parameters.Fields {
+	for paramName := range depBun.Parameters {
 		depParams[paramName] = struct{}{}
 	}
 

--- a/pkg/porter/run.go
+++ b/pkg/porter/run.go
@@ -261,13 +261,17 @@ func (p *Porter) ApplyBundleOutputs(opts RunOptions, outputs map[string]string) 
 
 					outpath := filepath.Join(config.BundleOutputsDir, bundleOutput.Name)
 
+					outputType, ok, err := bundleOutput.Schema.GetType()
+					if !ok && err != nil {
+						return errors.Wrap(err, "unable to get output type")
+					}
+
 					// Create data structure with relevant data for use in listing/showing later
 					output := output.Output{
 						Name:      bundleOutput.Name,
 						Sensitive: bundleOutput.Sensitive,
-						// TODO: helper func to translate Type interface{} to string representation
-						// Type:      bundleOutput.Type,
-						Value: outputValue,
+						Type:      outputType,
+						Value:     outputValue,
 					}
 
 					data, err := output.JSONMarshal()

--- a/pkg/porter/run.go
+++ b/pkg/porter/run.go
@@ -265,8 +265,9 @@ func (p *Porter) ApplyBundleOutputs(opts RunOptions, outputs map[string]string) 
 					output := output.Output{
 						Name:      bundleOutput.Name,
 						Sensitive: bundleOutput.Sensitive,
-						Type:      bundleOutput.Type,
-						Value:     outputValue,
+						// TODO: helper func to translate Type interface{} to string representation
+						// Type:      bundleOutput.Type,
+						Value: outputValue,
 					}
 
 					data, err := output.JSONMarshal()

--- a/pkg/porter/run_test.go
+++ b/pkg/porter/run_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/deislabs/porter/pkg/config"
 	"github.com/deislabs/porter/pkg/context"
 	output "github.com/deislabs/porter/pkg/outputs"
+
+	"github.com/deislabs/cnab-go/bundle/definition"
 )
 
 func TestPorter_readMixinOutputs(t *testing.T) {
@@ -127,14 +129,14 @@ func TestApplyBundleOutputs_Some_Match(t *testing.T) {
 		Outputs: []config.OutputDefinition{
 			{
 				Name: "foo",
-				Schema: config.Schema{
+				Schema: definition.Schema{
 					Type: "string",
 				},
 				Sensitive: true,
 			},
 			{
 				Name: "123",
-				Schema: config.Schema{
+				Schema: definition.Schema{
 					Type: "string",
 				},
 				Sensitive: false,
@@ -225,7 +227,7 @@ func TestApplyBundleOutputs_ApplyTo_True(t *testing.T) {
 				ApplyTo: []string{
 					"install",
 				},
-				Schema: config.Schema{
+				Schema: definition.Schema{
 					Type: "string",
 				},
 				Sensitive: false,

--- a/pkg/porter/testdata/porter.yaml
+++ b/pkg/porter/testdata/porter.yaml
@@ -10,7 +10,6 @@ tag: deislabs/porter-hello-custom-bundle:latest
 credentials:
   - name: my-first-cred
     env: MY_FIRST_CRED
-    required: true
   - name: my-second-cred
     description: "My second cred"
     path: /path/to/my-second-cred
@@ -21,7 +20,6 @@ parameters:
     default: 9
     destination:
       env: MY_FIRST_PARAM
-    required: true
   - name: my-second-param
     description: "My second parameter"
     type: string

--- a/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
@@ -16,19 +16,21 @@ import (
 
 // Bundle is a CNAB metadata document
 type Bundle struct {
-	SchemaVersion    string                 `json:"schemaVersion" mapstructure:"schemaVersion"`
-	Name             string                 `json:"name" mapstructure:"name"`
-	Version          string                 `json:"version" mapstructure:"version"`
-	Description      string                 `json:"description" mapstructure:"description"`
-	Keywords         []string               `json:"keywords,omitempty" mapstructure:"keywords"`
-	Maintainers      []Maintainer           `json:"maintainers,omitempty" mapstructure:"maintainers"`
-	InvocationImages []InvocationImage      `json:"invocationImages" mapstructure:"invocationImages"`
-	Images           map[string]Image       `json:"images,omitempty" mapstructure:"images"`
-	Actions          map[string]Action      `json:"actions,omitempty" mapstructure:"actions"`
-	Parameters       *ParametersDefinition  `json:"parameters,omitempty" mapstructure:"parameters"`
-	Credentials      map[string]Credential  `json:"credentials,omitempty" mapstructure:"credentials"`
-	Outputs          *OutputsDefinition     `json:"outputs,omitempty" mapstructure:"outputs"`
-	Definitions      definition.Definitions `json:"definitions,omitempty" mapstructure:"definitions"`
+	SchemaVersion      string                 `json:"schemaVersion" mapstructure:"schemaVersion"`
+	Name               string                 `json:"name" mapstructure:"name"`
+	Version            string                 `json:"version" mapstructure:"version"`
+	Description        string                 `json:"description" mapstructure:"description"`
+	Keywords           []string               `json:"keywords,omitempty" mapstructure:"keywords"`
+	Maintainers        []Maintainer           `json:"maintainers,omitempty" mapstructure:"maintainers"`
+	InvocationImages   []InvocationImage      `json:"invocationImages" mapstructure:"invocationImages"`
+	Images             map[string]Image       `json:"images,omitempty" mapstructure:"images"`
+	Actions            map[string]Action      `json:"actions,omitempty" mapstructure:"actions"`
+	Parameters         map[string]Parameter   `json:"parameters,omitempty" mapstructure:"parameters"`
+	Credentials        map[string]Credential  `json:"credentials,omitempty" mapstructure:"credentials"`
+	Outputs            *OutputsDefinition     `json:"outputs,omitempty" mapstructure:"outputs"`
+	Definitions        definition.Definitions `json:"definitions,omitempty" mapstructure:"definitions"`
+	License            string                 `json:"license,omitempty" mapstructure:"license"`
+	RequiredExtensions []string               `json:"requiredExtensions,omitempty" mapstructure:"requiredExtensions"`
 
 	// Custom extension metadata is a named collection of auxiliary data whose
 	// meaning is defined outside of the CNAB specification.
@@ -79,7 +81,7 @@ type LocationRef struct {
 type BaseImage struct {
 	ImageType string            `json:"imageType" mapstructure:"imageType"`
 	Image     string            `json:"image" mapstructure:"image"`
-	Digest    string            `json:"digest,omitempty" mapstructure:"digest"`
+	Digest    string            `json:"contentDigest,omitempty" mapstructure:"contentDigest"`
 	Size      uint64            `json:"size,omitempty" mapstructure:"size"`
 	Labels    map[string]string `json:"labels,omitempty" mapstructure:"labels"`
 	MediaType string            `json:"mediaType,omitempty" mapstructure:"mediaType"`
@@ -96,7 +98,7 @@ type InvocationImage struct {
 	BaseImage `mapstructure:",squash"`
 }
 
-// Map that stores the relocated images
+// ImageRelocationMap stores the relocated images
 // The key is the Image in bundle.json and the value is the new Image
 // from the relocated registry
 type ImageRelocationMap map[string]string
@@ -137,22 +139,13 @@ type Action struct {
 func ValuesOrDefaults(vals map[string]interface{}, currentVals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 
-	if b.Parameters == nil {
-		return res, nil
-	}
-
-	requiredMap := map[string]struct{}{}
-	for _, key := range b.Parameters.Required {
-		requiredMap[key] = struct{}{}
-	}
-
-	for name, def := range b.Parameters.Fields {
-		s, ok := b.Definitions[def.Definition]
+	for name, param := range b.Parameters {
+		s, ok := b.Definitions[param.Definition]
 		if !ok {
 			return res, fmt.Errorf("unable to find definition for %s", name)
 		}
 		if val, ok := vals[name]; ok {
-			if currentVal, ok := currentVals[name]; def.Immutable && ok && currentVal != val {
+			if currentVal, ok := currentVals[name]; param.Immutable && ok && currentVal != val {
 				return res, fmt.Errorf("parameter %s is immutable and cannot be overridden with value %v", name, val)
 			}
 			valErrs, err := s.Validate(val)
@@ -168,7 +161,7 @@ func ValuesOrDefaults(vals map[string]interface{}, currentVals map[string]interf
 			typedVal := s.CoerceValue(val)
 			res[name] = typedVal
 			continue
-		} else if _, ok := requiredMap[name]; ok {
+		} else if param.Required {
 			return res, fmt.Errorf("parameter %q is required", name)
 		}
 		res[name] = s.Default
@@ -189,6 +182,22 @@ func (b Bundle) Validate() error {
 
 	if b.Version == "latest" {
 		return errors.New("'latest' is not a valid bundle version")
+	}
+
+	reqExt := make(map[string]bool, len(b.RequiredExtensions))
+	for _, requiredExtension := range b.RequiredExtensions {
+		// Verify the custom extension declared as required exists
+		if _, exists := b.Custom[requiredExtension]; !exists {
+			return fmt.Errorf("required extension '%s' is not defined in the Custom section of the bundle", requiredExtension)
+		}
+
+		// Check for duplicate entries
+		if _, exists := reqExt[requiredExtension]; exists {
+			return fmt.Errorf("required extension '%s' is already declared", requiredExtension)
+		}
+
+		// Populate map with required extension, for duplicate check above
+		reqExt[requiredExtension] = true
 	}
 
 	for _, img := range b.InvocationImages {

--- a/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
@@ -135,8 +135,8 @@ type Action struct {
 }
 
 // ValuesOrDefaults returns parameter values or the default parameter values. An error is returned when the parameter value does not pass
-// the schema validation, a required parameter is missing or an immutable parameter is set with a new value.
-func ValuesOrDefaults(vals map[string]interface{}, currentVals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
+// the schema validation or a required parameter is missing.
+func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 
 	for name, param := range b.Parameters {
@@ -145,9 +145,6 @@ func ValuesOrDefaults(vals map[string]interface{}, currentVals map[string]interf
 			return res, fmt.Errorf("unable to find definition for %s", name)
 		}
 		if val, ok := vals[name]; ok {
-			if currentVal, ok := currentVals[name]; param.Immutable && ok && currentVal != val {
-				return res, fmt.Errorf("parameter %s is immutable and cannot be overridden with value %v", name, val)
-			}
 			valErrs, err := s.Validate(val)
 			if err != nil {
 				return res, pkgErrors.Wrapf(err, "encountered an error validating parameter %s", name)

--- a/vendor/github.com/deislabs/cnab-go/bundle/definition/schema.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/definition/schema.go
@@ -13,50 +13,51 @@ type Definitions map[string]*Schema
 
 // Schema represents a JSON Schema compatible CNAB Definition
 type Schema struct {
-	Comment              string                 `json:"$comment,omitempty" mapstructure:"$comment,omitempty"`
-	ID                   string                 `json:"$id,omitempty" mapstructure:"$ref,omitempty"`
-	Ref                  string                 `json:"$ref,omitempty" mapstructure:"$ref,omitempty"`
-	AdditionalItems      interface{}            `json:"additionalItems,omitempty" mapstructure:"additionalProperties,omitempty"`
-	AdditionalProperties interface{}            `json:"additionalProperties,omitempty" mapstructure:"additionalProperties,omitempty"`
-	AllOf                []*Schema              `json:"allOf,omitempty" mapstructure:"allOf,omitempty"`
-	Const                interface{}            `json:"const,omitempty" mapstructure:"const,omitempty"`
-	Contains             *Schema                `json:"contains,omitempty" mapstructure:"contains,omitempty"`
-	ContentEncoding      string                 `json:"contentEncoding,omitempty" mapstructure:"contentEncoding,omitempty"`
-	ContentMediaType     string                 `json:"contentMediaType,omitempty" mapstructure:"contentMediaType,omitempty"`
-	Default              interface{}            `json:"default,omitempty" mapstructure:"default,omitempty"`
-	Definitions          Definitions            `json:"definitions,omitempty" mapstructure:"definitions,omitempty"`
-	Dependencies         map[string]interface{} `json:"dependencies,omitempty" mapstructure:"dependencies,omitempty"`
-	Description          string                 `json:"description,omitempty" mapstructure:"description,omitempty"`
-	Else                 *Schema                `json:"else,omitempty" mapstructure:"else,omitempty"`
-	Enum                 []interface{}          `json:"enum,omitempty" mapstructure:"enum,omitempty"`
-	Examples             []interface{}          `json:"examples,omitempty" mapstructure:"examples,omitempty"`
-	ExclusiveMaximum     *float64               `json:"exclusiveMaximum,omitempty" mapstructure:"exclusiveMaximum,omitempty"`
-	ExclusiveMinimum     *float64               `json:"exclusiveMinimum,omitempty" mapstructure:"exclusiveMinimum,omitempty"`
-	Format               string                 `json:"format,omitempty" mapstructure:"format,omitempty"`
-	If                   *Schema                `json:"if,omitempty" mapstructure:"if,omitempty"`
+	Schema               string                 `json:"$schema,omitempty" yaml:"$schema,omitempty" mapstructure:"$schema,omitempty"`
+	Comment              string                 `json:"$comment,omitempty" yaml:"$comment,omitempty" mapstructure:"$comment,omitempty"`
+	ID                   string                 `json:"$id,omitempty" yaml:"$id,omitempty" mapstructure:"$id,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty" yaml:"$ref,omitempty" mapstructure:"$ref,omitempty"`
+	AdditionalItems      interface{}            `json:"additionalItems,omitempty" yaml:"additionalItems,omitempty" mapstructure:"additionalItems,omitempty"`
+	AdditionalProperties interface{}            `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty" mapstructure:"additionalProperties,omitempty"`
+	AllOf                []*Schema              `json:"allOf,omitempty" yaml:"allOf,omitempty" mapstructure:"allOf,omitempty"`
+	Const                interface{}            `json:"const,omitempty" yaml:"const,omitempty" mapstructure:"const,omitempty"`
+	Contains             *Schema                `json:"contains,omitempty" yaml:"contains,omitempty" mapstructure:"contains,omitempty"`
+	ContentEncoding      string                 `json:"contentEncoding,omitempty" yaml:"contentEncoding,omitempty" mapstructure:"contentEncoding,omitempty"`
+	ContentMediaType     string                 `json:"contentMediaType,omitempty" yaml:"contentMediaType,omitempty" mapstructure:"contentMediaType,omitempty"`
+	Default              interface{}            `json:"default,omitempty" yaml:"default,omitempty" mapstructure:"default,omitempty"`
+	Definitions          Definitions            `json:"definitions,omitempty" yaml:"definitions,omitempty" mapstructure:"definitions,omitempty"`
+	Dependencies         map[string]interface{} `json:"dependencies,omitempty" yaml:"dependencies,omitempty" mapstructure:"dependencies,omitempty"`
+	Description          string                 `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Else                 *Schema                `json:"else,omitempty" yaml:"else,omitempty" mapstructure:"else,omitempty"`
+	Enum                 []interface{}          `json:"enum,omitempty" yaml:"enum,omitempty" mapstructure:"enum,omitempty"`
+	Examples             []interface{}          `json:"examples,omitempty" yaml:"examples,omitempty" mapstructure:"examples,omitempty"`
+	ExclusiveMaximum     *float64               `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty" mapstructure:"exclusiveMaximum,omitempty"`
+	ExclusiveMinimum     *float64               `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty" mapstructure:"exclusiveMinimum,omitempty"`
+	Format               string                 `json:"format,omitempty" yaml:"format,omitempty" mapstructure:"format,omitempty"`
+	If                   *Schema                `json:"if,omitempty" yaml:"if,omitempty" mapstructure:"if,omitempty"`
 	//Items can be a Schema or an Array of Schema :(
-	Items         interface{} `json:"items,omitempty" mapstructure:"items,omitempty"`
-	Maximum       *float64    `json:"maximum,omitempty" mapstructure:"maximum,omitempty"`
-	MaxLength     *float64    `json:"maxLength,omitempty" mapstructure:"maxLength,omitempty"`
-	MinItems      *float64    `json:"minItems,omitempty" mapstructure:"minItems,omitempty"`
-	MinLength     *float64    `json:"minLength,omitempty" mapstructure:"minLength,omitempty"`
-	MinProperties *float64    `json:"minProperties,omitempty" mapstructure:"minProperties,omitempty"`
-	Minimum       *float64    `json:"minimum,omitempty" mapstructure:"minimum,omitempty"`
-	MultipleOf    *float64    `json:"multipleOf,omitempty" mapstructure:"multipleOf,omitempty"`
-	Not           *Schema     `json:"not,omitempty" mapstructure:"not,omitempty"`
-	OneOf         *Schema     `json:"oneOf,omitempty" mapstructure:"oneOf,omitempty"`
+	Items         interface{} `json:"items,omitempty" yaml:"items,omitempty" mapstructure:"items,omitempty"`
+	Maximum       *float64    `json:"maximum,omitempty" yaml:"maximum,omitempty" mapstructure:"maximum,omitempty"`
+	MaxLength     *float64    `json:"maxLength,omitempty" yaml:"maxLength,omitempty" mapstructure:"maxLength,omitempty"`
+	MinItems      *float64    `json:"minItems,omitempty" yaml:"minItems,omitempty" mapstructure:"minItems,omitempty"`
+	MinLength     *float64    `json:"minLength,omitempty" yaml:"minLength,omitempty" mapstructure:"minLength,omitempty"`
+	MinProperties *float64    `json:"minProperties,omitempty" yaml:"minProperties,omitempty" mapstructure:"minProperties,omitempty"`
+	Minimum       *float64    `json:"minimum,omitempty" yaml:"minimum,omitempty" mapstructure:"minimum,omitempty"`
+	MultipleOf    *float64    `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty" mapstructure:"multipleOf,omitempty"`
+	Not           *Schema     `json:"not,omitempty" yaml:"not,omitempty" mapstructure:"not,omitempty"`
+	OneOf         *Schema     `json:"oneOf,omitempty" yaml:"oneOf,omitempty" mapstructure:"oneOf,omitempty"`
 
-	PatternProperties map[string]*Schema `json:"patternProperties,omitempty" mapstructure:"patternProperties,omitempty"`
+	PatternProperties map[string]*Schema `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty" mapstructure:"patternProperties,omitempty"`
 
-	Properties    map[string]*Schema `json:"properties,omitempty" mapstructure:"properties,omitempty"`
-	PropertyNames *Schema            `json:"propertyNames,omitempty" mapstructure:"propertyNames,omitempty"`
-	ReadOnly      *bool              `json:"readOnly,omitempty" mapstructure:"readOnly,omitempty"`
-	Required      []string           `json:"required,omitempty" mapstructure:"required,omitempty"`
-	Then          *Schema            `json:"then,omitempty" mapstructure:"then,omitempty"`
-	Title         string             `json:"title,omitempty" mapstructure:"title,omitempty"`
-	Type          interface{}        `json:"type,omitempty" mapstructure:"type,omitempty"`
-	UniqueItems   *bool              `json:"uniqueItems,omitempty" mapstructure:"uniqueItems,omitempty"`
-	WriteOnly     *bool              `json:"writeOnly,omitempty" mapstructure:"writeOnly,omitempty"`
+	Properties    map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty" mapstructure:"properties,omitempty"`
+	PropertyNames *Schema            `json:"propertyNames,omitempty" yaml:"propertyNames,omitempty" mapstructure:"propertyNames,omitempty"`
+	ReadOnly      *bool              `json:"readOnly,omitempty" yaml:"readOnly,omitempty" mapstructure:"readOnly,omitempty"`
+	Required      []string           `json:"required,omitempty" yaml:"required,omitempty" mapstructure:"required,omitempty"`
+	Then          *Schema            `json:"then,omitempty" yaml:"then,omitempty" mapstructure:"then,omitempty"`
+	Title         string             `json:"title,omitempty" yaml:"title,omitempty" mapstructure:"title,omitempty"`
+	Type          interface{}        `json:"type,omitempty" yaml:"type,omitempty" mapstructure:"type,omitempty"`
+	UniqueItems   *bool              `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty" mapstructure:"uniqueItems,omitempty"`
+	WriteOnly     *bool              `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty" mapstructure:"writeOnly,omitempty"`
 }
 
 // GetType will return the singular type for a given schema and a success boolean. If the

--- a/vendor/github.com/deislabs/cnab-go/bundle/outputs.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/outputs.go
@@ -8,5 +8,5 @@ type OutputDefinition struct {
 	Definition  string   `json:"definition" mapstructure:"definition"`
 	ApplyTo     []string `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
 	Description string   `json:"description,omitempty" mapstructure:"description"`
-	Path        string   `json:"path,omitemtpty" mapstructure:"path,omitempty"`
+	Path        string   `json:"path" mapstructure:"path"`
 }

--- a/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
@@ -1,15 +1,11 @@
 package bundle
 
-type ParametersDefinition struct {
-	Fields   map[string]ParameterDefinition `json:"fields" mapstructure:"fields"`
-	Required []string                       `json:"required,omitempty" mapstructure:"required,omitempty"`
-}
-
-// ParameterDefinition defines a single parameter for a CNAB bundle
-type ParameterDefinition struct {
+// Parameter defines a single parameter for a CNAB bundle
+type Parameter struct {
 	Definition  string    `json:"definition" mapstructure:"definition"`
 	ApplyTo     []string  `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
 	Description string    `json:"description,omitempty" mapstructure:"description"`
 	Destination *Location `json:"destination,omitemtpty" mapstructure:"destination"`
 	Immutable   bool      `json:"immutable,omitempty" mapstructure:"immutable,omitempty"`
+	Required    bool      `json:"required,omitempty" mapstructure:"required,omitempty"`
 }

--- a/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
@@ -6,6 +6,5 @@ type Parameter struct {
 	ApplyTo     []string  `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
 	Description string    `json:"description,omitempty" mapstructure:"description"`
 	Destination *Location `json:"destination,omitemtpty" mapstructure:"destination"`
-	Immutable   bool      `json:"immutable,omitempty" mapstructure:"immutable,omitempty"`
 	Required    bool      `json:"required,omitempty" mapstructure:"required,omitempty"`
 }

--- a/vendor/github.com/deislabs/cnab-go/claim/claim.go
+++ b/vendor/github.com/deislabs/cnab-go/claim/claim.go
@@ -43,7 +43,6 @@ type Claim struct {
 	Result        Result                    `json:"result"`
 	Parameters    map[string]interface{}    `json:"parameters"`
 	Outputs       map[string]interface{}    `json:"outputs"`
-	Files         map[string]string         `json:"files"`
 	RelocationMap bundle.ImageRelocationMap `json:"relocationMap"`
 }
 

--- a/vendor/github.com/deislabs/cnab-go/driver/command/command_windows.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/command/command_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CheckDriverExists checks to see if the named driver exists
-func (d *CommandDriver) CheckDriverExists() bool {
+func (d *Driver) CheckDriverExists() bool {
 	cmd := exec.Command("where", d.cliName())
 	cmd.Env = os.Environ()
 	if err := cmd.Run(); err != nil {

--- a/vendor/github.com/docker/cnab-to-oci/converter/types.go
+++ b/vendor/github.com/docker/cnab-to-oci/converter/types.go
@@ -23,7 +23,7 @@ type BundleConfig struct {
 	SchemaVersion string                       `json:"schemaVersion" mapstructure:"schemaVersion"`
 	Actions       map[string]bundle.Action     `json:"actions,omitempty" mapstructure:"actions,omitempty"`
 	Definitions   definition.Definitions       `json:"definitions" mapstructure:"definitions"`
-	Parameters    *bundle.ParametersDefinition `json:"parameters" mapstructure:"parameters"`
+	Parameters    map[string]bundle.Parameter  `json:"parameters" mapstructure:"parameters"`
 	Credentials   map[string]bundle.Credential `json:"credentials" mapstructure:"credentials"`
 	Custom        map[string]interface{}       `json:"custom,omitempty" mapstructure:"custom"`
 }


### PR DESCRIPTION
Updates Porter to allow full support for JSON Schema (via cnab-go) in parameter definitions.

Also,
- removes Porter's own `Required` field for a Parameter.  This was motivated due to a conflict with cnab-go's `Schema` struct, which has a `Required` field of type `[]string`.  We embed/in-line the `Schema` struct, so there may be only one of this key.  Porter still defaults `Required` to `true` on the generated cnab-go `bundle.Parameter` struct, for any parameter that has no default specified, but we no longer expose the ability for a manifest author to supply this value.

Depends on ~~https://github.com/deislabs/cnab-go/pull/90 and https://github.com/docker/cnab-to-oci/pull/57 (Need to remove overrides/fork revisions from `Gopkg.toml`)~~ https://github.com/deislabs/porter/pull/505

Closes https://github.com/deislabs/porter/issues/444
