### PR TITLE
WIP chore(*): bump cnab-go dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -222,7 +222,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:9f60acd7d2ca0060ebd9064d616b4a09c8906aff099897273fffb2ec81f04815"
+  digest = "1:a85ff738c30a346b7022036c7234fea980ef84340ed848f62fcd7d964f3f87d6"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -234,8 +234,8 @@
     "utils/crud",
   ]
   pruneopts = "NT"
-  revision = "d0e47f49ea9a4ef8aedf1043b11ffa7506fc10d7"
-  version = "v0.2.0-beta1"
+  revision = "c992a169ba13fb2f36857dbddfb45e6790400758"
+  version = "v0.3.0-beta1"
 
 [[projects]]
   digest = "1:4f1e6f901178a2f34620772c5431e8cbf157db97e6dc6c663d8ea760e265920c"
@@ -1480,6 +1480,7 @@
     "github.com/docker/go-metrics",
     "github.com/ghodss/yaml",
     "github.com/gobuffalo/packr/v2",
+    "github.com/gobuffalo/packr/v2/file/resolver",
     "github.com/hashicorp/go-multierror",
     "github.com/mmcdole/gofeed/atom",
     "github.com/olekukonko/tablewriter",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,12 +5,12 @@
 
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  version = "0.2.0-beta.1"
+  version = "0.3.0-beta.1"
 
 # override currently needed or else cnab-to-oci dep causes issues
 [[override]]
   name = "github.com/deislabs/cnab-go"
-  version = "0.2.0-beta.1"
+  version = "0.3.0-beta.1"
 
 # Using master until there is a release of cnab-to-oci
 [[constraint]]

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -119,10 +119,9 @@ func (c *ManifestConverter) generateDefaultAction(action string) bundle.Action {
 	}
 }
 
