### PR TITLE
fix(context.go): ensure censored writer does not replace empty strings

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -57,7 +57,9 @@ func (cw *CensoredWriter) SetSensitiveValues(vals []string) {
 func (cw *CensoredWriter) Write(b []byte) (int, error) {
 	auditedBytes := b
 	for _, val := range cw.sensitiveValues {
-		auditedBytes = bytes.Replace(auditedBytes, []byte(val), []byte("*******"), -1)
+		if strings.TrimSpace(val) != "" {
+			auditedBytes = bytes.Replace(auditedBytes, []byte(val), []byte("*******"), -1)
+		}
 	}
 
 	_, err := cw.writer.Write(auditedBytes)

--- a/pkg/mixin/testdata/exec_input_with_whitespace.yaml
+++ b/pkg/mixin/testdata/exec_input_with_whitespace.yaml
@@ -1,0 +1,6 @@
+install:
+- exec:
+    description: "Say Hello"
+    command: bash
+    flags:
+        c: "printf \"Hello World \t\n\""


### PR DESCRIPTION
Adds a safeguard to ensure we don't attempt to mask empty strings, in the off-chance that they show up as a sensitive value.

Before
```
=== RUN   TestRunner_RunWithMaskedOutput
--- FAIL: TestRunner_RunWithMaskedOutput (0.34s)
    logger.go:11: *******H*******e*******l*******l*******o******* ***************************************************************
        *******
    runner_integration_test.go:69:
        	Error Trace:	runner_integration_test.go:69
        	Error:      	"*******H*******e*******l*******l*******o******* ***************************************************************
        	            	*******" does not contain "Hello *******"
        	Test:       	TestRunner_RunWithMaskedOutput
```

After
```
=== RUN   TestRunner_RunWithMaskedOutput
--- PASS: TestRunner_RunWithMaskedOutput (0.18s)
    logger.go:11: Hello *******
```