### PR TITLE
feat(*): enable parameters of type file in Porter manifest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -266,8 +266,8 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "carolynvs-op-config-func-plus-custom-validators"
-  digest = "1:3623d90066a808fc67397b29391c54554639bdbc1c734d093697465e2ad2a8c6"
+  branch = "fix/custom-validators"
+  digest = "1:82dc259bd94f991a4908898f18c419ea83618f3e1d0d1e844cd744058c1fb7e5"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -284,7 +284,7 @@
     "utils/crud",
   ]
   pruneopts = "NT"
-  revision = "d45d5e04f244cc146e16bf947bd7f07a89b145bf"
+  revision = "f51437c7d0babe80355d38e3e103a3a720ecaa97"
   source = "github.com/vdice/cnab-go"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -266,7 +266,8 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:397a47c688355450dd1ea9aea8795b3774d5278c8b37199ad4068758dd075956"
+  branch = "carolynvs-op-config-func-plus-custom-validators"
+  digest = "1:3623d90066a808fc67397b29391c54554639bdbc1c734d093697465e2ad2a8c6"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -283,8 +284,8 @@
     "utils/crud",
   ]
   pruneopts = "NT"
-  revision = "93515c713a91d6da48b5a9c68e4b0502d8d39963"
-  version = "v0.4.0-beta1"
+  revision = "d45d5e04f244cc146e16bf947bd7f07a89b145bf"
+  source = "github.com/vdice/cnab-go"
 
 [[projects]]
   digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,10 +1,12 @@
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  version = "v0.4.0-beta1"
+  source = "github.com/vdice/cnab-go"
+  branch = "fix/custom-validators"
 
 [[override]]
   name = "github.com/deislabs/cnab-go"
-  version = "v0.4.0-beta1"
+  source = "github.com/vdice/cnab-go"
+  branch = "fix/custom-validators"
 
 # Using master until there is a release of cnab-to-oci
 [[constraint]]

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -163,6 +163,10 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 		// (Both Params and Outputs may reference same Definition)
 		if _, exists := (*defs)[param.Name]; !exists {
 			def := param.Schema
+			if def.Type == "file" {
+				def.Type = "string"
+				def.ContentEncoding = "base64"
+			}
 			(*defs)[param.Name] = &def
 		}
 		params[param.Name] = p

--- a/pkg/cnab/config_adapter/adapter_test.go
+++ b/pkg/cnab/config_adapter/adapter_test.go
@@ -172,6 +172,20 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 				Default: `"myobject": { "foo": "true", "bar": [ 1, 2, 3 ] }`,
 			},
 		},
+		{
+			"afile",
+			bundle.Parameter{
+				Definition: "afile",
+				Destination: &bundle.Location{
+					Path: "/root/.kube/config",
+				},
+				Required: true,
+			},
+			definition.Schema{
+				Type:            "string",
+				ContentEncoding: "base64",
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
+++ b/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
@@ -47,6 +47,9 @@ parameters:
           3
         ]
       }'
+  - name: afile
+    type: file
+    path: /root/.kube/config
 
 mixins:
   - exec

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -71,17 +71,17 @@ func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]stri
 }
 
 func (d *Duffle) getUnconvertedValueFromRaw(def *definition.Schema, key, rawValue string) (string, error) {
-		// the parameter value (via rawValue) may represent a file on the local filesystem
-		if def.Type == "string" && def.ContentEncoding == "base64" {
-			if _, err := d.FileSystem.Stat(rawValue); err == nil {
-				bytes, err := d.FileSystem.ReadFile(rawValue)
-				if err != nil {
-					return "", errors.Wrapf(err, "unable to read file parameter %s", key)
-				}
-				return base64.StdEncoding.EncodeToString(bytes), nil
+	// the parameter value (via rawValue) may represent a file on the local filesystem
+	if def.Type == "string" && def.ContentEncoding == "base64" {
+		if _, err := d.FileSystem.Stat(rawValue); err == nil {
+			bytes, err := d.FileSystem.ReadFile(rawValue)
+			if err != nil {
+				return "", errors.Wrapf(err, "unable to read file parameter %s", key)
 			}
+			return base64.StdEncoding.EncodeToString(bytes), nil
 		}
-		return rawValue, nil
+	}
+	return rawValue, nil
 }
 
 // TODO: remove in favor of cnab-go logic: https://github.com/deislabs/cnab-go/pull/99

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -1,6 +1,7 @@
 package cnabprovider
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/deislabs/cnab-go/bundle"
@@ -25,7 +26,19 @@ func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]stri
 			return nil, fmt.Errorf("definition %s not defined in bundle", param.Definition)
 		}
 
