### PR TITLE
Rename claim to instance

### DIFF
--- a/cmd/porter/aliases.go
+++ b/cmd/porter/aliases.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/deislabs/porter/pkg/porter"
+	"github.com/spf13/cobra"
+)
+
+func buildAliasCommands(p *porter.Porter) []*cobra.Command {
+	return []*cobra.Command{
+		buildCreateAlias(p),
+		buildBuildAlias(p),
+		buildInstallAlias(p),
+		buildUpgradeAlias(p),
+		buildUninstallAlias(p),
+		buildInvokeAlias(p),
+		buildPublishAlias(p),
+		buildListAlias(p),
+		buildShowAlias(p),
+	}
+}
+
+func buildCreateAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundleCreateCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle create", "porter create", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildBuildAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundleBuildCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle build", "porter build", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildInstallAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundleInstallCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle install", "porter install", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildUpgradeAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundleUpgradeCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle upgrade", "porter upgrade", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildInvokeAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundleInvokeCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle invoke", "porter invoke", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildUninstallAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundleUninstallCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle uninstall", "porter uninstall", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildPublishAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundlePublishCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle publish", "porter publish", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildShowAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildInstanceShowCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle instance show", "porter show", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildListAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildInstancesListCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle instances list", "porter list", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	"github.com/deislabs/porter/pkg/porter"
 )
 
