### PR TITLE
Fix example exec output

### DIFF
--- a/examples/exec-outputs/generate-config.sh
+++ b/examples/exec-outputs/generate-config.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo '{"user": "sally"}' >> config.json
+echo '{"user": "sally"}' > config.json


### PR DESCRIPTION
The example was concatenating the config file instead of overwriting it. So when the user reran the bundle, the config file had multiple lines of the same example config.