### PR TITLE
Move outputs pkg into config

### DIFF
--- a/pkg/cnab/provider/duffle.go
+++ b/pkg/cnab/provider/duffle.go
@@ -14,7 +14,6 @@ import (
 	"github.com/deislabs/cnab-go/driver/lookup"
 
 	"github.com/deislabs/porter/pkg/config"
-	"github.com/deislabs/porter/pkg/outputs"
 )
 
 type Duffle struct {
@@ -94,8 +93,8 @@ func (d *Duffle) WriteClaimOutputs(c *claim.Claim, action string) error {
 
 	for name, output := range c.Bundle.Outputs {
 		// TODO: refactor with cnab-go logic: https://github.com/deislabs/cnab-go/pull/99
-		if outputs.AppliesTo(action, output) {
-			output, err := outputs.ReadBundleOutput(d.Config, name, c.Name)
+		if config.OutputAppliesTo(action, output) {
+			output, err := d.ReadBundleOutput(name, c.Name)
 			if err != nil {
 				return errors.Wrapf(err, "unable to read output %s", name)
 			}

--- a/pkg/config/outputs.go
+++ b/pkg/config/outputs.go
@@ -1,15 +1,12 @@
-package outputs
+package config
 
 import (
 	"encoding/json"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	"github.com/deislabs/porter/pkg/config"
-
 	"github.com/deislabs/cnab-go/bundle"
+	"github.com/pkg/errors"
 )
 
 // Output represents a bundle output
@@ -43,7 +40,7 @@ func (l Outputs) Less(i, j int) bool {
 // ReadBundleOutput reads the provided output associated with the provided bundle,
 // via the filesystem provided by the config.Config object,
 // returning the output's full Output representation
-func ReadBundleOutput(c *config.Config, name, claim string) (*Output, error) {
+func (c *Config) ReadBundleOutput(name string, claim string) (*Output, error) {
 	outputsDir, err := c.GetOutputsDir()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get outputs directory")
@@ -72,7 +69,7 @@ func (o *Output) JSONMarshal() ([]byte, error) {
 }
 
 // TODO: remove in favor of cnab-go logic: https://github.com/deislabs/cnab-go/pull/99
-func AppliesTo(action string, output bundle.Output) bool {
+func OutputAppliesTo(action string, output bundle.Output) bool {
 	if len(output.ApplyTo) == 0 {
 		return true
 	}

--- a/pkg/config/outputs_test.go
+++ b/pkg/config/outputs_test.go
@@ -1,23 +1,21 @@
-package outputs
+package config
 
 import (
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/deislabs/porter/pkg/config"
 )
 
 func TestPorter_ReadBundleOutput(t *testing.T) {
-	c := config.NewTestConfig(t)
+	c := NewTestConfig(t)
 
 	homeDir, err := c.GetHomeDir()
 	require.NoError(t, err)
 
 	c.TestContext.AddTestDirectory("../porter/testdata/outputs", filepath.Join(homeDir, "outputs"))
 
-	got, err := ReadBundleOutput(c.Config, "foo", "test-bundle")
+	got, err := c.ReadBundleOutput("foo", "test-bundle")
 	require.NoError(t, err)
 
 	want := &Output{

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -4,10 +4,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/deislabs/porter/pkg/config"
+
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/stretchr/testify/require"
-
-	"github.com/deislabs/porter/pkg/outputs"
 )
 
 func TestPorter_fetchBundleOutputs_Error(t *testing.T) {
@@ -36,7 +36,7 @@ func TestPorter_fetchBundleOutputs(t *testing.T) {
 	got, err := p.fetchBundleOutputs("test-bundle")
 	require.NoError(t, err)
 
-	want := &outputs.Outputs{
+	want := &config.Outputs{
 		{
 			Name:      "foo",
 			Type:      "string",
@@ -59,7 +59,7 @@ func TestPorter_printOutputsTable(t *testing.T) {
 	p.TestConfig.SetupPorterHome()
 	p.CNAB = NewTestCNABProvider()
 
-	outputs := &outputs.Outputs{
+	outputs := &config.Outputs{
 		{
 			Name:      "foo",
 			Type:      "string",

--- a/pkg/porter/run.go
+++ b/pkg/porter/run.go
@@ -6,14 +6,12 @@ import (
 	"path/filepath"
 	"strconv"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/deislabs/porter/pkg/config"
 	"github.com/deislabs/porter/pkg/context"
 	"github.com/deislabs/porter/pkg/mixin"
-	output "github.com/deislabs/porter/pkg/outputs"
 )
 
 type RunOptions struct {
@@ -268,7 +266,7 @@ func (p *Porter) ApplyBundleOutputs(opts RunOptions, outputs map[string]string) 
 					}
 
 					// Create data structure with relevant data for use in listing/showing later
-					output := output.Output{
+					output := config.Output{
 						Name:      bundleOutput.Name,
 						Sensitive: bundleOutput.Sensitive,
 						Type:      outputType,

--- a/pkg/porter/run_test.go
+++ b/pkg/porter/run_test.go
@@ -7,15 +7,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/deislabs/cnab-go/bundle/definition"
 	"github.com/deislabs/porter/pkg/config"
 	"github.com/deislabs/porter/pkg/context"
-	output "github.com/deislabs/porter/pkg/outputs"
 )
 
 func TestPorter_readMixinOutputs(t *testing.T) {
@@ -152,7 +150,7 @@ func TestApplyBundleOutputs_Some_Match(t *testing.T) {
 	err := p.ApplyBundleOutputs(opts, outputs)
 	assert.NoError(t, err)
 
-	want := map[string]output.Output{
+	want := map[string]config.Output{
 		"foo": {
 			Name:      "foo",
 			Type:      "string",
@@ -171,7 +169,7 @@ func TestApplyBundleOutputs_Some_Match(t *testing.T) {
 		bytes, err := p.FileSystem.ReadFile(filepath.Join(config.BundleOutputsDir, outputName))
 		assert.NoError(t, err)
 
-		var output output.Output
+		var output config.Output
 		err = json.Unmarshal(bytes, &output)
 		assert.NoError(t, err)
 
@@ -252,11 +250,11 @@ func TestApplyBundleOutputs_ApplyTo_True(t *testing.T) {
 	bytes, err := p.FileSystem.ReadFile(filepath.Join(config.BundleOutputsDir, "123"))
 	assert.NoError(t, err)
 
-	var got output.Output
+	var got config.Output
 	err = json.Unmarshal(bytes, &got)
 	assert.NoError(t, err)
 
-	want := output.Output{
+	want := config.Output{
 		Name:      "123",
 		Type:      "string",
 		Sensitive: false,


### PR DESCRIPTION
I was getting a lot of cyclical import problems because I kept wanting to use the very useful outputs package from other packages. Since it is operating on files in the config directory, it seems like a natural fit to move it into the config package. Hopefully the applies to logic will move into cnab-go soon anyway.