-func (c *ManifestConverter) generateBundleParameters(defs *definition.Definitions) *bundle.ParametersDefinition {
-	params := &bundle.ParametersDefinition{
-		Fields: make(map[string]bundle.ParameterDefinition, len(c.Manifest.Parameters)),
-	}
+func (c *ManifestConverter) generateBundleParameters(defs *definition.Definitions) map[string]bundle.Parameter {
+	params := make(map[string]bundle.Parameter, len(c.Manifest.Parameters))
+
 	for _, param := range append(c.Manifest.Parameters, c.buildDefaultPorterParameters()...) {
 		fmt.Fprintf(c.Out, "Generating parameter definition %s ====>\n", param.Name)
 		d := &definition.Schema{
@@ -136,7 +135,7 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 			MinLength:        param.MinLength,
 			MaxLength:        param.MaxLength,
 		}
-		p := bundle.ParameterDefinition{
+		p := bundle.Parameter{
 			Definition:  param.Name,
 			Description: param.Description,
 			ApplyTo:     param.ApplyTo,
@@ -144,7 +143,7 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 
 		// If the default is empty, set required to true.
 		if param.Default == nil {
-			params.Required = append(params.Required, param.Name)
+			p.Required = true
 		}
 
 		if param.Destination != nil {
@@ -163,18 +162,16 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 		if _, exists := (*defs)[param.Name]; !exists {
 			(*defs)[param.Name] = d
 		}
-		params.Fields[param.Name] = p
+		params[param.Name] = p
 	}
 	return params
 }
 
-func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) *bundle.OutputsDefinition {
-	var outputs *bundle.OutputsDefinition
+func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) map[string]bundle.Output {
+	var outputs map[string]bundle.Output
 
 	if len(c.Manifest.Outputs) > 0 {
-		outputs = &bundle.OutputsDefinition{
-			Fields: make(map[string]bundle.OutputDefinition, len(c.Manifest.Outputs)),
-		}
+		outputs = make(map[string]bundle.Output, len(c.Manifest.Outputs))
 
 		for _, output := range c.Manifest.Outputs {
 			fmt.Fprintf(c.Out, "Generating output definition %s ====>\n", output.Name)
@@ -187,7 +184,7 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 				MinLength: output.MinLength,
 				MaxLength: output.MaxLength,
 			}
-			o := bundle.OutputDefinition{
+			o := bundle.Output{
 				Definition:  output.Name,
 				Description: output.Description,
 				ApplyTo:     output.ApplyTo,
@@ -199,7 +196,7 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 			if _, exists := (*defs)[output.Name]; !exists {
 				(*defs)[output.Name] = d
 			}
-			outputs.Fields[output.Name] = o
+			outputs[output.Name] = o
 		}
 	}
 	return outputs

--- a/pkg/cnab/provider/claims.go
+++ b/pkg/cnab/provider/claims.go
@@ -1,17 +1,23 @@
 package cnabprovider
 
 import (
+	"path/filepath"
+
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/utils/crud"
-	"github.com/deislabs/duffle/pkg/duffle/home"
 	"github.com/pkg/errors"
+)
+
+const (
+	// ClaimsDirectory represents the name of the directory where claims are stored
+	ClaimsDirectory = "claims"
 )
 
 func (d *Duffle) NewClaimStore() claim.Store {
 	// TODO: I'm going to submit a PR after this so that GetHomeDir doesn't return an error
 	homepath, _ := d.GetHomeDir()
-	h := home.Home(homepath)
-	return claim.NewClaimStore(crud.NewFileSystemStore(h.Claims(), "json"))
+	claimsPath := filepath.Join(homepath, ClaimsDirectory)
+	return claim.NewClaimStore(crud.NewFileSystemStore(claimsPath, "json"))
 }
 
 // FetchClaim fetches a claim from the given CNABProvider's claim store

--- a/pkg/cnab/provider/credentials.go
+++ b/pkg/cnab/provider/credentials.go
@@ -6,7 +6,11 @@ import (
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/credentials"
-	"github.com/deislabs/duffle/pkg/duffle/home"
+)
+
+const (
+	// CredentialsDirectory represents the name of the directory where credentials are stored
+	CredentialsDirectory = "credentials"
 )
 
 func (d *Duffle) loadCredentials(b *bundle.Bundle, files []string) (map[string]string, error) {
@@ -28,7 +32,8 @@ func (d *Duffle) loadCredentials(b *bundle.Bundle, files []string) (map[string]s
 		if !d.isPathy(file) {
 			// TODO: when we export this function, having an instance where we can set home manually
 			// instead of on an env var would be super helpful. I had to inject the homepath instead of using duffle's homepath function.
-			file = filepath.Join(home.Home(homepath).Credentials(), file+".yaml")
+			credsPath := filepath.Join(homepath, CredentialsDirectory)
+			file = filepath.Join(credsPath, file+".yaml")
 		}
 		cset, err := credentials.Load(file)
 		if err != nil {

--- a/pkg/cnab/provider/dockerdriver_test.go
+++ b/pkg/cnab/provider/dockerdriver_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	duffledriver "github.com/deislabs/duffle/pkg/driver"
+	dockerdriver "github.com/deislabs/cnab-go/driver/docker"
 	"github.com/deislabs/porter/pkg/config"
 )
 
@@ -16,10 +16,10 @@ func TestNewDriver_Docker(t *testing.T) {
 	driver, err := d.newDriver("docker", "myclaim")
 	require.NoError(t, err)
 
-	if _, ok := driver.(*duffledriver.DockerDriver); ok {
+	if _, ok := driver.(*dockerdriver.Driver); ok {
 		// TODO: check dockerConfigurationOptions to verify expected bind mount setup,
-		// once we're able to (add ability to duffledriver pkg)
+		// once we're able to (add ability to dockerdriver pkg)
 	} else {
-		t.Fatal("expected driver to be of type *duffledriver.DockerDriver")
+		t.Fatal("expected driver to be of type *dockerdriver.Driver")
 	}
 }

--- a/pkg/cnab/provider/duffle.go
+++ b/pkg/cnab/provider/duffle.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/driver"
+	dockerdriver "github.com/deislabs/cnab-go/driver/docker"
 	duffledriver "github.com/deislabs/duffle/pkg/driver"
 	"github.com/deislabs/porter/pkg/config"
 	"github.com/deislabs/porter/pkg/outputs"
@@ -51,7 +52,7 @@ func (d *Duffle) newDriver(driverName, claimName string) (driver.Driver, error) 
 
 func (d *Duffle) setupOutputsMount(driverImpl driver.Driver, claimName string) error {
 	// If docker driver, setup host bind mount for outputs
-	if dockerish, ok := driverImpl.(*duffledriver.DockerDriver); ok {
+	if dockerish, ok := driverImpl.(*dockerdriver.Driver); ok {
 		outputsDir, err := d.Config.GetOutputsDir()
 		if err != nil {
 			return errors.Wrap(err, "unable to get outputs directory")
@@ -64,7 +65,7 @@ func (d *Duffle) setupOutputsMount(driverImpl driver.Driver, claimName string) e
 			return errors.Wrapf(err, "could not create outputs directory %s for docker driver bind mount", bundleOutputsDir)
 		}
 
-		var cfgOpt duffledriver.DockerConfigurationOption = func(containerCfg *container.Config, hostCfg *container.HostConfig) error {
+		var cfgOpt dockerdriver.ConfigurationOption = func(containerCfg *container.Config, hostCfg *container.HostConfig) error {
 			outputsMount := mount.Mount{
 				Type:   mount.TypeBind,
 				Source: bundleOutputsDir,

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -294,16 +294,15 @@ func (o *sharedOptions) combineParameters() map[string]string {
 	return final
 }
 
-// Validate that the provided driver is supported
+// defaultDriver supplies the default driver if none is specified
 func (o *sharedOptions) defaultDriver() {
 	if o.Driver == "" {
 		o.Driver = DefaultDriver
 	}
 }
 
-// Validate that the provided driver is supported
+// validateDriver validates that the provided driver is supported by Porter
 func (o *sharedOptions) validateDriver() error {
-	// Not using duffle's driver.Lookup() as it currently does not return an error on invalid drivers
 	switch o.Driver {
 	case "docker", "debug":
 		return nil

--- a/vendor/github.com/deislabs/cnab-go/action/action.go
+++ b/vendor/github.com/deislabs/cnab-go/action/action.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 
 	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/bundle/definition"
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/deislabs/cnab-go/driver"
@@ -27,6 +29,129 @@ const stateful = false
 type Action interface {
 	// Run an action, and record the status in the given claim
 	Run(*claim.Claim, credentials.Set, io.Writer) error
+}
+
+func golangTypeToJSONType(value interface{}) (string, error) {
+	switch v := value.(type) {
+	case nil:
+		return "null", nil
+	case bool:
+		return "boolean", nil
+	case float64:
+		// All numeric values are parsed by JSON into float64s. When a value could be an integer, it could also be a number, so give the more specific answer.
+		if math.Trunc(v) == v {
+			return "integer", nil
+		}
+		return "number", nil
+	case string:
+		return "string", nil
+	case map[string]interface{}:
+		return "object", nil
+	case []interface{}:
+		return "array", nil
+	default:
+		return fmt.Sprintf("%T", value), fmt.Errorf("unsupported type: %T", value)
+	}
+}
+
+// allowedTypes takes an output Schema and returns a map of the allowed types (to true)
+// or an error (if reading the allowed types from the schema failed).
+func allowedTypes(outputSchema definition.Schema) (map[string]bool, error) {
+	var outputTypes []string
+	mapOutputTypes := map[string]bool{}
+
+	// Get list of one or more allowed types for this output
+	outputType, ok, err1 := outputSchema.GetType()
+	if !ok { // there are multiple types
+		var err2 error
+		outputTypes, ok, err2 = outputSchema.GetTypes()
+		if !ok {
+			return mapOutputTypes, fmt.Errorf("Getting a single type errored with %q and getting multiple types errored with %q", err1, err2)
+		}
+	} else {
+		outputTypes = []string{outputType}
+	}
+
+	// Turn allowed outputs into map for easier membership checking
+	for _, v := range outputTypes {
+		mapOutputTypes[v] = true
+	}
+
+	// All integers make acceptable numbers, and our helper function provides the most specific type.
+	if mapOutputTypes["number"] {
+		mapOutputTypes["integer"] = true
+	}
+
+	return mapOutputTypes, nil
+}
+
+// keys takes a map and returns the keys joined into a comma-separate string.
+func keys(stringMap map[string]bool) string {
+	var keys []string
+	for k := range stringMap {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ",")
+}
+
+// isTypeOK uses the content and allowedTypes arguments to make sure the content of an output file matches one of the allowed types.
+// The other arguments (name and allowedTypesList) are used when assembling error messages.
+func isTypeOk(name, content string, allowedTypes map[string]bool) error {
+	if !allowedTypes["string"] { // String output types are always passed through as the escape hatch for non-JSON bundle outputs.
+		var value interface{}
+		if err := json.Unmarshal([]byte(content), &value); err != nil {
+			return fmt.Errorf("failed to parse %q: %s", name, err)
+		}
+
+		v, err := golangTypeToJSONType(value)
+		if err != nil {
+			return fmt.Errorf("%q is not a known JSON type. Expected %q to be one of: %s", name, v, keys(allowedTypes))
+		}
+		if !allowedTypes[v] {
+			return fmt.Errorf("%q is not any of the expected types (%s) because it is %q", name, keys(allowedTypes), v)
+		}
+	}
+	return nil
+}
+
+func setOutputsOnClaim(claim *claim.Claim, outputs map[string]string) error {
+	var outputErrors []error
+	claim.Outputs = map[string]interface{}{}
+
+	if claim.Bundle.Outputs == nil {
+		return nil
+	}
+
+	for outputName, v := range claim.Bundle.Outputs {
+		name := v.Definition
+		if name == "" {
+			return fmt.Errorf("invalid bundle: no definition set for output %q", outputName)
+		}
+
+		outputSchema := claim.Bundle.Definitions[name]
+		if outputSchema == nil {
+			return fmt.Errorf("invalid bundle: output %q references definition %q, which was not found", outputName, name)
+		}
+		outputTypes, err := allowedTypes(*outputSchema)
+		if err != nil {
+			return err
+		}
+
+		content := outputs[v.Path]
+		if content != "" {
+			err := isTypeOk(outputName, content, outputTypes)
+			if err != nil {
+				outputErrors = append(outputErrors, err)
+			}
+			claim.Outputs[outputName] = outputs[v.Path]
+		}
+	}
+
+	if len(outputErrors) > 0 {
+		return fmt.Errorf("error: %s", outputErrors)
+	}
+
+	return nil
 }
 
 func selectInvocationImage(d driver.Driver, c *claim.Claim) (bundle.InvocationImage, error) {
@@ -56,7 +181,7 @@ func getImageMap(b *bundle.Bundle) ([]byte, error) {
 	return json.Marshal(imgs)
 }
 
-func appliesToAction(action string, parameter bundle.ParameterDefinition) bool {
+func appliesToAction(action string, parameter bundle.Parameter) bool {
 	if len(parameter.ApplyTo) == 0 {
 		return true
 	}
@@ -76,15 +201,13 @@ func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.Invoca
 
 	// Quick verification that no params were passed that are not actual legit params.
 	for key := range c.Parameters {
-		if _, ok := c.Bundle.Parameters.Fields[key]; !ok {
+		if _, ok := c.Bundle.Parameters[key]; !ok {
 			return nil, fmt.Errorf("undefined parameter %q", key)
 		}
 	}
 
-	if c.Bundle.Parameters != nil {
-		if err := injectParameters(action, c, env, files); err != nil {
-			return nil, err
-		}
+	if err := injectParameters(action, c, env, files); err != nil {
+		return nil, err
 	}
 
 	imgMap, err := getImageMap(c.Bundle)
@@ -98,6 +221,13 @@ func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.Invoca
 	env["CNAB_BUNDLE_NAME"] = c.Bundle.Name
 	env["CNAB_BUNDLE_VERSION"] = c.Bundle.Version
 
+	var outputs []string
+	if c.Bundle.Outputs != nil {
+		for _, v := range c.Bundle.Outputs {
+			outputs = append(outputs, v.Path)
+		}
+	}
+
 	return &driver.Operation{
 		Action:       action,
 		Installation: c.Name,
@@ -107,20 +237,16 @@ func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.Invoca
 		Revision:     c.Revision,
 		Environment:  env,
 		Files:        files,
+		Outputs:      outputs,
 		Out:          w,
 	}, nil
 }
 
 func injectParameters(action string, c *claim.Claim, env, files map[string]string) error {
-	requiredMap := map[string]struct{}{}
-	for _, key := range c.Bundle.Parameters.Required {
-		requiredMap[key] = struct{}{}
-	}
-	for k, param := range c.Bundle.Parameters.Fields {
+	for k, param := range c.Bundle.Parameters {
 		rawval, ok := c.Parameters[k]
 		if !ok {
-			_, required := requiredMap[k]
-			if required && appliesToAction(action, param) {
+			if param.Required && appliesToAction(action, param) {
 				return fmt.Errorf("missing required parameter %q for action %q", k, action)
 			}
 			continue

--- a/vendor/github.com/deislabs/cnab-go/action/install.go
+++ b/vendor/github.com/deislabs/cnab-go/action/install.go
@@ -24,13 +24,18 @@ func (i *Install) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error 
 	if err != nil {
 		return err
 	}
-	if err := i.Driver.Run(op); err != nil {
+
+	opResult, err := i.Driver.Run(op)
+
+	// update outputs in claim even if there were errors so users can see the output files.
+	outputErrors := setOutputsOnClaim(c, opResult.Outputs)
+
+	if err != nil {
 		c.Update(claim.ActionInstall, claim.StatusFailure)
 		c.Result.Message = err.Error()
 		return err
 	}
-
-	// Update claim:
 	c.Update(claim.ActionInstall, claim.StatusSuccess)
-	return nil
+
+	return outputErrors
 }

--- a/vendor/github.com/deislabs/cnab-go/action/run_custom.go
+++ b/vendor/github.com/deislabs/cnab-go/action/run_custom.go
@@ -48,7 +48,7 @@ func (i *RunCustom) Run(c *claim.Claim, creds credentials.Set, w io.Writer) erro
 		return err
 	}
 
-	err = i.Driver.Run(op)
+	opResult, err := i.Driver.Run(op)
 
 	// If this action says it does not modify the release, then we don't track
 	// it in the claim. Otherwise, we do.
@@ -56,12 +56,15 @@ func (i *RunCustom) Run(c *claim.Claim, creds credentials.Set, w io.Writer) erro
 		return err
 	}
 
-	status := claim.StatusSuccess
-	if err != nil {
-		c.Result.Message = err.Error()
-		status = claim.StatusFailure
-	}
+	// update outputs in claim even if there were errors so users can see the output files.
+	outputErrors := setOutputsOnClaim(c, opResult.Outputs)
 
-	c.Update(i.Action, status)
-	return err
+	if err != nil {
+		c.Update(i.Action, claim.StatusFailure)
+		c.Result.Message = err.Error()
+		return err
+	}
+	c.Update(i.Action, claim.StatusSuccess)
+
+	return outputErrors
 }

--- a/vendor/github.com/deislabs/cnab-go/action/status.go
+++ b/vendor/github.com/deislabs/cnab-go/action/status.go
@@ -24,5 +24,8 @@ func (i *Status) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return i.Driver.Run(op)
+
+	// Ignore OperationResult because non-modifying actions don't have outputs to save.
+	_, err = i.Driver.Run(op)
+	return err
 }

--- a/vendor/github.com/deislabs/cnab-go/action/uninstall.go
+++ b/vendor/github.com/deislabs/cnab-go/action/uninstall.go
@@ -24,12 +24,16 @@ func (u *Uninstall) Run(c *claim.Claim, creds credentials.Set, w io.Writer) erro
 	if err != nil {
 		return err
 	}
-	if err := u.Driver.Run(op); err != nil {
+
+	opResult, err := u.Driver.Run(op)
+	outputErrors := setOutputsOnClaim(c, opResult.Outputs)
+
+	if err != nil {
 		c.Update(claim.ActionUninstall, claim.StatusFailure)
 		c.Result.Message = err.Error()
 		return err
 	}
-
 	c.Update(claim.ActionUninstall, claim.StatusSuccess)
-	return nil
+
+	return outputErrors
 }

--- a/vendor/github.com/deislabs/cnab-go/action/upgrade.go
+++ b/vendor/github.com/deislabs/cnab-go/action/upgrade.go
@@ -24,12 +24,16 @@ func (u *Upgrade) Run(c *claim.Claim, creds credentials.Set, w io.Writer) error 
 	if err != nil {
 		return err
 	}
-	if err := u.Driver.Run(op); err != nil {
+
+	opResult, err := u.Driver.Run(op)
+	outputErrors := setOutputsOnClaim(c, opResult.Outputs)
+
+	if err != nil {
 		c.Update(claim.ActionUpgrade, claim.StatusFailure)
 		c.Result.Message = err.Error()
 		return err
 	}
-
 	c.Update(claim.ActionUpgrade, claim.StatusSuccess)
-	return nil
+
+	return outputErrors
 }

--- a/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/bundle.go
@@ -16,23 +16,25 @@ import (
 
 // Bundle is a CNAB metadata document
 type Bundle struct {
-	SchemaVersion    string                 `json:"schemaVersion" mapstructure:"schemaVersion"`
-	Name             string                 `json:"name" mapstructure:"name"`
-	Version          string                 `json:"version" mapstructure:"version"`
-	Description      string                 `json:"description" mapstructure:"description"`
-	Keywords         []string               `json:"keywords,omitempty" mapstructure:"keywords"`
-	Maintainers      []Maintainer           `json:"maintainers,omitempty" mapstructure:"maintainers"`
-	InvocationImages []InvocationImage      `json:"invocationImages" mapstructure:"invocationImages"`
-	Images           map[string]Image       `json:"images,omitempty" mapstructure:"images"`
-	Actions          map[string]Action      `json:"actions,omitempty" mapstructure:"actions"`
-	Parameters       *ParametersDefinition  `json:"parameters,omitempty" mapstructure:"parameters"`
-	Credentials      map[string]Credential  `json:"credentials,omitempty" mapstructure:"credentials"`
-	Outputs          *OutputsDefinition     `json:"outputs,omitempty" mapstructure:"outputs"`
-	Definitions      definition.Definitions `json:"definitions,omitempty" mapstructure:"definitions"`
+	SchemaVersion      string                 `json:"schemaVersion" yaml:"schemaVersion"`
+	Name               string                 `json:"name" yaml:"name"`
+	Version            string                 `json:"version" yaml:"version"`
+	Description        string                 `json:"description" yaml:"description"`
+	Keywords           []string               `json:"keywords,omitempty" yaml:"keywords,omitempty"`
+	Maintainers        []Maintainer           `json:"maintainers,omitempty" yaml:"maintainers,omitempty"`
+	InvocationImages   []InvocationImage      `json:"invocationImages" yaml:"invocationImages"`
+	Images             map[string]Image       `json:"images,omitempty" yaml:"images,omitempty"`
+	Actions            map[string]Action      `json:"actions,omitempty" yaml:"actions,omitempty"`
+	Parameters         map[string]Parameter   `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Credentials        map[string]Credential  `json:"credentials,omitempty" yaml:"credentials,omitempty"`
+	Outputs            map[string]Output      `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	Definitions        definition.Definitions `json:"definitions,omitempty" yaml:"definitions,omitempty"`
+	License            string                 `json:"license,omitempty" yaml:"license,omitempty"`
+	RequiredExtensions []string               `json:"requiredExtensions,omitempty" yaml:"requiredExtensions,omitempty"`
 
 	// Custom extension metadata is a named collection of auxiliary data whose
 	// meaning is defined outside of the CNAB specification.
-	Custom map[string]interface{} `json:"custom,omitempty" mapstructure:"custom"`
+	Custom map[string]interface{} `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
 //Unmarshal unmarshals a Bundle that was not signed.
@@ -70,33 +72,33 @@ func (b Bundle) WriteTo(w io.Writer) (int64, error) {
 
 // LocationRef specifies a location within the invocation package
 type LocationRef struct {
-	Path      string `json:"path" mapstructure:"path"`
-	Field     string `json:"field" mapstructure:"field"`
-	MediaType string `json:"mediaType" mapstructure:"mediaType"`
+	Path      string `json:"path" yaml:"path"`
+	Field     string `json:"field" yaml:"field"`
+	MediaType string `json:"mediaType" yaml:"mediaType"`
 }
 
 // BaseImage contains fields shared across image types
 type BaseImage struct {
-	ImageType string            `json:"imageType" mapstructure:"imageType"`
-	Image     string            `json:"image" mapstructure:"image"`
-	Digest    string            `json:"digest,omitempty" mapstructure:"digest"`
-	Size      uint64            `json:"size,omitempty" mapstructure:"size"`
-	Labels    map[string]string `json:"labels,omitempty" mapstructure:"labels"`
-	MediaType string            `json:"mediaType,omitempty" mapstructure:"mediaType"`
+	ImageType string            `json:"imageType" yaml:"imageType"`
+	Image     string            `json:"image" yaml:"image"`
+	Digest    string            `json:"contentDigest,omitempty" yaml:"contentDigest"`
+	Size      uint64            `json:"size,omitempty" yaml:"size,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	MediaType string            `json:"mediaType,omitempty" yaml:"mediaType,omitempty"`
 }
 
 // Image describes a container image in the bundle
 type Image struct {
-	BaseImage   `mapstructure:",squash"`
-	Description string `json:"description" mapstructure:"description"` //TODO: change? see where it's being used? change to description?
+	BaseImage   `yaml:",inline"`
+	Description string `json:"description" yaml:"description"` //TODO: change? see where it's being used? change to description?
 }
 
 // InvocationImage contains the image type and location for the installation of a bundle
 type InvocationImage struct {
-	BaseImage `mapstructure:",squash"`
+	BaseImage `yaml:",inline"`
 }
 
-// Map that stores the relocated images
+// ImageRelocationMap stores the relocated images
 // The key is the Image in bundle.json and the value is the new Image
 // from the relocated registry
 type ImageRelocationMap map[string]string
@@ -106,18 +108,18 @@ type ImageRelocationMap map[string]string
 //
 // A location may be either a file (by path) or an environment variable.
 type Location struct {
-	Path                string `json:"path,omitempty" mapstructure:"path"`
-	EnvironmentVariable string `json:"env,omitempty" mapstructure:"env"`
+	Path                string `json:"path,omitempty" yaml:"path,omitempty"`
+	EnvironmentVariable string `json:"env,omitempty" yaml:"env,omitempty"`
 }
 
 // Maintainer describes a code maintainer of a bundle
 type Maintainer struct {
 	// Name is a user name or organization name
-	Name string `json:"name" mapstructure:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Email is an optional email address to contact the named maintainer
-	Email string `json:"email,omitempty" mapstructure:"email"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
 	// Url is an optional URL to an address for the named maintainer
-	URL string `json:"url,omitempty" mapstructure:"url"`
+	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
 // Action describes a custom (non-core) action.
@@ -125,36 +127,24 @@ type Action struct {
 	// Modifies indicates whether this action modifies the release.
 	//
 	// If it is possible that an action modify a release, this must be set to true.
-	Modifies bool `json:"modifies,omitempty" mapstructure:"modifies"`
+	Modifies bool `json:"modifies,omitempty" yaml:"modifies,omitempty"`
 	// Stateless indicates that the action is purely informational, that credentials are not required, and that the runtime should not keep track of its invocation
-	Stateless bool `json:"stateless,omitempty" mapstructure:"stateless"`
+	Stateless bool `json:"stateless,omitempty" yaml:"stateless,omitempty"`
 	// Description describes the action as a user-readable string
-	Description string `json:"description,omitempty" mapstructure:"description"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // ValuesOrDefaults returns parameter values or the default parameter values. An error is returned when the parameter value does not pass
-// the schema validation, a required parameter is missing or an immutable parameter is set with a new value.
-func ValuesOrDefaults(vals map[string]interface{}, currentVals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
+// the schema validation or a required parameter is missing.
+func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 
-	if b.Parameters == nil {
-		return res, nil
-	}
-
-	requiredMap := map[string]struct{}{}
-	for _, key := range b.Parameters.Required {
-		requiredMap[key] = struct{}{}
-	}
-
-	for name, def := range b.Parameters.Fields {
-		s, ok := b.Definitions[def.Definition]
+	for name, param := range b.Parameters {
+		s, ok := b.Definitions[param.Definition]
 		if !ok {
 			return res, fmt.Errorf("unable to find definition for %s", name)
 		}
 		if val, ok := vals[name]; ok {
-			if currentVal, ok := currentVals[name]; def.Immutable && ok && currentVal != val {
-				return res, fmt.Errorf("parameter %s is immutable and cannot be overridden with value %v", name, val)
-			}
 			valErrs, err := s.Validate(val)
 			if err != nil {
 				return res, pkgErrors.Wrapf(err, "encountered an error validating parameter %s", name)
@@ -168,7 +158,7 @@ func ValuesOrDefaults(vals map[string]interface{}, currentVals map[string]interf
 			typedVal := s.CoerceValue(val)
 			res[name] = typedVal
 			continue
-		} else if _, ok := requiredMap[name]; ok {
+		} else if param.Required {
 			return res, fmt.Errorf("parameter %q is required", name)
 		}
 		res[name] = s.Default
@@ -189,6 +179,22 @@ func (b Bundle) Validate() error {
 
 	if b.Version == "latest" {
 		return errors.New("'latest' is not a valid bundle version")
+	}
+
+	reqExt := make(map[string]bool, len(b.RequiredExtensions))
+	for _, requiredExtension := range b.RequiredExtensions {
+		// Verify the custom extension declared as required exists
+		if _, exists := b.Custom[requiredExtension]; !exists {
+			return fmt.Errorf("required extension '%s' is not defined in the Custom section of the bundle", requiredExtension)
+		}
+
+		// Check for duplicate entries
+		if _, exists := reqExt[requiredExtension]; exists {
+			return fmt.Errorf("required extension '%s' is already declared", requiredExtension)
+		}
+
+		// Populate map with required extension, for duplicate check above
+		reqExt[requiredExtension] = true
 	}
 
 	for _, img := range b.InvocationImages {

--- a/vendor/github.com/deislabs/cnab-go/bundle/credentials.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/credentials.go
@@ -2,7 +2,7 @@ package bundle
 
 // Credential represents the definition of a CNAB credential
 type Credential struct {
-	Location    `mapstructure:",squash"`
-	Description string `json:"description,omitempty" mapstructure:"description"`
-	Required    bool   `json:"required,omitempty" mapstructure:"required"`
+	Location    `yaml:",inline"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
 }

--- a/vendor/github.com/deislabs/cnab-go/bundle/definition/schema.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/definition/schema.go
@@ -13,50 +13,51 @@ type Definitions map[string]*Schema
 
 // Schema represents a JSON Schema compatible CNAB Definition
 type Schema struct {
-	Comment              string                 `json:"$comment,omitempty" mapstructure:"$comment,omitempty"`
-	ID                   string                 `json:"$id,omitempty" mapstructure:"$ref,omitempty"`
-	Ref                  string                 `json:"$ref,omitempty" mapstructure:"$ref,omitempty"`
-	AdditionalItems      interface{}            `json:"additionalItems,omitempty" mapstructure:"additionalProperties,omitempty"`
-	AdditionalProperties interface{}            `json:"additionalProperties,omitempty" mapstructure:"additionalProperties,omitempty"`
-	AllOf                []*Schema              `json:"allOf,omitempty" mapstructure:"allOf,omitempty"`
-	Const                interface{}            `json:"const,omitempty" mapstructure:"const,omitempty"`
-	Contains             *Schema                `json:"contains,omitempty" mapstructure:"contains,omitempty"`
-	ContentEncoding      string                 `json:"contentEncoding,omitempty" mapstructure:"contentEncoding,omitempty"`
-	ContentMediaType     string                 `json:"contentMediaType,omitempty" mapstructure:"contentMediaType,omitempty"`
-	Default              interface{}            `json:"default,omitempty" mapstructure:"default,omitempty"`
-	Definitions          Definitions            `json:"definitions,omitempty" mapstructure:"definitions,omitempty"`
-	Dependencies         map[string]interface{} `json:"dependencies,omitempty" mapstructure:"dependencies,omitempty"`
-	Description          string                 `json:"description,omitempty" mapstructure:"description,omitempty"`
-	Else                 *Schema                `json:"else,omitempty" mapstructure:"else,omitempty"`
-	Enum                 []interface{}          `json:"enum,omitempty" mapstructure:"enum,omitempty"`
-	Examples             []interface{}          `json:"examples,omitempty" mapstructure:"examples,omitempty"`
-	ExclusiveMaximum     *float64               `json:"exclusiveMaximum,omitempty" mapstructure:"exclusiveMaximum,omitempty"`
-	ExclusiveMinimum     *float64               `json:"exclusiveMinimum,omitempty" mapstructure:"exclusiveMinimum,omitempty"`
-	Format               string                 `json:"format,omitempty" mapstructure:"format,omitempty"`
-	If                   *Schema                `json:"if,omitempty" mapstructure:"if,omitempty"`
+	Schema               string                 `json:"$schema,omitempty" yaml:"$schema,omitempty"`
+	Comment              string                 `json:"$comment,omitempty" yaml:"$comment,omitempty"`
+	ID                   string                 `json:"$id,omitempty" yaml:"$id,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	AdditionalItems      interface{}            `json:"additionalItems,omitempty" yaml:"additionalItems,omitempty"`
+	AdditionalProperties interface{}            `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
+	AllOf                []*Schema              `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	Const                interface{}            `json:"const,omitempty" yaml:"const,omitempty"`
+	Contains             *Schema                `json:"contains,omitempty" yaml:"contains,omitempty"`
+	ContentEncoding      string                 `json:"contentEncoding,omitempty" yaml:"contentEncoding,omitempty"`
+	ContentMediaType     string                 `json:"contentMediaType,omitempty" yaml:"contentMediaType,omitempty"`
+	Default              interface{}            `json:"default,omitempty" yaml:"default,omitempty"`
+	Definitions          Definitions            `json:"definitions,omitempty" yaml:"definitions,omitempty"`
+	Dependencies         map[string]interface{} `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Description          string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Else                 *Schema                `json:"else,omitempty" yaml:"else,omitempty"`
+	Enum                 []interface{}          `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Examples             []interface{}          `json:"examples,omitempty" yaml:"examples,omitempty"`
+	ExclusiveMaximum     *float64               `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	ExclusiveMinimum     *float64               `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	Format               string                 `json:"format,omitempty" yaml:"format,omitempty"`
+	If                   *Schema                `json:"if,omitempty" yaml:"if,omitempty"`
 	//Items can be a Schema or an Array of Schema :(
-	Items         interface{} `json:"items,omitempty" mapstructure:"items,omitempty"`
-	Maximum       *float64    `json:"maximum,omitempty" mapstructure:"maximum,omitempty"`
-	MaxLength     *float64    `json:"maxLength,omitempty" mapstructure:"maxLength,omitempty"`
-	MinItems      *float64    `json:"minItems,omitempty" mapstructure:"minItems,omitempty"`
-	MinLength     *float64    `json:"minLength,omitempty" mapstructure:"minLength,omitempty"`
-	MinProperties *float64    `json:"minProperties,omitempty" mapstructure:"minProperties,omitempty"`
-	Minimum       *float64    `json:"minimum,omitempty" mapstructure:"minimum,omitempty"`
-	MultipleOf    *float64    `json:"multipleOf,omitempty" mapstructure:"multipleOf,omitempty"`
-	Not           *Schema     `json:"not,omitempty" mapstructure:"not,omitempty"`
-	OneOf         *Schema     `json:"oneOf,omitempty" mapstructure:"oneOf,omitempty"`
+	Items         interface{} `json:"items,omitempty" yaml:"items,omitempty"`
+	Maximum       *float64    `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	MaxLength     *float64    `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinItems      *float64    `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MinLength     *float64    `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MinProperties *float64    `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	Minimum       *float64    `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	MultipleOf    *float64    `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Not           *Schema     `json:"not,omitempty" yaml:"not,omitempty"`
+	OneOf         *Schema     `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
 
-	PatternProperties map[string]*Schema `json:"patternProperties,omitempty" mapstructure:"patternProperties,omitempty"`
+	PatternProperties map[string]*Schema `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty"`
 
-	Properties    map[string]*Schema `json:"properties,omitempty" mapstructure:"properties,omitempty"`
-	PropertyNames *Schema            `json:"propertyNames,omitempty" mapstructure:"propertyNames,omitempty"`
-	ReadOnly      *bool              `json:"readOnly,omitempty" mapstructure:"readOnly,omitempty"`
-	Required      []string           `json:"required,omitempty" mapstructure:"required,omitempty"`
-	Then          *Schema            `json:"then,omitempty" mapstructure:"then,omitempty"`
-	Title         string             `json:"title,omitempty" mapstructure:"title,omitempty"`
-	Type          interface{}        `json:"type,omitempty" mapstructure:"type,omitempty"`
-	UniqueItems   *bool              `json:"uniqueItems,omitempty" mapstructure:"uniqueItems,omitempty"`
-	WriteOnly     *bool              `json:"writeOnly,omitempty" mapstructure:"writeOnly,omitempty"`
+	Properties    map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
+	PropertyNames *Schema            `json:"propertyNames,omitempty" yaml:"propertyNames,omitempty"`
+	ReadOnly      *bool              `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+	Required      []string           `json:"required,omitempty" yaml:"required,omitempty"`
+	Then          *Schema            `json:"then,omitempty" yaml:"then,omitempty"`
+	Title         string             `json:"title,omitempty" yaml:"title,omitempty"`
+	Type          interface{}        `json:"type,omitempty" yaml:"type,omitempty"`
+	UniqueItems   *bool              `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	WriteOnly     *bool              `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
 }
 
 // GetType will return the singular type for a given schema and a success boolean. If the

--- a/vendor/github.com/deislabs/cnab-go/bundle/outputs.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/outputs.go
@@ -1,12 +1,8 @@
 package bundle
 
-type OutputsDefinition struct {
-	Fields map[string]OutputDefinition `json:"fields" mapstructure:"fields"`
-}
-
-type OutputDefinition struct {
-	Definition  string   `json:"definition" mapstructure:"definition"`
-	ApplyTo     []string `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
-	Description string   `json:"description,omitempty" mapstructure:"description"`
-	Path        string   `json:"path,omitemtpty" mapstructure:"path,omitempty"`
+type Output struct {
+	Definition  string   `json:"definition" yaml:"definition"`
+	ApplyTo     []string `json:"applyTo,omitempty" yaml:"applyTo,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Path        string   `json:"path" yaml:"path"`
 }

--- a/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
@@ -1,15 +1,10 @@
 package bundle
 
-type ParametersDefinition struct {
-	Fields   map[string]ParameterDefinition `json:"fields" mapstructure:"fields"`
-	Required []string                       `json:"required,omitempty" mapstructure:"required,omitempty"`
-}
-
-// ParameterDefinition defines a single parameter for a CNAB bundle
-type ParameterDefinition struct {
-	Definition  string    `json:"definition" mapstructure:"definition"`
-	ApplyTo     []string  `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
-	Description string    `json:"description,omitempty" mapstructure:"description"`
-	Destination *Location `json:"destination,omitemtpty" mapstructure:"destination"`
-	Immutable   bool      `json:"immutable,omitempty" mapstructure:"immutable,omitempty"`
+// Parameter defines a single parameter for a CNAB bundle
+type Parameter struct {
+	Definition  string    `json:"definition" yaml:"definition"`
+	ApplyTo     []string  `json:"applyTo,omitempty" yaml:"applyTo,omitempty"`
+	Description string    `json:"description,omitempty" yaml:"description,omitempty"`
+	Destination *Location `json:"destination,omitemtpty" yaml:"destination,omitempty"`
+	Required    bool      `json:"required,omitempty" yaml:"required,omitempty"`
 }

--- a/vendor/github.com/deislabs/cnab-go/claim/claim.go
+++ b/vendor/github.com/deislabs/cnab-go/claim/claim.go
@@ -35,15 +35,15 @@ const (
 // provide the necessary data to upgrade, uninstall, and downgrade
 // a CNAB package.
 type Claim struct {
-	Name          string                    `json:"name"`
-	Revision      string                    `json:"revision"`
-	Created       time.Time                 `json:"created"`
-	Modified      time.Time                 `json:"modified"`
-	Bundle        *bundle.Bundle            `json:"bundle"`
-	Result        Result                    `json:"result"`
-	Parameters    map[string]interface{}    `json:"parameters"`
+	Name       string                 `json:"name"`
+	Revision   string                 `json:"revision"`
+	Created    time.Time              `json:"created"`
+	Modified   time.Time              `json:"modified"`
+	Bundle     *bundle.Bundle         `json:"bundle"`
+	Result     Result                 `json:"result"`
+	Parameters map[string]interface{} `json:"parameters"`
+	// Outputs is a map from the names of outputs (defined in the bundle) to the contents of the files.
 	Outputs       map[string]interface{}    `json:"outputs"`
-	Files         map[string]string         `json:"files"`
 	RelocationMap bundle.ImageRelocationMap `json:"relocationMap"`
 }
 

--- a/vendor/github.com/deislabs/cnab-go/driver/command/command_windows.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/command/command_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CheckDriverExists checks to see if the named driver exists
-func (d *CommandDriver) CheckDriverExists() bool {
+func (d *Driver) CheckDriverExists() bool {
 	cmd := exec.Command("where", d.cliName())
 	cmd.Env = os.Environ()
 	if err := cmd.Run(); err != nil {

--- a/vendor/github.com/deislabs/cnab-go/driver/docker/docker.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/docker/docker.go
@@ -34,7 +34,7 @@ type Driver struct {
 }
 
 // Run executes the Docker driver
-func (d *Driver) Run(op *driver.Operation) error {
+func (d *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 	return d.exec(op)
 }
 
@@ -54,6 +54,7 @@ func (d *Driver) Config() map[string]string {
 		"VERBOSE":             "Increase verbosity. true, false are supported values",
 		"PULL_ALWAYS":         "Always pull image, even if locally available (0|1)",
 		"DOCKER_DRIVER_QUIET": "Make the Docker driver quiet (only print container stdout/stderr)",
+		"OUTPUTS_MOUNT_PATH":  "Absolute path to where Docker driver can create temporary directories to bundle outputs. Defaults to temp dir.",
 	}
 }
 
@@ -124,20 +125,20 @@ func (d *Driver) initializeDockerCli() (command.Cli, error) {
 	return cli, nil
 }
 
-func (d *Driver) exec(op *driver.Operation) error {
+func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	ctx := context.Background()
 
 	cli, err := d.initializeDockerCli()
 	if err != nil {
-		return err
+		return driver.OperationResult{}, err
 	}
 
 	if d.Simulate {
-		return nil
+		return driver.OperationResult{}, nil
 	}
 	if d.config["PULL_ALWAYS"] == "1" {
 		if err := pullImage(ctx, cli, op.Image); err != nil {
-			return err
+			return driver.OperationResult{}, err
 		}
 	}
 	var env []string
@@ -153,11 +154,10 @@ func (d *Driver) exec(op *driver.Operation) error {
 		AttachStdout: true,
 	}
 
-	hostCfg := &container.HostConfig{AutoRemove: true}
-
+	hostCfg := &container.HostConfig{}
 	for _, opt := range d.dockerConfigurationOptions {
 		if err := opt(cfg, hostCfg); err != nil {
-			return err
+			return driver.OperationResult{}, err
 		}
 	}
 
@@ -166,18 +166,20 @@ func (d *Driver) exec(op *driver.Operation) error {
 	case client.IsErrNotFound(err):
 		fmt.Fprintf(cli.Err(), "Unable to find image '%s' locally\n", op.Image)
 		if err := pullImage(ctx, cli, op.Image); err != nil {
-			return err
+			return driver.OperationResult{}, err
 		}
 		if resp, err = cli.Client().ContainerCreate(ctx, cfg, hostCfg, nil, ""); err != nil {
-			return fmt.Errorf("cannot create container: %v", err)
+			return driver.OperationResult{}, fmt.Errorf("cannot create container: %v", err)
 		}
 	case err != nil:
-		return fmt.Errorf("cannot create container: %v", err)
+		return driver.OperationResult{}, fmt.Errorf("cannot create container: %v", err)
 	}
+
+	defer cli.Client().ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{})
 
 	tarContent, err := generateTar(op.Files)
 	if err != nil {
-		return fmt.Errorf("error staging files: %s", err)
+		return driver.OperationResult{}, fmt.Errorf("error staging files: %s", err)
 	}
 	options := types.CopyToContainerOptions{
 		AllowOverwriteDirWithFile: false,
@@ -186,7 +188,7 @@ func (d *Driver) exec(op *driver.Operation) error {
 	// path from the given file, starting at the /.
 	err = cli.Client().CopyToContainer(ctx, resp.ID, "/", tarContent, options)
 	if err != nil {
-		return fmt.Errorf("error copying to / in container: %s", err)
+		return driver.OperationResult{}, fmt.Errorf("error copying to / in container: %s", err)
 	}
 
 	attach, err := cli.Client().ContainerAttach(ctx, resp.ID, types.ContainerAttachOptions{
@@ -196,7 +198,7 @@ func (d *Driver) exec(op *driver.Operation) error {
 		Logs:   true,
 	})
 	if err != nil {
-		return fmt.Errorf("unable to retrieve logs: %v", err)
+		return driver.OperationResult{}, fmt.Errorf("unable to retrieve logs: %v", err)
 	}
 	var (
 		stdout io.Writer = os.Stdout
@@ -218,25 +220,82 @@ func (d *Driver) exec(op *driver.Operation) error {
 		}
 	}()
 
-	statusc, errc := cli.Client().ContainerWait(ctx, resp.ID, container.WaitConditionRemoved)
+	statusc, errc := cli.Client().ContainerWait(ctx, resp.ID, container.WaitConditionNextExit)
 	if err = cli.Client().ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
-		return fmt.Errorf("cannot start container: %v", err)
+		return driver.OperationResult{}, fmt.Errorf("cannot start container: %v", err)
 	}
 	select {
 	case err := <-errc:
 		if err != nil {
-			return fmt.Errorf("error in container: %v", err)
+			opResult, fetchErr := d.fetchOutputs(ctx, resp.ID)
+			return opResult, containerError("error in container", err, fetchErr)
 		}
 	case s := <-statusc:
 		if s.StatusCode == 0 {
-			return nil
+			return d.fetchOutputs(ctx, resp.ID)
 		}
 		if s.Error != nil {
-			return fmt.Errorf("container exit code: %d, message: %v", s.StatusCode, s.Error.Message)
+			opResult, fetchErr := d.fetchOutputs(ctx, resp.ID)
+			return opResult, containerError(fmt.Sprintf("container exit code: %d, message", s.StatusCode), err, fetchErr)
 		}
-		return fmt.Errorf("container exit code: %d", s.StatusCode)
+		opResult, fetchErr := d.fetchOutputs(ctx, resp.ID)
+		return opResult, containerError(fmt.Sprintf("container exit code: %d, message", s.StatusCode), err, fetchErr)
 	}
-	return err
+	opResult, fetchErr := d.fetchOutputs(ctx, resp.ID)
+	if fetchErr != nil {
+		return opResult, fmt.Errorf("fetching outputs failed: %s", fetchErr)
+	}
+	return opResult, err
+}
+
+func containerError(containerMessage string, containerErr, fetchErr error) error {
+	if fetchErr != nil {
+		return fmt.Errorf("%s: %v. fetching outputs failed: %s", containerMessage, containerErr, fetchErr)
+	}
+
+	return fmt.Errorf("%s: %v", containerMessage, containerErr)
+}
+
+// fetchOutputs takes a context and a container ID; it copies the /cnab/app/outputs directory from that container.
+// The goal is to collect all the files in the directory (recursively) and put them in a flat map of path to contents.
+// This map will be inside the OperationResult. When fetchOutputs returns an error, it may also return partial results.
+func (d *Driver) fetchOutputs(ctx context.Context, container string) (driver.OperationResult, error) {
+	opResult := driver.OperationResult{
+		Outputs: map[string]string{},
+	}
+	ioReader, _, err := d.dockerCli.Client().CopyFromContainer(ctx, container, "/cnab/app/outputs")
+	if err != nil {
+		return opResult, fmt.Errorf("error copying outputs from container: %s", err)
+	}
+
+	tarReader := tar.NewReader(ioReader)
+	header, err := tarReader.Next()
+
+	// io.EOF pops us out of loop on successful run.
+	for err == nil {
+		// skip directories because we're gathering file contents
+		if header.FileInfo().IsDir() {
+			header, err = tarReader.Next()
+			continue
+		}
+
+		var contents []byte
+		// CopyFromContainer strips prefix above outputs directory.
+		pathInContainer := unix_path.Join("/cnab", "app", header.Name)
+
+		contents, err = ioutil.ReadAll(tarReader)
+		if err != nil {
+			return opResult, fmt.Errorf("error while reading %q from outputs tar: %s", pathInContainer, err)
+		}
+		opResult.Outputs[pathInContainer] = string(contents)
+		header, err = tarReader.Next()
+	}
+
+	if err != io.EOF {
+		return opResult, err
+	}
+
+	return opResult, nil
 }
 
 func generateTar(files map[string]string) (io.Reader, error) {


### PR DESCRIPTION
Bumps to latest cnab-go [release](https://github.com/deislabs/cnab-go/releases/tag/v0.3.0-beta1)

Currently pending on corresponding duffle and cnab-to-oci bumps...

For the former duffle dep, https://github.com/deislabs/cnab-go/pull/97 and https://github.com/deislabs/cnab-go/pull/98 should represent the last few ports needed to remove the duffle dep from this repo...