### PR TITLE
Use debian only for base image

### DIFF
--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -30,11 +30,11 @@ func TestPorter_buildDockerfile(t *testing.T) {
 	require.NoError(t, err)
 
 	wantlines := []string{
-		"FROM quay.io/deis/lightweight-docker-go:v0.2.0",
 		"FROM debian:stretch",
-		"COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt",
 		"",
 		"ARG BUNDLE_DIR",
+		"",
+		"RUN apt-get update && apt-get install -y ca-certificates",
 		"",
 		"COPY .cnab /cnab",
 		"COPY . $BUNDLE_DIR",
@@ -99,11 +99,11 @@ func TestPorter_buildDockerfile_output(t *testing.T) {
 
 	wantlines := `
 Generating Dockerfile =======>
-FROM quay.io/deis/lightweight-docker-go:v0.2.0
 FROM debian:stretch
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ARG BUNDLE_DIR
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 COPY .cnab /cnab
 COPY . $BUNDLE_DIR

--- a/pkg/porter/templates/build/Dockerfile
+++ b/pkg/porter/templates/build/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/deis/lightweight-docker-go:v0.2.0
 FROM debian:stretch
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ARG BUNDLE_DIR
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 COPY .cnab /cnab
 COPY . $BUNDLE_DIR


### PR DESCRIPTION
Install ca-certificates using apt instead of copying from another base image to not have to download multiple base images.