### PR TITLE
Default the mixin feed url to DeisLabs

### DIFF
--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/deislabs/porter/pkg/mixin"
 	"github.com/deislabs/porter/pkg/mixin/feed"
 	"github.com/deislabs/porter/pkg/porter"
@@ -66,7 +68,7 @@ func BuildMixinInstallCommand(p *porter.Porter) *cobra.Command {
 	cmd.Flags().StringVar(&opts.URL, "url", "",
 		"URL from where the mixin can be downloaded, for example https://github.com/org/proj/releases/downloads")
 	cmd.Flags().StringVar(&opts.FeedURL, "feed-url", "",
-		"URL of an atom feed where the mixin can be downloaded")
+		fmt.Sprintf(`URL of an atom feed where the mixin can be downloaded (default %s)`, mixin.DefaultFeedUrl))
 	return cmd
 }
 

--- a/docs/content/cli/mixins_install.md
+++ b/docs/content/cli/mixins_install.md
@@ -27,7 +27,7 @@ porter mixins install NAME [flags]
 ### Options
 
 ```
-      --feed-url string   URL of an atom feed where the mixin can be downloaded
+      --feed-url string   URL of an atom feed where the mixin can be downloaded (default https://cdn.deislabs.io/porter/atom.xml)
   -h, --help              help for install
       --url string        URL from where the mixin can be downloaded, for example https://github.com/org/proj/releases/downloads
   -v, --version string    The mixin version. This can either be a version number, or a tagged release like 'latest' or 'canary' (default "latest")

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -65,7 +65,7 @@ You can update an existing mixin, or install a new mixin using the `porter mixin
 install` command:
 
 ```console
-$ porter mixin install terraform --feed-url https://cdn.deislabs.io/porter/atom.xml
+$ porter mixin install terraform
 installed terraform mixin
 v0.3.0-beta.1 (0d24b85)
 ```

--- a/docs/content/mixins/aws.md
+++ b/docs/content/mixins/aws.md
@@ -11,7 +11,7 @@ Source: https://github.com/deislabs/porter-aws
 
 ### Install or Upgrade
 ```
-porter mixin install aws --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install aws
 ```
 
 ### Mixin Syntax

--- a/docs/content/mixins/azure.md
+++ b/docs/content/mixins/azure.md
@@ -11,7 +11,7 @@ https://github.com/deislabs/porter-azure/
 
 ### Install or Upgrade
 ```
-porter mixin install azure --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install azure
 ```
 
 ### Examples

--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -9,7 +9,7 @@ Source: https://github.com/deislabs/porter/tree/master/pkg/exec
 
 ### Install or Upgrade
 ```
-porter mixin install terraform --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install exec
 ```
 
 ## Mixin Syntax

--- a/docs/content/mixins/gcloud.md
+++ b/docs/content/mixins/gcloud.md
@@ -11,7 +11,7 @@ Source: https://github.com/deislabs/porter-gcloud
 
 ### Install or Upgrade
 ```
-porter mixin install gcloud --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install gcloud
 ```
 
 ## Mixin Syntax

--- a/docs/content/mixins/helm.md
+++ b/docs/content/mixins/helm.md
@@ -11,7 +11,7 @@ Source: https://github.com/deislabs/porter-helm
 
 ### Install or Upgrade
 ```
-porter mixin install helm --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install helm
 ```
 
 ### Examples

--- a/docs/content/mixins/kubernetes.md
+++ b/docs/content/mixins/kubernetes.md
@@ -11,7 +11,7 @@ Source: https://github.com/deislabs/porter/tree/master/pkg/kubernetes
 
 ### Install or Upgrade
 ```
-porter mixin install kubernetes --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install kubernete
 ```
 
 ### Examples

--- a/docs/content/mixins/terraform.md
+++ b/docs/content/mixins/terraform.md
@@ -11,7 +11,7 @@ Source: https://github.com/deislabs/porter-terraform
 
 ### Install or Upgrade
 ```
