### PR TITLE
fix(brigade.js): set generous default timeout for GoJob

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -312,6 +312,9 @@ class GoJob extends Job {
       "mv /src/.git " + localPath,
       "cd " + localPath
     ];
+
+    // Set default job timeout to 1800000 milliseconds / 30 minutes
+    this.timeout = 1800000
   }
 
   // enabledDind enables Docker-in-Docker for this job,


### PR DESCRIPTION
We've been seeing many false-negative Brigade pipeline failures due to Brigade giving up on the longer-running checks (integration, cli tests, example bundle publishing, etc.), even though they may (usually) end up passing.  Therefore, I propose we set a very generous job timeout for the standard `GoJob` that we re-use in our `brigade.js` file.