### PR TITLE
Improve the schema command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,15 @@ fetch-bundle-schema:
 	@curl --fail --silent --show-error -o $(BUNDLE_SCHEMA_PATH) \
 		https://raw.githubusercontent.com/deislabs/cnab-spec/master/schema/bundle.schema.json
 
-install:
+install: install-porter install-mixins
+
+install-porter:
 	mkdir -p $(HOME)/.porter
-	cp -R bin/mixins $(HOME)/.porter/
 	cp bin/porter* $(HOME)/.porter/
 	ln -f -s $(HOME)/.porter/porter /usr/local/bin/porter
+
+install-mixins:
+	cp -R bin/mixins $(HOME)/.porter/
 
 clean: clean-mixins clean-last-testrun
 


### PR DESCRIPTION
* Add troubleshooting hook to porter schema

    When porter.json is present in PORTER_HOME, the porter schema command will return it, instead of generating a schema. This is intended to assist with troubleshooting VS Code. It will allow someone to tweak the schema without modifying porter or the mixins and quickly iterate inside of VS Code, and then we can update the Go code to match the desired schema later.
* Make porter schema more robust
  * When an error occurs generating a schema, return the template so that we at least have the basic schema available at all times.
  * When an error occurs injecting a mixin, always skip and continue to the next, never error out so that an out of date mixin doesn't cause the entire command to fail.