### PR TITLE
Sync doc for porter version

### DIFF
--- a/docs/content/cli/version.md
+++ b/docs/content/cli/version.md
@@ -18,7 +18,8 @@ porter version [flags]
 ### Options
 
 ```
-  -h, --help   help for version
+  -h, --help            help for version
+  -o, --output string   Specify an output format.  Allowed values: json, plaintext (default "plaintext")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
A PR to modify this command was merged near the same time that I automated the docs for the site and this file was missed.