### PR TITLE
fix(duffle.go): add check for output's applyTo before attempting to read

### DIFF
--- a/pkg/cnab/provider/dockerdriver_test.go
+++ b/pkg/cnab/provider/dockerdriver_test.go
@@ -1,11 +1,15 @@
 package cnabprovider
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	dockerdriver "github.com/deislabs/cnab-go/driver/docker"
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/claim"
+	"github.com/deislabs/cnab-go/driver/docker"
+
 	"github.com/deislabs/porter/pkg/config"
 )
 
@@ -16,10 +20,51 @@ func TestNewDriver_Docker(t *testing.T) {
 	driver, err := d.newDriver("docker", "myclaim")
 	require.NoError(t, err)
 
-	if _, ok := driver.(*dockerdriver.Driver); ok {
+	if _, ok := driver.(*docker.Driver); ok {
 		// TODO: check dockerConfigurationOptions to verify expected bind mount setup,
 		// once we're able to (add ability to dockerdriver pkg)
 	} else {
 		t.Fatal("expected driver to be of type *dockerdriver.Driver")
 	}
+}
+
+func TestWriteClaimOutputs(t *testing.T) {
+	c := config.NewTestConfig(t)
+	d := NewDuffle(c.Config)
+
+	homeDir, err := c.GetHomeDir()
+	require.NoError(t, err)
+
+	c.TestContext.AddTestDirectory("../../porter/testdata/outputs", filepath.Join(homeDir, "outputs"))
+
+	claim, err := claim.New("test-bundle")
+	require.NoError(t, err)
+
+	// Expect error when claim has no associated bundle
+	err = d.WriteClaimOutputs(claim, "install")
+	require.EqualError(t, err, "claim has no bundle")
+
+	claim.Bundle = &bundle.Bundle{}
+
+	// Expect no error if Bundle.Outputs is empty
+	err = d.WriteClaimOutputs(claim, "install")
+	require.NoError(t, err)
+
+	claim.Bundle.Outputs = map[string]bundle.Output{
+		"foo": bundle.Output{},
+	}
+
+	// Expect no error; by default, outputs apply to all actions
+	err = d.WriteClaimOutputs(claim, "install")
+	require.NoError(t, err)
+
+	claim.Bundle.Outputs["foo"] = bundle.Output{
+		ApplyTo: []string{
+			"status",
+		},
+	}
+
+	// Expect no error if output does not apply to action
+	err = d.WriteClaimOutputs(claim, "install")
+	require.NoError(t, err)
 }

--- a/pkg/cnab/provider/install.go
+++ b/pkg/cnab/provider/install.go
@@ -68,7 +68,7 @@ func (d *Duffle) Install(args ActionArguments) error {
 	runErr := i.Run(c, creds, d.Out)
 
 	// Add/update the outputs section of a claim and capture error
-	writeErr := d.WriteClaimOutputs(c)
+	writeErr := d.WriteClaimOutputs(c, string(config.ActionInstall))
 
 	// ALWAYS write out a claim, even if the installation fails
 	claimStore, err := d.NewClaimStore()

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -63,7 +63,7 @@ func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]stri
 	return bundle.ValuesOrDefaults(overrides, bun)
 }
 
-// TODO: pilfered from cnab-go.  PR to export func?
+// TODO: remove in favor of cnab-go logic: https://github.com/deislabs/cnab-go/pull/99
 func appliesToAction(action string, parameter bundle.Parameter) bool {
 	if len(parameter.ApplyTo) == 0 {
 		return true

--- a/pkg/cnab/provider/upgrade.go
+++ b/pkg/cnab/provider/upgrade.go
@@ -69,7 +69,7 @@ func (d *Duffle) Upgrade(args ActionArguments) error {
 	runErr := i.Run(&claim, creds, d.Out)
 
 	// Add/update the outputs section of a claim and capture error
-	err = d.WriteClaimOutputs(&claim)
+	err = d.WriteClaimOutputs(&claim, string(config.ActionUpgrade))
 
 	// ALWAYS write out a claim, even if the upgrade fails
 	saveErr := claims.Store(claim)

--- a/pkg/outputs/outputs.go
+++ b/pkg/outputs/outputs.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/deislabs/porter/pkg/config"
+
+	"github.com/deislabs/cnab-go/bundle"
 )
 
 // Output represents a bundle output
@@ -67,4 +69,17 @@ func ReadBundleOutput(c *config.Config, name, claim string) (*Output, error) {
 // JSONMarshal marshals an Output to JSON, returning a byte array or error
 func (o *Output) JSONMarshal() ([]byte, error) {
 	return json.MarshalIndent(o, "", "  ")
+}
+
+// TODO: remove in favor of cnab-go logic: https://github.com/deislabs/cnab-go/pull/99
+func AppliesTo(action string, output bundle.Output) bool {
+	if len(output.ApplyTo) == 0 {
+		return true
+	}
+	for _, act := range output.ApplyTo {
+		if action == act {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Fixes bug where Porter would attempt to read/write an output without checking to see if the output applied to the current action.  Now, if the output does not apply to the current action, Porter does not attempt to read/write.

Note some TODOs exist around https://github.com/deislabs/cnab-go/pull/99