### PR TITLE
 Don't build before running unit tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,11 @@ endif
 
 test: clean-last-testrun test-unit test-integration test-cli
 
-test-unit: build
+test-unit:
 	go test ./...
 
 test-integration: build
-	go test -v -timeout 20m -tags=integration ./tests
+	go test -v -timeout 20m -tags=integration ./...
 
 test-cli: clean-last-testrun build init-porter-home-for-ci
 	REGISTRY=$(REGISTRY) KUBECONFIG=$(KUBECONFIG) ./scripts/test/test-cli.sh

--- a/pkg/mixin/helpers.go
+++ b/pkg/mixin/helpers.go
@@ -1,7 +1,6 @@
 package mixin
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/deislabs/porter/pkg/context"
@@ -23,8 +22,10 @@ func NewTestRunner(t *testing.T, mixin string, runtime bool) *TestRunner {
 	r.Context = c.Context
 
 	// Setup Mixin Home
-	srcMixinsDir := filepath.Join(c.FindBinDir(), "mixins")
-	c.AddTestDirectory(srcMixinsDir, "/root/.porter/mixins")
+	c.FileSystem.Create("/root/.porter/porter")
+	c.FileSystem.Create("/root/.porter/porter-runtime")
+	c.FileSystem.Create("/root/.porter/mixins/exec/exec")
+	c.FileSystem.Create("/root/.porter/mixins/exec/exec-runtime")
 
 	return r
 }

--- a/pkg/mixin/provider/filesystem_test.go
+++ b/pkg/mixin/provider/filesystem_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package mixinprovider
 
 import (

--- a/pkg/mixin/runner_integration_test.go
+++ b/pkg/mixin/runner_integration_test.go
@@ -1,0 +1,68 @@
+// +build integration
+
+package mixin
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/deislabs/porter/pkg/context"
+	"github.com/deislabs/porter/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunner_Run(t *testing.T) {
+	// Provide a way for tests to capture stdout
+	output := &bytes.Buffer{}
+
+	binDir := context.NewTestContext(t).FindBinDir()
+
+	// I'm not using the TestRunner because I want to use the current filesystem, not an isolated one
+	r := NewRunner("exec", filepath.Join(binDir, "mixins/exec"), false)
+	r.Command = "install"
+	r.File = "testdata/exec_input.yaml"
+
+	// Capture the output
+	r.Out = output
+	r.Err = output
+
+	err := r.Validate()
+	require.NoError(t, err)
+
+	err = r.Run()
+	assert.NoError(t, err)
+	assert.Contains(t, string(output.Bytes()), "Hello World")
+}
+
+func TestRunner_RunWithMaskedOutput(t *testing.T) {
+	// Provide a way for tests to capture stdout
+	output := &bytes.Buffer{}
+
+	// Copy output to the test log simultaneously, use go test -v to see the output
+	aggOutput := io.MultiWriter(output, test.Logger{T: t})
+
+	// Supply an CensoredWriter with values needing masking
+	censoredWriter := context.NewCensoredWriter(aggOutput)
+	censoredWriter.SetSensitiveValues([]string{"World"})
+
+	binDir := context.NewTestContext(t).FindBinDir()
+
+	// I'm not using the TestRunner because I want to use the current filesystem, not an isolated one
+	r := NewRunner("exec", filepath.Join(binDir, "mixins/exec"), false)
+	r.Command = "install"
+	r.File = "testdata/exec_input.yaml"
+
+	// Capture the output
+	r.Out = censoredWriter
+	r.Err = censoredWriter
+
+	err := r.Validate()
+	require.NoError(t, err)
+
+	err = r.Run()
+	assert.NoError(t, err)
+	assert.Contains(t, string(output.Bytes()), "Hello *******")
+}