-func buildBundlesCommand(p *porter.Porter) *cobra.Command {
+func buildBundleCommands(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bundles",
 		Aliases: []string{"bundle"},
@@ -21,28 +19,12 @@ func buildBundlesCommand(p *porter.Porter) *cobra.Command {
 
 	cmd.AddCommand(buildBundleCreateCommand(p))
 	cmd.AddCommand(buildBundleBuildCommand(p))
-	cmd.AddCommand(buildBundleListCommand(p))
 	cmd.AddCommand(buildBundleInstallCommand(p))
 	cmd.AddCommand(buildBundleUpgradeCommand(p))
 	cmd.AddCommand(buildBundleInvokeCommand(p))
 	cmd.AddCommand(buildBundleUninstallCommand(p))
-	cmd.AddCommand(buildBundleShowCommand(p))
-	cmd.AddCommand(buildBundleOutputCommand(p))
 
 	return cmd
-}
-
-func buildBundleAliasCommands(p *porter.Porter) []*cobra.Command {
-	return []*cobra.Command{
-		buildCreateCommand(p),
-		buildBuildCommand(p),
-		buildInstallCommand(p),
-		buildUpgradeCommand(p),
-		buildUninstallCommand(p),
-		buildInvokeCommand(p),
-		buildPublishCommand(p),
-		buildShowCommand(p),
-	}
 }
 
 func buildBundleCreateCommand(p *porter.Porter) *cobra.Command {
@@ -54,15 +36,6 @@ func buildBundleCreateCommand(p *porter.Porter) *cobra.Command {
 			return p.Create()
 		},
 	}
-}
-
-func buildCreateCommand(p *porter.Porter) *cobra.Command {
-	cmd := buildBundleCreateCommand(p)
-	cmd.Example = strings.Replace(cmd.Example, "porter bundle create", "porter create", -1)
-	cmd.Annotations = map[string]string{
-		"group": "alias",
-	}
-	return cmd
 }
 
 func buildBundleBuildCommand(p *porter.Porter) *cobra.Command {
@@ -82,54 +55,17 @@ func buildBundleBuildCommand(p *porter.Porter) *cobra.Command {
 	return cmd
 }
 
-func buildBuildCommand(p *porter.Porter) *cobra.Command {
-	cmd := buildBundleBuildCommand(p)
-	cmd.Example = strings.Replace(cmd.Example, "porter bundle build", "porter build", -1)
-	cmd.Annotations = map[string]string{
-		"group": "alias",
-	}
-	return cmd
-}
-
-func buildBundleListCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.ListOptions{}
-
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "list installed bundles",
-		Long: `List all bundles installed by Porter.
-
-A listing of bundles currently installed by Porter will be provided, along with metadata such as creation time, last action, last status, etc.
-
-Optional output formats include json and yaml.`,
-		Example: `  porter bundle list
-  porter bundle list -o json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.ParseFormat()
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListBundles(opts)
-		},
-	}
-
-	f := cmd.Flags()
-	f.StringVarP(&opts.RawFormat, "output", "o", "table",
-		"Specify an output format.  Allowed values: table, json, yaml")
-
-	return cmd
-}
-
 func buildBundleInstallCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.InstallOptions{}
 	cmd := &cobra.Command{
-		Use:   "install [CLAIM]",
-		Short: "Install a bundle",
-		Long: `Install a bundle.
+		Use:   "install [INSTANCE]",
+		Short: "Install a new instance of a bundle",
+		Long: `Install a new instance of a bundle.
 
-The first argument is the name of the claim to create for the installation. The claim name defaults to the name of the bundle. 
+The first argument is the bundle instance name to create for the installation. This defaults to the name of the bundle. 
 
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
-For instance, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle install
   porter bundle install --insecure
   porter bundle install MyAppInDev --file myapp/bundle.json
@@ -168,26 +104,17 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	return cmd
 }
 
-func buildInstallCommand(p *porter.Porter) *cobra.Command {
-	cmd := buildBundleInstallCommand(p)
-	cmd.Example = strings.Replace(cmd.Example, "porter bundle install", "porter install", -1)
-	cmd.Annotations = map[string]string{
-		"group": "alias",
-	}
-	return cmd
-}
-
 func buildBundleUpgradeCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.UpgradeOptions{}
 	cmd := &cobra.Command{
-		Use:   "upgrade [CLAIM]",
-		Short: "Upgrade a bundle",
-		Long: `Upgrade a bundle.
+		Use:   "upgrade [INSTANCE]",
+		Short: "Upgrade a bundle instance",
+		Long: `Upgrade a bundle instance.
 
-The first argument is the name of the claim to upgrade. The claim name defaults to the name of the bundle.
+The first argument is the bundle instance name to upgrade. This defaults to the name of the bundle.
 
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
-For instance, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle upgrade
   porter bundle upgrade --insecure
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
@@ -227,26 +154,17 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	return cmd
 }
 
-func buildUpgradeCommand(p *porter.Porter) *cobra.Command {
-	cmd := buildBundleUpgradeCommand(p)
-	cmd.Example = strings.Replace(cmd.Example, "porter bundle upgrade", "porter upgrade", -1)
-	cmd.Annotations = map[string]string{
-		"group": "alias",
-	}
-	return cmd
-}
-
 func buildBundleInvokeCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.InvokeOptions{}
 	cmd := &cobra.Command{
-		Use:   "invoke [CLAIM] --action ACTION",
-		Short: "Invoke a custom action on a bundle",
-		Long: `Invoke a custom action on a bundle.
+		Use:   "invoke [INSTANCE] --action ACTION",
+		Short: "Invoke a custom action on a bundle instance",
+		Long: `Invoke a custom action on a bundle instance.
 
-The first argument is the name of the claim upon which to invoke the action. The claim name defaults to the name of the bundle.
+The first argument is the bundle instance name upon which to invoke the action. This defaults to the name of the bundle.
 
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
-For instance, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle invoke --action ACTION
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter bundle invoke --action ACTION --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
@@ -285,26 +203,17 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	return cmd
 }
 
-func buildInvokeCommand(p *porter.Porter) *cobra.Command {
-	cmd := buildBundleInvokeCommand(p)
-	cmd.Example = strings.Replace(cmd.Example, "porter bundle invoke", "porter invoke", -1)
-	cmd.Annotations = map[string]string{
-		"group": "alias",
-	}
-	return cmd
-}
-
 func buildBundleUninstallCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.UninstallOptions{}
 	cmd := &cobra.Command{
-		Use:   "uninstall [CLAIM]",
-		Short: "Uninstall a bundle",
-		Long: `Uninstall a bundle
+		Use:   "uninstall [INSTANCE]",
+		Short: "Uninstall a bundle instance",
+		Long: `Uninstall a bundle instance
 
-The first argument is the name of the claim to uninstall. The claim name defaults to the name of the bundle.
+The first argument is the bundle instance name to uninstall. This defaults to the name of the bundle.
 
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
-For instance, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle uninstall
   porter bundle uninstall --insecure
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
@@ -345,15 +254,6 @@ For instance, the 'debug' driver may be specified, which simply logs the info gi
 	return cmd
 }
 
-func buildUninstallCommand(p *porter.Porter) *cobra.Command {
-	cmd := buildBundleUninstallCommand(p)
-	cmd.Example = strings.Replace(cmd.Example, "porter bundle uninstall", "porter uninstall", -1)
-	cmd.Annotations = map[string]string{
-		"group": "alias",
-	}
-	return cmd
-}
-
 func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 
 	opts := porter.PublishOptions{}
@@ -376,113 +276,5 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
 	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false, "Don't require TLS for the registry.")
-	return &cmd
-}
-
-func buildPublishCommand(p *porter.Porter) *cobra.Command {
-	cmd := buildBundlePublishCommand(p)
-	cmd.Example = strings.Replace(cmd.Example, "porter bundle publish", "porter publish", -1)
-	cmd.Annotations = map[string]string{
-		"group": "alias",
-	}
-	return cmd
-}
-
-func buildBundleShowCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.ShowOptions{}
-
-	cmd := cobra.Command{
-		Use:   "show [CLAIM]",
-		Short: "Show a bundle",
-		Long:  "Displays info relating to a bundle claim, including status and a listing of outputs.",
-		Example: `  porter bundle show [CLAIM]
-
-Optional output formats include json and yaml.
-`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p.Context)
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ShowBundle(opts)
-		},
-	}
-
-	f := cmd.Flags()
-	f.StringVarP(&opts.RawFormat, "output", "o", "table",
-		"Specify an output format.  Allowed values: table, json, yaml")
-
-	return &cmd
-}
-
-func buildShowCommand(p *porter.Porter) *cobra.Command {
-	cmd := buildBundleShowCommand(p)
-	cmd.Example = strings.Replace(cmd.Example, "porter bundle show", "porter show", -1)
-	cmd.Annotations = map[string]string{
-		"group": "alias",
-	}
-	return cmd
-}
-
-func buildBundleOutputCommand(p *porter.Porter) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "output",
-		Aliases: []string{"outputs"},
-		Short:   "Output commands",
-		Annotations: map[string]string{
-			"group": "resource",
-		},
-	}
-
-	cmd.AddCommand(buildBundleOutputShowCommand(p))
-	cmd.AddCommand(buildBundleOutputListCommand(p))
-
-	return cmd
-}
-
-func buildBundleOutputListCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.OutputListOptions{}
-
-	cmd := cobra.Command{
-		Use:   "list [CLAIM]",
-		Short: "List bundle outputs",
-		Long:  "Displays a listing of bundle outputs.",
-		Example: `  porter bundle outputs list [CLAIM]
-
-Optional output formats include json and yaml.
-`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p.Context)
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListBundleOutputs(&opts)
-		},
-	}
-
-	f := cmd.Flags()
-	f.StringVarP(&opts.RawFormat, "output", "o", "table",
-		"Specify an output format.  Allowed values: table, json, yaml")
-
-	return &cmd
-}
-
-func buildBundleOutputShowCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.OutputShowOptions{}
-
-	cmd := cobra.Command{
-		Use:     "show NAME [--claim|-c CLAIM]",
-		Short:   "Show a bundle output",
-		Long:    "Show a bundle output.",
-		Example: `  porter bundle output show NAME [--claim|-c CLAIM]`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p.Context)
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ShowBundleOutput(&opts)
-		},
-	}
-
-	f := cmd.Flags()
-	f.StringVarP(&opts.Name, "claim", "c", "", "Specify a claim that the output belongs to.")
-
 	return &cmd
 }

--- a/cmd/porter/bundle_test.go
+++ b/cmd/porter/bundle_test.go
@@ -97,15 +97,15 @@ func TestValidateInvokeCommand(t *testing.T) {
 	}
 }
 
-func TestValidateBundleListCommand(t *testing.T) {
+func TestValidateInstanceListCommand(t *testing.T) {
 	testcases := []struct {
 		name      string
 		args      string
 		wantError string
 	}{
-		{"no args", "bundle list", ""},
-		{"output json", "bundle list -o json", ""},
-		{"invalid format", "bundle list -o wingdings", "invalid format: wingdings"},
+		{"no args", "instance list", ""},
+		{"output json", "instance list -o json", ""},
+		{"invalid format", "instance list -o wingdings", "invalid format: wingdings"},
 	}
 
 	for _, tc := range testcases {

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func buildCredentialsCommand(p *porter.Porter) *cobra.Command {
+func buildCredentialsCommands(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "credentials",
 		Aliases:     []string{"credential", "cred", "creds"},

--- a/cmd/porter/instances.go
+++ b/cmd/porter/instances.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"github.com/deislabs/porter/pkg/porter"
+	"github.com/spf13/cobra"
+)
+
+func buildInstanceCommands(p *porter.Porter) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "instances",
+		Aliases: []string{"inst", "instance"},
+		Short:   "Bundle Instance commands",
+		Long:    "Commands for working with instances of a bundle",
+	}
+	cmd.Annotations = map[string]string{
+		"group": "resource",
+	}
+
+	cmd.AddCommand(buildInstancesListCommand(p))
+	cmd.AddCommand(buildInstanceShowCommand(p))
+
+	cmd.AddCommand(buildInstanceOutputsCommands(p))
+
+	return cmd
+}
+
+func buildInstancesListCommand(p *porter.Porter) *cobra.Command {
+	opts := porter.ListOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list instances of installed bundles",
+		Long: `List instances of all bundles installed by Porter.
+
+A listing of instances of bundles currently installed by Porter will be provided, along with metadata such as creation time, last action, last status, etc.
+
+Optional output formats include json and yaml.`,
+		Example: `  porter instances list
+  porter instances list -o json`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.ParseFormat()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.ListInstances(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.RawFormat, "output", "o", "table",
+		"Specify an output format.  Allowed values: table, json, yaml")
+
+	return cmd
+}
+
+func buildInstanceShowCommand(p *porter.Porter) *cobra.Command {
+	opts := porter.ShowOptions{}
+
+	cmd := cobra.Command{
+		Use:   "show [INSTANCE]",
+		Short: "Show an instance of a bundle",
+		Long:  "Displays info relating to an instance of a bundle, including status and a listing of outputs.",
+		Example: `  porter instance show
+porter instance show another-bundle
+
+Optional output formats include json and yaml.
+`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(args, p.Context)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.ShowInstances(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.RawFormat, "output", "o", "table",
+		"Specify an output format.  Allowed values: table, json, yaml")
+
+	return &cmd
+}

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -39,19 +39,14 @@ func buildRootCommand() *cobra.Command {
 	cmd.AddCommand(buildVersionCommand(p))
 	cmd.AddCommand(buildSchemaCommand(p))
 	cmd.AddCommand(buildRunCommand(p))
-	cmd.AddCommand(buildBundlesCommand(p))
-	cmd.AddCommand(buildMixinsCommand(p))
-	cmd.AddCommand(buildCredentialsCommand(p))
+	cmd.AddCommand(buildBundleCommands(p))
+	cmd.AddCommand(buildInstanceCommands(p))
+	cmd.AddCommand(buildMixinCommands(p))
+	cmd.AddCommand(buildCredentialsCommands(p))
 
-	for _, alias := range buildBundleAliasCommands(p) {
+	for _, alias := range buildAliasCommands(p) {
 		cmd.AddCommand(alias)
 	}
-
-	// Hide the help command from the help text
-	cmd.SetHelpCommand(&cobra.Command{
-		Use:    "help",
-		Hidden: true,
-	})
 
 	help := newHelptextBox()
 	usage, _ := help.FindString("usage.txt")

--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func buildMixinsCommand(p *porter.Porter) *cobra.Command {
+func buildMixinCommands(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "mixins",
 		Aliases: []string{"mixin"},

--- a/cmd/porter/outputs.go
+++ b/cmd/porter/outputs.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"github.com/deislabs/porter/pkg/porter"
+	"github.com/spf13/cobra"
+)
+
+func buildInstanceOutputsCommands(p *porter.Porter) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "output",
+		Aliases: []string{"outputs"},
+		Short:   "Output commands",
+		Annotations: map[string]string{
+			"group": "resource",
+		},
+	}
+
+	cmd.AddCommand(buildBundleOutputShowCommand(p))
+	cmd.AddCommand(buildBundleOutputListCommand(p))
+
+	return cmd
+}
+
+func buildBundleOutputListCommand(p *porter.Porter) *cobra.Command {
+	opts := porter.OutputListOptions{}
+
+	cmd := cobra.Command{
+		Use:   "list [--instance|i INSTANCE]",
+		Short: "List bundle instance outputs",
+		Long:  "Displays a listing of bundle instance outputs.",
+		Example: `  porter instance outputs list
+    porter instance outputs list --instance another-bundle
+`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(args, p.Context)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.ListBundleOutputs(&opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.RawFormat, "output", "o", "table",
+		"Specify an output format.  Allowed values: table, json, yaml")
+	f.StringVarP(&opts.Name, "instance", "i", "",
+		"Specify the bundle instance to which the output belongs.")
+
+	return &cmd
+}
+
+func buildBundleOutputShowCommand(p *porter.Porter) *cobra.Command {
+	opts := porter.OutputShowOptions{}
+
+	cmd := cobra.Command{
+		Use:   "show NAME [--instance|-i INSTANCE]",
+		Short: "Show the output of a bundle instance",
+		Long:  "Show the output of a bundle instance",
+		Example: `  porter instance output show kubeconfig
+    porter instance output show subscription-id --instance azure-mysql`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(args, p.Context)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.ShowBundleOutput(&opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.Name, "instance", "i", "",
+		"Specify the bundle instance to which the output belongs.")
+
+	return &cmd
+}

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -82,27 +82,27 @@ defaultContentLanguage = "en"
     weight = 128
     parent = "cli"
   [[menu.main]]
-    name = "porter bundle list"
-    url = "/cli#bundle-list"
-    identifier = "cli-bundle-list"
+    name = "porter list"
+    url = "/cli#list"
+    identifier = "cli-list"
     weight = 129
     parent = "cli"
   [[menu.main]]
-    name = "porter bundle show"
-    url = "/cli#bundle-show"
-    identifier = "cli-bundle-show"
+    name = "porter show"
+    url = "/cli#show"
+    identifier = "cli-show"
     weight = 129
     parent = "cli"
   [[menu.main]]
-    name = "porter bundle outputs list"
-    url = "/cli#bundle-outputs-list"
-    identifier = "cli-bundle-outputs-list"
+    name = "porter instance outputs list"
+    url = "/cli#instance-outputs-list"
+    identifier = "cli-instance-outputs-list"
     weight = 130
     parent = "cli"
   [[menu.main]]
-    name = "porter bundle output show"
-    url = "/cli#bundle-output-show"
-    identifier = "cli-bundle-output-show"
+    name = "porter instance output show"
+    url = "/cli#instance-output-show"
+    identifier = "cli-instance-output-show"
     weight = 131
     parent = "cli"
   [[menu.main]]

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -4,6 +4,8 @@ description: Porter CLI Commands Explained
 ---
 
 * [Bundle Commands](#bundle-commands)
+* [Instance Commands](#instance-commands)
+* [Instance Outputs Commands](#outputs-commands)
 * [Mixin Commands](#mixin-commands)
 * [Meta Commands](#meta-commands)
 
@@ -56,8 +58,8 @@ and `porter bundle install`.
 $ porter install --help
 Install a bundle.
 
-The first argument is the name of the claim to create for the installation. The
-claim name defaults to the name of the bundle.
+The first argument is the bundle instance name to create for the installation.
+This defaults to the name of the bundle.
 
 Porter uses the Docker driver as the default runtime for executing a bundle's
 invocation image, but an alternate driver may be supplied via '--driver/-d'. For
@@ -65,7 +67,7 @@ instance, the 'debug' driver may be specified, which simply logs the info given
 to it and then exits.
 
 Usage:
-  porter install [CLAIM] [flags]
+  porter install [INSTANCE] [flags]
 
 Examples:
   porter install
@@ -106,8 +108,8 @@ bundle upgrade`.
 $ porter upgrade --help
 Upgrade a bundle.
 
-The first argument is the name of the claim to upgrade. The claim name defaults
-to the name of the bundle.
+The first argument is the bundle instance name to upgrade. This defaults to the
+name of the bundle.
 
 Porter uses the Docker driver as the default runtime for executing a bundle's
 invocation image, but an alternate driver may be supplied via '--driver/-d'. For
@@ -115,7 +117,7 @@ instance, the 'debug' driver may be specified, which simply logs the info given
 to it and then exits.
 
 Usage:
-  porter upgrade [CLAIM] [flags]
+  porter upgrade [INSTANCE] [flags]
 
 Examples:
   porter upgrade
@@ -155,8 +157,8 @@ and `porter bundle invoke`.
 ```console
 Invoke a custom action on a bundle.
 
-The first argument is the name of the claim upon which to invoke the action. The
-claim name defaults to the name of the bundle.
+The first argument is the bundle instance name upon which to invoke the action.
+This defaults to the name of the bundle.
 
 Porter uses the Docker driver as the default runtime for executing a bundle's
 invocation image, but an alternate driver may be supplied via '--driver/-d'. For
@@ -164,7 +166,7 @@ instance, the 'debug' driver may be specified, which simply logs the info given
 to it and then exits.
 
 Usage:
-  porter invoke [CLAIM] --action ACTION [flags]
+  porter invoke [INSTANCE] --action ACTION [flags]
 
 Examples:
   porter invoke --action ACTION
@@ -207,8 +209,8 @@ and `porter bundle uninstall`.
 $ porter uninstall --help
 Uninstall a bundle
 
-The first argument is the name of the claim to uninstall. The claim name
-defaults to the name of the bundle.
+The first argument is the bundle instance name to uninstall. This defaults to
+the name of the bundle.
 
 Porter uses the Docker driver as the default runtime for executing a bundle's
 invocation image, but an alternate driver may be supplied via '--driver/-d'. For
@@ -216,7 +218,7 @@ instance, the 'debug' driver may be specified, which simply logs the info given
 to it and then exits.
 
 Usage:
-  porter uninstall [CLAIM] [flags]
+  porter uninstall [INSTANCE] [flags]
 
 Examples:
   porter uninstall
@@ -248,12 +250,14 @@ Global Flags:
       --debug   Enable debug logging
 ```
 
-### Bundle List
+## Instance Commands
 
-This command is available both as `porter bundle list` and `porter bundles list`.
+### Instances List
+
+This command is available both as `porter instance list` and `porter list`.
 
 ```console
-$ porter bundle list --help
+$ porter instance list --help
 List all bundles installed by Porter.
 
 A listing of bundles currently installed by Porter will be provided, along with
@@ -265,8 +269,8 @@ Usage:
   porter bundles list [flags]
 
 Examples:
-  porter bundle list
-  porter bundle list -o json
+  porter instance list
+  porter instance list -o json
 
 Flags:
   -h, --help            help for list
@@ -277,19 +281,19 @@ Global Flags:
       --debug   Enable debug logging
 ```
 
-### Bundle Show
+### Instance Show
 
-This command is available both as `porter bundle show` and `porter bundles show`.
+This command is available both as `porter instance show` and `porter show`.
 
 ```console
-$ porter bundle show --help
-Displays info relating to a bundle claim, including status and a listing of outputs.
+$ porter instance show --help
+Displays info relating to a bundle instance, including status and a listing of outputs.
 
 Usage:
-  porter bundles show [CLAIM] [flags]
+  porter bundles show [INSTANCE] [flags]
 
 Examples:
-  porter bundle show [CLAIM]
+  porter bundle show [INSTANCE]
 
 Optional output formats include json and yaml.
 
@@ -302,24 +306,28 @@ Global Flags:
       --debug   Enable debug logging
 ```
 
-### Bundle Outputs List
+## Instance Outputs Commands
 
-Outputs from a bundle claim can be listed via `porter bundle outputs list`.
+### Instance Outputs List
+
+Outputs from a bundle instance can be listed via `porter instance outputs list`.
 
 ```console
- $ porter bundle outputs list --help
+ $ porter instance outputs list --help
 Displays a listing of bundle outputs.
 
 Usage:
-  porter bundles output list [CLAIM] [flags]
+  porter bundles output list [INSTANCE] [flags]
 
 Examples:
-  porter bundle outputs list [CLAIM]
+  porter instance outputs list
+  porter instance outputs list --instance another-bundle
 
 Optional output formats include json and yaml.
 
 
 Flags:
+  -i, --instance string   Specify the instance to which the output belongs.
   -h, --help            help for list
   -o, --output string   Specify an output format.  Allowed values: table, json, yaml (default "table")
 
@@ -327,23 +335,24 @@ Global Flags:
       --debug   Enable debug logging
 ```
 
-### Bundle Outputs Show
+### Instance Outputs Show
 
-An individual output from a bundle claim can be retrieved via `porter bundle output show`.
+An individual output from a bundle instance can be retrieved via `porter instance output show`.
 
 ```console
- $ porter bundle outputs show --help
+ $ porter instance outputs show --help
 Show a bundle output.
 
 Usage:
-  porter bundles output show NAME [--claim|-c CLAIM] [flags]
+  porter bundles output show NAME [--instance|-i INSTANCE] [flags]
 
 Examples:
-  porter bundle output show NAME [--claim|-c CLAIM]
+  porter instance output show kubeconfig
+  porter instance output show subscription-id --instance azure-mysql
 
 Flags:
-  -c, --claim string   Specify a claim that the output belongs to.
-  -h, --help           help for show
+  -i, --instance string   Specify the instance to which the output belongs.
+  -h, --help              help for show
 
 Global Flags:
       --debug   Enable debug logging

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -252,7 +252,7 @@ Global Flags:
 
 ## Instance Commands
 
-### Instances List
+### List
 
 This command is available both as `porter instance list` and `porter list`.
 
@@ -281,7 +281,7 @@ Global Flags:
       --debug   Enable debug logging
 ```
 
-### Instance Show
+### Show
 
 This command is available both as `porter instance show` and `porter show`.
 
@@ -317,7 +317,7 @@ Outputs from a bundle instance can be listed via `porter instance outputs list`.
 Displays a listing of bundle outputs.
 
 Usage:
-  porter bundles output list [INSTANCE] [flags]
+  porter instance output list [INSTANCE] [flags]
 
 Examples:
   porter instance outputs list
@@ -344,7 +344,7 @@ An individual output from a bundle instance can be retrieved via `porter instanc
 Show a bundle output.
 
 Usage:
-  porter bundles output show NAME [--instance|-i INSTANCE] [flags]
+  porter instance output show NAME [--instance|-i INSTANCE] [flags]
 
 Examples:
   porter instance output show kubeconfig

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -701,10 +701,10 @@ Modify the hello bundle to print "Hello, YOUR NAME", for example "Hello, Aarti",
 1. Finally run `porter install --param name=YOUR_NAME` and look for your name in the output.
 
 ---
-### porter bundle list
+### porter list
 
 ```
-$ porter bundle list
+$ porter list
 NAME          CREATED         MODIFIED        LAST ACTION   LAST STATUS
 HELLO_LLAMA   5 seconds ago   3 seconds ago   install       success
 HELLO         8 minutes ago   8 minutes ago   install       success

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -733,10 +733,10 @@ Modify the hello bundle to print "Hello, YOUR NAME", for example "Hello, Aarti",
 
 ---
 
-### porter bundle list
+### porter list
 
 ```console
-$ porter bundle list
+$ porter list
 NAME          CREATED         MODIFIED        LAST ACTION   LAST STATUS
 HELLO_LLAMA   5 seconds ago   3 seconds ago   install       success
 HELLO         8 minutes ago   8 minutes ago   install       success

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -6,7 +6,7 @@ import (
 
 // Shared arguments for all CNAB actions supported by duffle
 type ActionArguments struct {
-	// Name of the claim.
+	// Name of the instance.
 	Claim string
 
 	// Either a filepath to the bundle or the name of the bundle.

--- a/pkg/cnab/provider/claims.go
+++ b/pkg/cnab/provider/claims.go
@@ -23,11 +23,11 @@ func (d *Duffle) NewClaimStore() (claim.Store, error) {
 func (d *Duffle) FetchClaim(name string) (*claim.Claim, error) {
 	claimStore, err := d.NewClaimStore()
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not retrieve claim %s", name)
+		return nil, errors.Wrapf(err, "could not retrieve bundle instance %s", name)
 	}
 	claim, err := claimStore.Read(name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not retrieve claim %s", name)
+		return nil, errors.Wrapf(err, "could not retrieve bundle instance %s", name)
 	}
 	return &claim, nil
 }

--- a/pkg/cnab/provider/dockerdriver_test.go
+++ b/pkg/cnab/provider/dockerdriver_test.go
@@ -42,7 +42,7 @@ func TestWriteClaimOutputs(t *testing.T) {
 
 	// Expect error when claim has no associated bundle
 	err = d.WriteClaimOutputs(claim, "install")
-	require.EqualError(t, err, "claim has no bundle")
+	require.EqualError(t, err, "bundle instance has no bundle set")
 
 	claim.Bundle = &bundle.Bundle{}
 

--- a/pkg/cnab/provider/duffle.go
+++ b/pkg/cnab/provider/duffle.go
@@ -84,7 +84,7 @@ func (d *Duffle) setupOutputsMount(driverImpl driver.Driver, claimName string) e
 // and Duffle config
 func (d *Duffle) WriteClaimOutputs(c *claim.Claim, action string) error {
 	if c.Bundle == nil {
-		return errors.New("claim has no bundle")
+		return errors.New("bundle instance has no bundle set")
 	}
 
 	if c.Bundle.Outputs == nil {

--- a/pkg/cnab/provider/install.go
+++ b/pkg/cnab/provider/install.go
@@ -15,7 +15,7 @@ func (d *Duffle) Install(args ActionArguments) error {
 
 	c, err := claim.New(args.Claim)
 	if err != nil {
-		return errors.Wrap(err, "invalid claim name")
+		return errors.Wrap(err, "invalid bundle instance name")
 	}
 
 	b, err := d.LoadBundle(args.BundlePath, args.Insecure)
@@ -79,7 +79,7 @@ func (d *Duffle) Install(args ActionArguments) error {
 		return errors.Wrap(runErr, "failed to install the bundle")
 	}
 	if writeErr != nil {
-		return errors.Wrap(writeErr, "failed to write outputs to the claim")
+		return errors.Wrap(writeErr, "failed to write outputs to the bundle instance")
 	}
 	return errors.Wrap(saveErr, "failed to record the installation for the bundle")
 }

--- a/pkg/cnab/provider/uninstall.go
+++ b/pkg/cnab/provider/uninstall.go
@@ -23,7 +23,7 @@ func (d *Duffle) Uninstall(args ActionArguments) error {
 		if err == claim.ErrClaimNotFound {
 			return nil
 		}
-		return errors.Wrapf(err, "could not load claim %s", args.Claim)
+		return errors.Wrapf(err, "could not load bundle instance %s", args.Claim)
 	}
 
 	if args.BundlePath != "" {

--- a/pkg/cnab/provider/upgrade.go
+++ b/pkg/cnab/provider/upgrade.go
@@ -19,7 +19,7 @@ func (d *Duffle) Upgrade(args ActionArguments) error {
 	}
 	c, err := claims.Read(args.Claim)
 	if err != nil {
-		return errors.Wrapf(err, "could not load claim %s", args.Claim)
+		return errors.Wrapf(err, "could not load bundle instance %s", args.Claim)
 	}
 
 	if args.BundlePath != "" {
@@ -77,7 +77,7 @@ func (d *Duffle) Upgrade(args ActionArguments) error {
 		return errors.Wrap(runErr, "failed to upgrade the bundle")
 	}
 	if err != nil {
-		return errors.Wrap(err, "failed to write outputs to the claim")
+		return errors.Wrap(err, "failed to write outputs to the bundle instance")
 	}
 	return errors.Wrap(saveErr, "failed to record the upgrade for the bundle")
 }

--- a/pkg/config/outputs.go
+++ b/pkg/config/outputs.go
@@ -51,13 +51,13 @@ func (c *Config) ReadBundleOutput(name string, claim string) (*Output, error) {
 
 	bytes, err := c.FileSystem.ReadFile(outputPath)
 	if err != nil {
-		return nil, errors.Errorf("unable to read output %q for claim %q", name, claim)
+		return nil, errors.Errorf("unable to read output %q for bundle instance %q", name, claim)
 	}
 
 	var output Output
 	err = json.Unmarshal(bytes, &output)
 	if err != nil {
-		return nil, errors.Errorf("unable to unmarshal output %q for claim %q", name, claim)
+		return nil, errors.Errorf("unable to unmarshal output %q for bundle instance %q", name, claim)
 	}
 
 	return &output, nil

--- a/pkg/mixin/provider/filesystem_test.go
+++ b/pkg/mixin/provider/filesystem_test.go
@@ -77,6 +77,5 @@ func TestFileSystem_GetSchema(t *testing.T) {
 
 	wantSchema, err := ioutil.ReadFile("../../exec/testdata/schema.json")
 	require.NoError(t, err)
-
 	assert.Equal(t, string(wantSchema), string(gotSchema))
 }

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -53,7 +53,7 @@ func (o *bundleFileOptions) Validate(cxt *context.Context) error {
 type sharedOptions struct {
 	bundleFileOptions
 
-	// Name of the claim. Defaults to the name of the bundle.
+	// Name of the instance. Defaults to the name of the bundle.
 	Name string
 
 	// Insecure bundles allowed.
@@ -87,7 +87,7 @@ type sharedOptions struct {
 func (o *sharedOptions) Validate(args []string, cxt *context.Context) error {
 	o.Insecure = true
 
-	err := o.validateClaimName(args)
+	err := o.validateInstanceName(args)
 	if err != nil {
 		return err
 	}
@@ -111,12 +111,12 @@ func (o *sharedOptions) Validate(args []string, cxt *context.Context) error {
 	return nil
 }
 
-// validateClaimName grabs the claim name from the first positional argument.
-func (o *sharedOptions) validateClaimName(args []string) error {
+// validateInstanceName grabs the claim name from the first positional argument.
+func (o *sharedOptions) validateInstanceName(args []string) error {
 	if len(args) == 1 {
 		o.Name = args[0]
 	} else if len(args) > 1 {
-		return errors.Errorf("only one positional argument may be specified, the claim name, but multiple were received: %s", args)
+		return errors.Errorf("only one positional argument may be specified, the bundle instance name, but multiple were received: %s", args)
 	}
 
 	return nil

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -2,7 +2,6 @@ package porter
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -186,14 +185,13 @@ func (t *TestCNABProvider) Uninstall(arguments cnabprovider.ActionArguments) err
 func (t *TestCNABProvider) FetchClaim(name string) (*claim.Claim, error) {
 	bytes, err := afero.ReadFile(t.FileSystem, name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not read claim file for %s", name)
+		return nil, errors.Wrapf(err, "could not read bundle instance file for %s", name)
 	}
 
 	var claim claim.Claim
 	err = json.Unmarshal(bytes, &claim)
 	if err != nil {
-		fmt.Printf("unmarshaled claim: %v", claim)
-		return nil, errors.Wrapf(err, "error encountered unmarshaling claim %s", name)
+		return nil, errors.Wrapf(err, "error encountered unmarshaling bundle instance %s", name)
 	}
 
 	return &claim, nil
@@ -202,7 +200,7 @@ func (t *TestCNABProvider) FetchClaim(name string) (*claim.Claim, error) {
 func (t *TestCNABProvider) CreateClaim(claim *claim.Claim) error {
 	bytes, err := json.Marshal(claim)
 	if err != nil {
-		return errors.Wrapf(err, "error encountered marshaling claim %s", claim.Name)
+		return errors.Wrapf(err, "error encountered marshaling bundle instance %s", claim.Name)
 	}
 
 	return afero.WriteFile(t.FileSystem, claim.Name, bytes, os.ModePerm)

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -103,7 +103,7 @@ func TestInstallOptions_validateParams(t *testing.T) {
 	assert.Len(t, opts.Params, 2)
 }
 
-func TestInstallOptions_validateClaimName(t *testing.T) {
+func TestInstallOptions_validateInstanceName(t *testing.T) {
 	testcases := []struct {
 		name      string
 		args      []string
@@ -112,13 +112,13 @@ func TestInstallOptions_validateClaimName(t *testing.T) {
 	}{
 		{"none", nil, "", ""},
 		{"name set", []string{"wordpress"}, "wordpress", ""},
-		{"too many args", []string{"wordpress", "extra"}, "", "only one positional argument may be specified, the claim name, but multiple were received: [wordpress extra]"},
+		{"too many args", []string{"wordpress", "extra"}, "", "only one positional argument may be specified, the bundle instance name, but multiple were received: [wordpress extra]"},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := InstallOptions{}
-			err := opts.validateClaimName(tc.args)
+			err := opts.validateInstanceName(tc.args)
 
 			if tc.wantError == "" {
 				require.NoError(t, err)

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -37,8 +37,8 @@ func (l CondensedClaimList) Less(i, j int) bool {
 	return l[i].Modified.Before(l[j].Modified)
 }
 
-// ListBundles lists installed bundles by their claims.
-func (p *Porter) ListBundles(opts ListOptions) error {
+// ListInstances lists installed bundles by their claims.
+func (p *Porter) ListInstances(opts ListOptions) error {
 	cp := cnab.NewDuffle(p.Config)
 	claimStore, err := cp.NewClaimStore()
 	if err != nil {
@@ -46,7 +46,7 @@ func (p *Porter) ListBundles(opts ListOptions) error {
 	}
 	claims, err := claimStore.ReadAll()
 	if err != nil {
-		return errors.Wrap(err, "could not list claims")
+		return errors.Wrap(err, "could not list bundle instances")
 	}
 
 	var condensedClaims CondensedClaimList

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -42,7 +42,7 @@ func (o *OutputShowOptions) Validate(args []string, cxt *context.Context) error 
 	if o.sharedOptions.Name == "" {
 		err := o.sharedOptions.defaultBundleFiles(cxt)
 		if err != nil {
-			return errors.New("claim name must be provided via [--claim|-c CLAIM]")
+			return errors.New("bundle instance name must be provided via [--instance|-i INSTANCE]")
 		}
 	}
 
@@ -53,7 +53,7 @@ func (o *OutputShowOptions) Validate(args []string, cxt *context.Context) error 
 // setting attributes of OutputListOptions as applicable
 func (o *OutputListOptions) Validate(args []string, cxt *context.Context) error {
 	// Ensure only one argument exists (claim name) if args length non-zero
-	err := o.sharedOptions.validateClaimName(args)
+	err := o.sharedOptions.validateInstanceName(args)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (o *OutputListOptions) Validate(args []string, cxt *context.Context) error 
 	// Attempt to derive claim name from context
 	err = o.sharedOptions.defaultBundleFiles(cxt)
 	if err != nil {
-		return errors.Wrap(err, "claim name must be provided")
+		return errors.Wrap(err, "bundle instance name must be provided")
 	}
 
 	return o.ParseFormat()
@@ -77,7 +77,7 @@ func (p *Porter) ShowBundleOutput(opts *OutputShowOptions) error {
 
 	output, err := p.ReadBundleOutput(opts.Output, name)
 	if err != nil {
-		return errors.Wrapf(err, "unable to read output '%s' for claim '%s'", opts.Output, name)
+		return errors.Wrapf(err, "unable to read output '%s' for bundle instance '%s'", opts.Output, name)
 	}
 
 	fmt.Fprintln(p.Out, output.Value)
@@ -126,7 +126,7 @@ func (p *Porter) fetchBundleOutputs(claim string) (*config.Outputs, error) {
 			if !info.IsDir() {
 				output, err := p.ReadBundleOutput(info.Name(), claim)
 				if err != nil {
-					return errors.Wrapf(err, "unable to read output '%s' for claim '%s'", info.Name(), claim)
+					return errors.Wrapf(err, "unable to read output '%s' for bundle instance '%s'", info.Name(), claim)
 				}
 
 				outputList = append(outputList, *output)

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -21,7 +21,7 @@ func TestPorter_fetchBundleOutputs_Error(t *testing.T) {
 
 	_, err = p.fetchBundleOutputs("bad-outputs-bundle")
 	require.EqualError(t, err,
-		"unable to read output 'bad-output' for claim 'bad-outputs-bundle': unable to unmarshal output \"bad-output\" for claim \"bad-outputs-bundle\"")
+		"unable to read output 'bad-output' for bundle instance 'bad-outputs-bundle': unable to unmarshal output \"bad-output\" for bundle instance \"bad-outputs-bundle\"")
 }
 
 func TestPorter_fetchBundleOutputs(t *testing.T) {

--- a/pkg/porter/run.go
+++ b/pkg/porter/run.go
@@ -81,7 +81,7 @@ func (o *RunOptions) defaultDebug() error {
 func (p *Porter) Run(opts RunOptions) error {
 	claimName := os.Getenv(config.EnvClaimName)
 	bundleName := os.Getenv(config.EnvBundleName)
-	fmt.Fprintf(p.Out, "executing %s action from %s (claim: %s) defined in %s\n", opts.parsedAction, bundleName, claimName, opts.File)
+	fmt.Fprintf(p.Out, "executing %s action from %s (bundle instance: %s) defined in %s\n", opts.parsedAction, bundleName, claimName, opts.File)
 
 	err := p.LoadManifestFrom(opts.File)
 	if err != nil {

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -5,9 +5,7 @@ import (
 	"time"
 
 	dtprinter "github.com/carolynvs/datetime-printer"
-	"github.com/pkg/errors"
-
-	context "github.com/deislabs/porter/pkg/context"
+	"github.com/deislabs/porter/pkg/context"
 	"github.com/deislabs/porter/pkg/printer"
 )
 
@@ -19,24 +17,23 @@ type ShowOptions struct {
 
 // Validate prepares for a show bundle action and validates the args/options.
 func (so *ShowOptions) Validate(args []string, cxt *context.Context) error {
-	// Ensure only one argument exists (claim name) if args length non-zero
-	err := so.sharedOptions.validateClaimName(args)
+	// Ensure only one argument exists (instance name) if args length non-zero
+	err := so.sharedOptions.validateInstanceName(args)
 	if err != nil {
 		return err
 	}
 
-	// If args length zero, attempt to derive claim name from context
 	err = so.sharedOptions.defaultBundleFiles(cxt)
 	if err != nil {
-		return errors.Wrap(err, "claim name must be provided")
+		return err
 	}
 
 	return so.ParseFormat()
 }
 
-// ShowBundle shows a bundle, or more properly a bundle claim, along with any
+// ShowInstances shows a bundle, or more properly a bundle claim, along with any
 // associated outputs
-func (p *Porter) ShowBundle(opts ShowOptions) error {
+func (p *Porter) ShowInstances(opts ShowOptions) error {
 	err := p.applyDefaultOptions(&opts.sharedOptions)
 	if err != nil {
 		return err

--- a/pkg/porter/show_test.go
+++ b/pkg/porter/show_test.go
@@ -50,7 +50,7 @@ func TestPorter_ShowBundle(t *testing.T) {
 		t.Fatal("expected p.CNAB to be of type *TestCNABProvider")
 	}
 
-	err = p.ShowBundle(opts)
+	err = p.ShowInstances(opts)
 	require.NoError(t, err)
 
 	wantOutput :=

--- a/scripts/test/test-terraform.sh
+++ b/scripts/test/test-terraform.sh
@@ -42,8 +42,8 @@ echo "${list_outputs}" | grep -q "foo!"
 
 ${PORTER_HOME}/porter upgrade --insecure --debug --param file_contents='bar!'
 
-echo "Verifing bundle output(s) via 'porter bundle output show' after upgrade"
-${PORTER_HOME}/porter bundle output show file_contents | grep -q "bar!"
+echo "Verifying instance output(s) via 'porter instance output show' after upgrade"
+${PORTER_HOME}/porter instance output show file_contents | grep -q "bar!"
 
 # TODO: enable when status supported
 # ${PORTER_HOME}/porter status --debug | grep -q 'content = bar!'

--- a/scripts/test/test-terraform.sh
+++ b/scripts/test/test-terraform.sh
@@ -31,8 +31,8 @@ if ! cat ${porter_output} | grep -q 'content:  "" => "foo!"'; then
   exit 1
 fi
 
-echo "Verifing bundle output(s) via 'porter bundle outputs list' after install"
-list_outputs=$(${PORTER_HOME}/porter bundle outputs list)
+echo "Verifying instance output(s) via 'porter instance outputs list' after install"
+list_outputs=$(${PORTER_HOME}/porter instance outputs list)
 echo "${list_outputs}"
 echo "${list_outputs}" | grep -q "file_contents"
 echo "${list_outputs}" | grep -q "foo!"

--- a/tests/dependencies_test.go
+++ b/tests/dependencies_test.go
@@ -178,9 +178,9 @@ func uninstallWordpressBundle(p *porter.TestPorter, namespace string) {
 
 	// Verify that the dependency claim is uninstalled
 	_, err = p.CNAB.FetchClaim("wordpress-mysql")
-	assert.EqualError(p.T(), err, "could not retrieve claim wordpress-mysql: Claim does not exist")
+	assert.EqualError(p.T(), err, "could not retrieve bundle instance wordpress-mysql: Claim does not exist")
 
 	// Verify that the bundle claim is uninstalled
 	_, err = p.CNAB.FetchClaim("wordpress")
-	assert.EqualError(p.T(), err, "could not retrieve claim wordpress: Claim does not exist")
+	assert.EqualError(p.T(), err, "could not retrieve bundle instance wordpress: Claim does not exist")
 }

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -45,5 +45,5 @@ func TestInvokeCustomAction(t *testing.T) {
 	// Verify that the custom action was recorded properly
 	claim, err := p.CNAB.FetchClaim(p.Manifest.Name)
 	require.NoError(t, err, "could not fetch claim")
-	assert.Equal(t, "zombies", claim.Result.Action, "the custom action wasn't recorded in the claim")
+	assert.Equal(t, "zombies", claim.Result.Action, "the custom action wasn't recorded in the bundle instance")
 }


### PR DESCRIPTION
* porter bundle list -> porter instances list
* alias porter instances list to porter list
* porter bundle outputs list -> porter instance outputs list
* porter bundle outputs show -> porter instance outputs show
* Made positional argument consistent for specifying the instance name
when listing outputs for an instance. I made it a flag since outputs
show uses a flag. Positional arguments should be used when it is the
name of the resource. In this case the resource is output, so instance
should have been a flag to begin with.
* Updated documentation to match.

Closes #330 