-porter mixin install terraform --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install terraform
 ```
 
 ### Examples

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -1306,7 +1306,7 @@ Make a new bundle and install the Helm chart for etcd-operator
 
 Anyone can make a mixin and have people install it using Porter
 
-**porter mixin install terraform --feed-url cdn.deislabs.io/porter/atom.xml**
+**porter mixin install terraform**
 
 ---
 

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -1219,7 +1219,7 @@ Make a new bundle and install the Helm chart for etcd-operator
 
 Anyone can make a mixin and have people install it using Porter
 
-**porter mixin install terraform --feed-url cdn.deislabs.io/porter/atom.xml**
+**porter mixin install terraform**
 
 ---
 

--- a/pkg/mixin/install.go
+++ b/pkg/mixin/install.go
@@ -7,6 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	DefaultFeedUrl = "https://cdn.deislabs.io/porter/atom.xml"
+)
+
 type InstallOptions struct {
 	Name          string
 	URL           string
@@ -47,8 +51,8 @@ func (o *InstallOptions) Validate(args []string) error {
 }
 
 func (o *InstallOptions) validateURL() error {
-	if o.URL == "" && o.FeedURL == "" {
-		return errors.New("either --url or --feed-url is required")
+	if o.URL == "" {
+		return nil
 	}
 
 	parsedURL, err := url.Parse(o.URL)
@@ -61,8 +65,8 @@ func (o *InstallOptions) validateURL() error {
 }
 
 func (o *InstallOptions) validateFeedURL() error {
-	if o.FeedURL == "" {
-		return nil
+	if o.URL == "" && o.FeedURL == "" {
+		o.FeedURL = DefaultFeedUrl
 	}
 
 	parsedFeedURL, err := url.Parse(o.FeedURL)

--- a/pkg/mixin/install_test.go
+++ b/pkg/mixin/install_test.go
@@ -40,13 +40,14 @@ func TestInstallOptions_Validate_BadFeedURL(t *testing.T) {
 	assert.EqualError(t, err, "invalid --feed-url :#: parse :: missing protocol scheme")
 }
 
-func TestInstallOptions_Validate_MissingURL(t *testing.T) {
+func TestInstallOptions_Validate_DefaultFeedURL(t *testing.T) {
 	opts := InstallOptions{
 		URL: "",
 	}
 
 	err := opts.Validate([]string{"helm"})
-	assert.EqualError(t, err, "either --url or --feed-url is required")
+	require.NoError(t, err)
+	assert.Equal(t, DefaultFeedUrl, opts.FeedURL)
 }
 
 func TestInstallOptions_Validate_FeedUrlSpecified(t *testing.T) {

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -13,12 +13,11 @@ chmod +x $PORTER_HOME/porter
 cp $PORTER_HOME/porter $PORTER_HOME/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
-FEED_URL=$PORTER_URL/atom.xml
-$PORTER_HOME/porter mixin install exec --version $PORTER_VERSION --feed-url $FEED_URL
-$PORTER_HOME/porter mixin install kubernetes --version $PORTER_VERSION --feed-url $FEED_URL
-$PORTER_HOME/porter mixin install helm --version $PORTER_VERSION --feed-url $FEED_URL
-$PORTER_HOME/porter mixin install azure --version $PORTER_VERSION --feed-url $FEED_URL
-$PORTER_HOME/porter mixin install terraform --version $PORTER_VERSION --feed-url $FEED_URL
+$PORTER_HOME/porter mixin install exec --version $PORTER_VERSION
+$PORTER_HOME/porter mixin install kubernetes --version $PORTER_VERSION
+$PORTER_HOME/porter mixin install helm --version $PORTER_VERSION
+$PORTER_HOME/porter mixin install azure --version $PORTER_VERSION
+$PORTER_HOME/porter mixin install terraform --version $PORTER_VERSION
 
 echo "Installation complete."
 echo "Add porter to your path by running:"

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -14,12 +14,11 @@ chmod +x $PORTER_HOME/porter
 chmod +x $PORTER_HOME/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
-FEED_URL=$PORTER_URL/atom.xml
-$PORTER_HOME/porter mixin install exec --version $PORTER_VERSION --feed-url $FEED_URL
-$PORTER_HOME/porter mixin install kubernetes --version $PORTER_VERSION --feed-url $FEED_URL
-$PORTER_HOME/porter mixin install helm --version $PORTER_VERSION --feed-url $FEED_URL
-$PORTER_HOME/porter mixin install azure --version $PORTER_VERSION --feed-url $FEED_URL
-$PORTER_HOME/porter mixin install terraform --version $PORTER_VERSION --feed-url $FEED_URL
+$PORTER_HOME/porter mixin install exec --version $PORTER_VERSION
+$PORTER_HOME/porter mixin install kubernetes --version $PORTER_VERSION
+$PORTER_HOME/porter mixin install helm --version $PORTER_VERSION
+$PORTER_HOME/porter mixin install azure --version $PORTER_VERSION
+$PORTER_HOME/porter mixin install terraform --version $PORTER_VERSION
 
 echo "Installation complete."
 echo "Add porter to your path by running:"

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -9,12 +9,11 @@ mkdir -f $PORTER_HOME
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_VERSION/porter-linux-amd64", "$PORTER_HOME\porter-runtime")
 echo "Installed $(& $PORTER_HOME\porter.exe version)"
 
-$FEED_URL="$PORTER_URL/atom.xml"
-& $PORTER_HOME/porter mixin install exec --version $PORTER_VERSION --feed-url $FEED_URL
-& $PORTER_HOME/porter mixin install kubernetes --version $PORTER_VERSION --feed-url $FEED_URL
-& $PORTER_HOME/porter mixin install helm --version $PORTER_VERSION --feed-url $FEED_URL
-& $PORTER_HOME/porter mixin install azure --version $PORTER_VERSION --feed-url $FEED_URL
-& $PORTER_HOME/porter mixin install terraform --version $PORTER_VERSION --feed-url $FEED_URL
+& $PORTER_HOME/porter mixin install exec --version $PORTER_VERSION
+& $PORTER_HOME/porter mixin install kubernetes --version $PORTER_VERSION
+& $PORTER_HOME/porter mixin install helm --version $PORTER_VERSION
+& $PORTER_HOME/porter mixin install azure --version $PORTER_VERSION
+& $PORTER_HOME/porter mixin install terraform --version $PORTER_VERSION
 
 echo "Installation complete."
 echo "Add porter to your path by running:"

--- a/workshop/aws-bucket/README.md
+++ b/workshop/aws-bucket/README.md
@@ -4,7 +4,7 @@ This example creates an AWS bucket, lists the buckets on your account and then d
 
 Install the aws mixin
 ```
-porter mixin install aws --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install aws
 ```
 
 # Credentials

--- a/workshop/gcloud-compute/README.md
+++ b/workshop/gcloud-compute/README.md
@@ -5,7 +5,7 @@ This example creates an Google Cloud VM, labels it and then deletes the test VM.
 Install the gcloud mixin
 
 ```
-porter mixin install gcloud --feed-url https://cdn.deislabs.io/porter/atom.xml
+porter mixin install gcloud
 ```
 
 # Credentials


### PR DESCRIPTION
* Unless the user specifies `--url` or `--feed-url`, use the atom feed for deislabs
* Update all the install instructions for the mixins to not specify `--feed-url`
* Update stray references of --feed-url to not use it unless strictly necessary