--- a/pkg/mixin/runner_test.go
+++ b/pkg/mixin/runner_test.go
@@ -1,13 +1,8 @@
 package mixin
 
 import (
-	"bytes"
-	"io"
-	"path/filepath"
 	"testing"
 
-	"github.com/deislabs/porter/pkg/context"
-	"github.com/deislabs/porter/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,57 +36,4 @@ func TestRunner_Validate_MissingExecutable(t *testing.T) {
 	err = r.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mixin not found")
-}
-
-func TestRunner_Run(t *testing.T) {
-	// Provide a way for tests to capture stdout
-	output := &bytes.Buffer{}
-
-	binDir := context.NewTestContext(t).FindBinDir()
-
-	// I'm not using the TestRunner because I want to use the current filesystem, not an isolated one
-	r := NewRunner("exec", filepath.Join(binDir, "mixins/exec"), false)
-	r.Command = "install"
-	r.File = "testdata/exec_input.yaml"
-
-	// Capture the output
-	r.Out = output
-	r.Err = output
-
-	err := r.Validate()
-	require.NoError(t, err)
-
-	err = r.Run()
-	assert.NoError(t, err)
-	assert.Contains(t, string(output.Bytes()), "Hello World")
-}
-
-func TestRunner_RunWithMaskedOutput(t *testing.T) {
-	// Provide a way for tests to capture stdout
-	output := &bytes.Buffer{}
-
-	// Copy output to the test log simultaneously, use go test -v to see the output
-	aggOutput := io.MultiWriter(output, test.Logger{T: t})
-
-	// Supply an CensoredWriter with values needing masking
-	censoredWriter := context.NewCensoredWriter(aggOutput)
-	censoredWriter.SetSensitiveValues([]string{"World"})
-
-	binDir := context.NewTestContext(t).FindBinDir()
-
-	// I'm not using the TestRunner because I want to use the current filesystem, not an isolated one
-	r := NewRunner("exec", filepath.Join(binDir, "mixins/exec"), false)
-	r.Command = "install"
-	r.File = "testdata/exec_input.yaml"
-
-	// Capture the output
-	r.Out = censoredWriter
-	r.Err = censoredWriter
-
-	err := r.Validate()
-	require.NoError(t, err)
-
-	err = r.Run()
-	assert.NoError(t, err)
-	assert.Contains(t, string(output.Bytes()), "Hello *******")
 }

--- a/pkg/porter/mixins_test.go
+++ b/pkg/porter/mixins_test.go
@@ -1,7 +1,6 @@
 package porter
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/deislabs/porter/pkg/mixin"
@@ -14,23 +13,12 @@ func TestPorter_PrintMixins(t *testing.T) {
 	p := NewTestPorter(t)
 	p.TestConfig.SetupPorterHome()
 
-	// Start with a fresh mixins dir to make the test more durable as we add more mixins later
-	mixinsDir, err := p.GetMixinsDir()
-	require.Nil(t, err)
-	err = p.FileSystem.RemoveAll(mixinsDir)
-	require.Nil(t, err)
-
-	// Just copy in the exec and helm mixins
-	srcMixinsDir := filepath.Join(p.TestConfig.TestContext.FindBinDir(), "mixins")
-	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(srcMixinsDir, "/helm"), filepath.Join(mixinsDir, "helm"))
-	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(srcMixinsDir, "/exec"), filepath.Join(mixinsDir, "exec"))
-
 	opts := PrintMixinsOptions{
 		PrintOptions: printer.PrintOptions{
 			Format: printer.FormatTable,
 		},
 	}
-	err = p.PrintMixins(opts)
+	err := p.PrintMixins(opts)
 
 	require.Nil(t, err)
 	wantOutput := "exec\nhelm\n"


### PR DESCRIPTION
I've made two changes:
1. `make test-unit` doesn't do a build before running `go test`. This will make them faster to run, and also safer to run in a one-off fashion from an IDE or command-line using go test directly.
2. Cleanup tests usage of filesystem
    Some tests used the filesystem (bin) but didn't really need it, so I fixed them so that they could run as unit tests now that we aren't building before running the tests. 
    
    Other tests really do need to hit the file system and need a properly populated bin, so I promoted them to integration tests.