### PR TITLE
Fix ignore of .cnab

### DIFF
--- a/pkg/porter/templates/create/.gitignore
+++ b/pkg/porter/templates/create/.gitignore
@@ -1,2 +1,2 @@
 Dockerfile
-cnab/
+.cnab/


### PR DESCRIPTION
I forgot to update the default `.gitignore` entry when I renamed `cnab` to `.cnab`.