-		value, err := def.ConvertValue(rawValue)
+		unconverted := rawValue
+		// parameter may represent a file on the local filesystem
+		if def.Type == "string" && def.ContentEncoding == "base64" {
+			if _, err := d.FileSystem.Stat(rawValue); err == nil {
+				bytes, err := d.FileSystem.ReadFile(rawValue)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to read file parameter %s", key)
+				}
+				unconverted = base64.StdEncoding.EncodeToString(bytes)
+			}
+		}
+
+		value, err := def.ConvertValue(unconverted)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert parameter's %s value %s to the destination parameter type %s", key, rawValue, def.Type)
 		}

--- a/pkg/cnab/provider/testdata/file-param
+++ b/pkg/cnab/provider/testdata/file-param
@@ -1,0 +1,1 @@
+Hello World!

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -144,13 +144,11 @@ func (pd *ParameterDefinition) Validate() error {
 
 // DeepCopy copies a ParameterDefinition and returns the copy
 func (pd *ParameterDefinition) DeepCopy() *ParameterDefinition {
-	return &ParameterDefinition{
-		Name:        pd.Name,
-		Sensitive:   pd.Sensitive,
-		ApplyTo:     pd.ApplyTo,
-		Destination: pd.Destination,
-		Schema:      pd.Schema,
-	}
+	var p2 ParameterDefinition
+	p2 = *pd
+	p2.ApplyTo = make([]string, len(pd.ApplyTo))
+	copy(p2.ApplyTo, pd.ApplyTo)
+	return &p2
 }
 
 type CredentialDefinition struct {

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -95,7 +95,10 @@ func TestValidateParameterDefinition(t *testing.T) {
 	pd.Destination = Location{}
 
 	err := pd.Validate()
-	assert.EqualError(t, err, "no destination path supplied for parameter myparam")
+	assert.EqualError(t, err, `1 error occurred:
+	* no destination path supplied for parameter myparam
+
+`)
 
 	pd.Destination.Path = "/path/to/file"
 

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -92,12 +92,9 @@ func TestValidateParameterDefinition(t *testing.T) {
 		},
 	}
 
-	err := pd.Validate()
-	assert.EqualError(t, err, "no destination supplied for parameter myparam")
-
 	pd.Destination = Location{}
 
-	err = pd.Validate()
+	err := pd.Validate()
 	assert.EqualError(t, err, "no destination path supplied for parameter myparam")
 
 	pd.Destination.Path = "/path/to/file"

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/deislabs/cnab-go/bundle/definition"
 	"gopkg.in/yaml.v2"
 
 	"github.com/stretchr/testify/assert"
@@ -81,4 +82,26 @@ func TestMixinDeclaration_MarshalYAML(t *testing.T) {
 	require.NoError(t, err, "could not read testdata")
 
 	assert.Equal(t, string(wantYaml), string(gotYaml))
+}
+
+func TestValidateParameterDefinition(t *testing.T) {
+	pd := ParameterDefinition{
+		Name: "myparam",
+		Schema: definition.Schema{
+			Type: "file",
+		},
+	}
+
+	err := pd.Validate()
+	assert.EqualError(t, err, "no destination supplied for parameter myparam")
+
+	pd.Destination = Location{}
+
+	err = pd.Validate()
+	assert.EqualError(t, err, "no destination path supplied for parameter myparam")
+
+	pd.Destination.Path = "/path/to/file"
+
+	err = pd.Validate()
+	assert.NoError(t, err)
 }

--- a/pkg/config/testdata/file-param
+++ b/pkg/config/testdata/file-param
@@ -1,0 +1,1 @@
+SGVsbG8gV29ybGQh

--- a/pkg/porter/run.go
+++ b/pkg/porter/run.go
@@ -93,6 +93,14 @@ func (p *Porter) Run(opts RunOptions) error {
 		return err
 	}
 
+	// Prepare prepares the runtime environment prior to step execution.
+	// As an example, for parameters of type "file", we may need to decode file contents
+	// on the filesystem before execution of the step/action
+	err = runtimeManifest.Prepare()
+	if err != nil {
+		return err
+	}
+
 	err = p.FileSystem.MkdirAll(context.MixinOutputsDir, 0755)
 	if err != nil {
 		return errors.Wrapf(err, "could not create outputs directory %s", context.MixinOutputsDir)

--- a/pkg/porter/testdata/porter.yaml
+++ b/pkg/porter/testdata/porter.yaml
@@ -16,7 +16,7 @@ credentials:
 
 parameters:
   - name: my-first-param
-    type: int
+    type: integer
     default: 9
     env: MY_FIRST_PARAM
   - name: my-second-param

--- a/tests/testdata/bundle-with-file-params.yaml
+++ b/tests/testdata/bundle-with-file-params.yaml
@@ -1,0 +1,44 @@
+name: mybun
+version: 0.1.0
+description: "An example Porter configuration"
+invocationImage: porter-hello:latest
+tag: deislabs/porter-hello-bundle:latest
+
+mixins:
+  - exec
+
+parameters:
+  - name: myfile
+    type: file
+    destination:
+      path: /root/myfile
+
+outputs:
+  - name: myfile
+    type: string
+    applyTo:
+      - install
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      flags:
+        c: cat /root/myfile
+      outputs:
+        - name: myfile
+          path: /root/myfile
+
+upgrade:
+  - exec:
+      description: "World 2.0"
+      command: bash
+      flags:
+        c: cat /root/myfile
+
+uninstall:
+  - exec:
+      description: "Uninstall Hello World"
+      command: bash
+      flags:
+        c: cat /root/myfile

--- a/tests/testdata/bundle-with-file-params.yaml
+++ b/tests/testdata/bundle-with-file-params.yaml
@@ -10,8 +10,7 @@ mixins:
 parameters:
   - name: myfile
     type: file
-    destination:
-      path: /root/myfile
+    path: /root/myfile
 
 outputs:
   - name: myfile

--- a/tests/testdata/myfile
+++ b/tests/testdata/myfile
@@ -1,0 +1,1 @@
+Hello World!

--- a/vendor/github.com/deislabs/cnab-go/bundle/definition/schema.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/definition/schema.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/qri-io/jsonschema"
 )
 
 type Definitions map[string]*Schema
@@ -96,7 +95,7 @@ func (s *Schema) UnmarshalJSON(data []byte) error {
 	// Before we unmarshal into the cnab-go bundle/definition/Schema type, unmarshal into
 	// the library struct so we can handle any validation errors in the schema. If there
 	// are any errors, return those.
-	js := new(jsonschema.RootSchema)
+	js := NewRootSchema()
 	if err := js.UnmarshalJSON(data); err != nil {
 		return err
 	}

--- a/vendor/github.com/deislabs/cnab-go/bundle/definition/validation.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/definition/validation.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
-	"github.com/qri-io/jsonschema"
 )
 
 // ValidationError error represents a validation error
@@ -24,7 +23,7 @@ func (s *Schema) Validate(data interface{}) ([]ValidationError, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to load schema")
 	}
-	def := new(jsonschema.RootSchema)
+	def := NewRootSchema()
 	err = json.Unmarshal([]byte(b), def)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to build schema")

--- a/vendor/github.com/deislabs/cnab-go/bundle/definition/validators.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/definition/validators.go
@@ -1,0 +1,29 @@
+package definition
+
+import (
+	"github.com/qri-io/jsonschema"
+)
+
+// ContentEncoding represents a "custom" Schema property
+type ContentEncoding string
+
+// NewContentEncoding allocates a new ContentEncoding validator
+func NewContentEncoding() jsonschema.Validator {
+	return new(ContentEncoding)
+}
+
+// Validate implements the Validator interface for ContentEncoding
+// Currently, this is a no-op and is only used to register with the jsonschema library
+// that 'contentEncoding' is a valid property (as of writing, it isn't one of the defaults)
+func (c ContentEncoding) Validate(propPath string, data interface{}, errs *[]jsonschema.ValError) {}
+
+// NewRootSchema returns a jsonschema.RootSchema with any needed custom
+// jsonschema.Validators pre-registered
+func NewRootSchema() *jsonschema.RootSchema {
+	// Register custom validators here
+	// Note: as of writing, jsonschema doesn't have a stock validator for intances of type `contentEncoding`
+	// There may be others missing in the library that exist in http://json-schema.org/draft-07/schema#
+	// and thus, we'd need to create/register them here (if not included upstream)
+	jsonschema.RegisterValidator("contentEncoding", NewContentEncoding)
+	return new(jsonschema.RootSchema)
+}

--- a/vendor/github.com/deislabs/cnab-go/claim/claim.go
+++ b/vendor/github.com/deislabs/cnab-go/claim/claim.go
@@ -48,7 +48,7 @@ type Claim struct {
 }
 
 // ValidName is a regular expression that indicates whether a name is a valid claim name.
-var ValidName = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
+var ValidName = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
 
 // New creates a new Claim initialized for an installation operation.
 func New(name string) (*Claim, error) {


### PR DESCRIPTION
Enables Porter manifest parameters of type `file`.  Ref https://github.com/deislabs/porter/issues/480

TODO:
 - [x] remove `vendor` mods:  PR changes to `cnab-go` and update Gopkg w/ temp commit, etc.... or something else entirely (see https://github.com/deislabs/cnab-go/issues/117)

~~Note: validation broken pending https://github.com/deislabs/porter/pull/581~~