### PR TITLE
Include mixin version in porter mixins list output

### DIFF
--- a/cmd/exec/main.go
+++ b/cmd/exec/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -12,7 +11,6 @@ import (
 func main() {
 	cmd := buildRootCommand(os.Stdin)
 	if err := cmd.Execute(); err != nil {
-		fmt.Printf("err: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/exec/version.go
+++ b/cmd/exec/version.go
@@ -2,15 +2,27 @@ package main
 
 import (
 	"github.com/deislabs/porter/pkg/exec"
+	"github.com/deislabs/porter/pkg/porter/version"
 	"github.com/spf13/cobra"
 )
 
 func buildVersionCommand(m *exec.Mixin) *cobra.Command {
-	return &cobra.Command{
+	opts := version.Options{}
+
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the mixin version",
-		Run: func(cmd *cobra.Command, args []string) {
-			m.PrintVersion()
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return m.PrintVersion(opts)
 		},
 	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.RawFormat, "output", "o", string(version.DefaultVersionFormat),
+		"Specify an output format.  Allowed values: json, plaintext")
+
+	return cmd
 }

--- a/cmd/kubernetes/version.go
+++ b/cmd/kubernetes/version.go
@@ -2,15 +2,27 @@ package main
 
 import (
 	"github.com/deislabs/porter/pkg/kubernetes"
+	"github.com/deislabs/porter/pkg/porter/version"
 	"github.com/spf13/cobra"
 )
 
-func buildVersionCommand(mixin *kubernetes.Mixin) *cobra.Command {
-	return &cobra.Command{
+func buildVersionCommand(m *kubernetes.Mixin) *cobra.Command {
+	opts := version.Options{}
+
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the mixin verison",
-		Run: func(cmd *cobra.Command, args []string) {
-			mixin.PrintVersion()
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return m.PrintVersion(opts)
 		},
 	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.RawFormat, "output", "o", string(version.DefaultVersionFormat),
+		"Specify an output format.  Allowed values: json, plaintext")
+
+	return cmd
 }

--- a/cmd/porter/version.go
+++ b/cmd/porter/version.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"github.com/deislabs/porter/pkg/porter"
+	"github.com/deislabs/porter/pkg/porter/version"
 	"github.com/spf13/cobra"
 )
 
 func buildVersionCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.VersionOptions{}
+	opts := version.Options{}
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the application version",
@@ -22,7 +23,7 @@ func buildVersionCommand(p *porter.Porter) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVarP(&opts.RawFormat, "output", "o", string(porter.DefaultVersionFormat),
+	f.StringVarP(&opts.RawFormat, "output", "o", string(version.DefaultVersionFormat),
 		"Specify an output format.  Allowed values: json, plaintext")
 
 	return cmd

--- a/docs/content/mixin-commands.md
+++ b/docs/content/mixin-commands.md
@@ -230,16 +230,21 @@ status:
 
 # version
 
-The version command (optional) is not used by porter. We encourage you to
-implement it to be consistent with the other mixins and help users know that
-they have the correct version of your mixin installed.
+The version command (optional) is used by porter when listing installed mixins 
+via `porter mixins list`. It should support an `--output|o` flag that accepts
+either `plaintext` or `json` as values, defaulting to `plaintext`.
  
 Example:
 
 ```console
 $ ~/.porter/mixins/exec/exec version
-exec mixin v0.4.0-ralpha.1+dubonnet (2aa921d)
+exec mixin v0.13.1-beta.1 (37f3637)
+
+$ ~/.porter/mixins/exec/exec version --output json
+{
+  "name": "exec",
+  "version": "v0.13.1-beta.1",
+  "commit": "37f3637",
+  "author": "DeisLabs"
+}
 ```
-
-
-

--- a/pkg/exec/version.go
+++ b/pkg/exec/version.go
@@ -1,11 +1,19 @@
 package exec
 
 import (
-	"fmt"
-
 	"github.com/deislabs/porter/pkg"
+	"github.com/deislabs/porter/pkg/mixin"
+	"github.com/deislabs/porter/pkg/porter/version"
 )
 
-func (m *Mixin) PrintVersion() {
-	fmt.Fprintf(m.Out, "exec mixin %s (%s)\n", pkg.Version, pkg.Commit)
+func (m *Mixin) PrintVersion(opts version.Options) error {
+	metadata := mixin.Metadata{
+		Name: "exec",
+		VersionInfo: mixin.VersionInfo{
+			Version: pkg.Version,
+			Commit:  pkg.Commit,
+			Author:  "DeisLabs",
+		},
+	}
+	return version.PrintVersion(m.Context, opts, metadata)
 }

--- a/pkg/exec/version_test.go
+++ b/pkg/exec/version_test.go
@@ -4,6 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/deislabs/porter/pkg/printer"
+
+	"github.com/deislabs/porter/pkg/porter/version"
+	"github.com/stretchr/testify/require"
+
 	"github.com/deislabs/porter/pkg"
 )
 
@@ -12,10 +17,39 @@ func TestPrintVersion(t *testing.T) {
 	pkg.Version = "v1.2.3"
 
 	m := NewTestMixin(t)
-	m.PrintVersion()
+
+	opts := version.Options{}
+	err := opts.Validate()
+	require.NoError(t, err)
+	m.PrintVersion(opts)
 
 	gotOutput := m.TestContext.GetOutput()
-	wantOutput := "exec mixin v1.2.3 (abc123)"
+	wantOutput := "exec v1.2.3 (abc123) by DeisLabs"
+	if !strings.Contains(gotOutput, wantOutput) {
+		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
+	}
+}
+
+func TestPrintJsonVersion(t *testing.T) {
+	pkg.Commit = "abc123"
+	pkg.Version = "v1.2.3"
+
+	m := NewTestMixin(t)
+
+	opts := version.Options{}
+	opts.RawFormat = string(printer.FormatJson)
+	err := opts.Validate()
+	require.NoError(t, err)
+	m.PrintVersion(opts)
+
+	gotOutput := m.TestContext.GetOutput()
+	wantOutput := `{
+  "name": "exec",
+  "version": "v1.2.3",
+  "commit": "abc123",
+  "author": "DeisLabs"
+}
+`
 	if !strings.Contains(gotOutput, wantOutput) {
 		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
 	}

--- a/pkg/kubernetes/version.go
+++ b/pkg/kubernetes/version.go
@@ -1,11 +1,19 @@
 package kubernetes
 
 import (
-	"fmt"
-
 	"github.com/deislabs/porter/pkg"
+	"github.com/deislabs/porter/pkg/mixin"
+	"github.com/deislabs/porter/pkg/porter/version"
 )
 
-func (m *Mixin) PrintVersion() {
-	fmt.Fprintf(m.Out, "kubernetes mixin %s (%s)\n", pkg.Version, pkg.Commit)
+func (m *Mixin) PrintVersion(opts version.Options) error {
+	metadata := mixin.Metadata{
+		Name: "kubernetes",
+		VersionInfo: mixin.VersionInfo{
+			Version: pkg.Version,
+			Commit:  pkg.Commit,
+			Author:  "DeisLabs",
+		},
+	}
+	return version.PrintVersion(m.Context, opts, metadata)
 }

--- a/pkg/kubernetes/version_test.go
+++ b/pkg/kubernetes/version_test.go
@@ -1,0 +1,56 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deislabs/porter/pkg/printer"
+
+	"github.com/deislabs/porter/pkg/porter/version"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deislabs/porter/pkg"
+)
+
+func TestPrintVersion(t *testing.T) {
+	pkg.Commit = "abc123"
+	pkg.Version = "v1.2.3"
+
+	m := NewTestMixin(t)
+
+	opts := version.Options{}
+	err := opts.Validate()
+	require.NoError(t, err)
+	m.PrintVersion(opts)
+
+	gotOutput := m.TestContext.GetOutput()
+	wantOutput := "kubernetes v1.2.3 (abc123) by DeisLabs"
+	if !strings.Contains(gotOutput, wantOutput) {
+		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
+	}
+}
+
+func TestPrintJsonVersion(t *testing.T) {
+	pkg.Commit = "abc123"
+	pkg.Version = "v1.2.3"
+
+	m := NewTestMixin(t)
+
+	opts := version.Options{}
+	opts.RawFormat = string(printer.FormatJson)
+	err := opts.Validate()
+	require.NoError(t, err)
+	m.PrintVersion(opts)
+
+	gotOutput := m.TestContext.GetOutput()
+	wantOutput := `{
+  "name": "kubernetes",
+  "version": "v1.2.3",
+  "commit": "abc123",
+  "author": "DeisLabs"
+}
+`
+	if !strings.Contains(gotOutput, wantOutput) {
+		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
+	}
+}

--- a/pkg/mixin/main_test.go
+++ b/pkg/mixin/main_test.go
@@ -1,0 +1,11 @@
+package mixin
+
+import (
+	"testing"
+
+	"github.com/deislabs/porter/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	test.TestMainWithMockedCommandHandlers(m)
+}

--- a/pkg/mixin/metadata.go
+++ b/pkg/mixin/metadata.go
@@ -1,16 +1,20 @@
 package mixin
 
-// Metadata about a mixin
+// Metadata about an installed mixin.
 type Metadata struct {
 	// Mixin Name
-	Name string
+	Name string `json:"name"`
 	// Mixin Directory
-	Dir string
+	Dir string `json:"dir,omitempty"`
 	// Path to the client executable
-	ClientPath string
-	// Version
-	// Repository or Source (where did it come from)
-	// Author
-	// Is it up to date
-	// etc
+	ClientPath string `json:"clientPath,omitempty"`
+	// Metadata about the mixin version returned from calling version on the mixin
+	VersionInfo
+}
+
+// Information from running the version command against the mixin.
+type VersionInfo struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Author  string `json:"author,omitempty"`
 }

--- a/pkg/mixin/runner.go
+++ b/pkg/mixin/runner.go
@@ -57,16 +57,23 @@ func (r *Runner) Run() error {
 	}
 
 	mixinPath := r.getMixinPath()
-	cmd := r.NewCommand(mixinPath, r.Command)
+	cmdArgs := strings.Split(r.Command, " ")
+	command := cmdArgs[0]
+	cmd := r.NewCommand(mixinPath, cmdArgs...)
 
 	// Pipe the output from the mixin to porter
 	cmd.Stdout = r.Context.Out
 	cmd.Stderr = r.Context.Err
 
-	if !IsCoreMixinCommand(r.Command) {
+	if !IsCoreMixinCommand(command) {
 		// For custom commands, don't call the mixin as "mixin CUSTOM" but as "mixin invoke --action CUSTOM"
-		cmd.Args[1] = "invoke"
-		cmd.Args = append(cmd.Args, "--action", r.Command)
+		for i := range cmd.Args {
+			if cmd.Args[i] == command {
+				cmd.Args[i] = "invoke"
+				break
+			}
+		}
+		cmd.Args = append(cmd.Args, "--action", command)
 	}
 
 	if r.File != "" {

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -119,8 +119,8 @@ func (p *TestMixinProvider) GetVersion(m mixin.Metadata) (string, error) {
 	return "exec mixin v1.0 (abc123)", nil
 }
 
-func (p *TestMixinProvider) Install(o mixin.InstallOptions) (mixin.Metadata, error) {
-	return mixin.Metadata{Name: "exec", Dir: "~/.porter/mixins/exec"}, nil
+func (p *TestMixinProvider) Install(o mixin.InstallOptions) (*mixin.Metadata, error) {
+	return &mixin.Metadata{Name: "exec", Dir: "~/.porter/mixins/exec"}, nil
 }
 
 // If you seek a mock cache for testing, use this

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -119,6 +119,10 @@ func (p *TestMixinProvider) GetVersion(m mixin.Metadata) (string, error) {
 	return "exec mixin v1.0 (abc123)", nil
 }
 
+func (p *TestMixinProvider) GetVersionMetadata(m mixin.Metadata) (*mixin.VersionInfo, error) {
+	return &mixin.VersionInfo{Version: "v1.0", Commit: "abc123", Author: "Deis Labs"}, nil
+}
+
 func (p *TestMixinProvider) Install(o mixin.InstallOptions) (*mixin.Metadata, error) {
 	return &mixin.Metadata{Name: "exec", Dir: "~/.porter/mixins/exec"}, nil
 }

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -13,7 +13,7 @@ type MixinProvider interface {
 	List() ([]mixin.Metadata, error)
 	GetSchema(m mixin.Metadata) (string, error)
 	GetVersion(m mixin.Metadata) (string, error)
-	Install(opts mixin.InstallOptions) (mixin.Metadata, error)
+	Install(opts mixin.InstallOptions) (*mixin.Metadata, error)
 }
 
 // PrintMixinsOptions represent options for the PrintMixins function
@@ -54,7 +54,7 @@ func (p *Porter) InstallMixin(opts mixin.InstallOptions) error {
 	}
 
 	// TODO: Once we can extract the version from the mixin with json (#263), then we can print it out as installed mixin @v1.0.0
-	confirmedVersion, err := p.Mixins.GetVersion(m)
+	confirmedVersion, err := p.Mixins.GetVersion(*m)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -12,7 +12,14 @@ import (
 type MixinProvider interface {
 	List() ([]mixin.Metadata, error)
 	GetSchema(m mixin.Metadata) (string, error)
+
+	// GetVersion is the obsolete form of retrieving mixin version, e.g. exec version, which returned an unstructured
+	// version string. It will be deprecated soon and is replaced by GetVersionMetadata.
 	GetVersion(m mixin.Metadata) (string, error)
+
+	// GetVersionMetadata is the new form of retrieving mixin version, e.g. exec version --output json, which returns
+	// a structured version string. It replaces GetVersion.
+	GetVersionMetadata(m mixin.Metadata) (*mixin.VersionInfo, error)
 	Install(opts mixin.InstallOptions) (*mixin.Metadata, error)
 }
 
@@ -22,7 +29,7 @@ type PrintMixinsOptions struct {
 }
 
 func (p *Porter) PrintMixins(opts PrintMixinsOptions) error {
-	mixins, err := p.Mixins.List()
+	mixins, err := p.ListMixins()
 	if err != nil {
 		return err
 	}
@@ -35,9 +42,9 @@ func (p *Porter) PrintMixins(opts PrintMixinsOptions) error {
 				if !ok {
 					return nil
 				}
-				return []interface{}{m.Name}
+				return []interface{}{m.Name, m.VersionInfo.Version, m.VersionInfo.Author}
 			}
-		return printer.PrintTable(p.Out, mixins, printMixinRow)
+		return printer.PrintTable(p.Out, mixins, printMixinRow, "Name", "Version", "Author")
 	case printer.FormatJson:
 		return printer.PrintJson(p.Out, mixins)
 	case printer.FormatYaml:
@@ -45,6 +52,29 @@ func (p *Porter) PrintMixins(opts PrintMixinsOptions) error {
 	default:
 		return fmt.Errorf("invalid format: %s", opts.Format)
 	}
+}
+
+func (p *Porter) ListMixins() ([]mixin.Metadata, error) {
+	// List out what is installed on the file system
+	mixins, err := p.Mixins.List()
+	if err != nil {
+		return nil, err
+	}
+
+	// Query each mixin and fill out their version metadata, if available
+	for i := range mixins {
+		m := &mixins[i]
+		v, err := p.Mixins.GetVersionMetadata(*m)
+		if err != nil {
+			// For now, while we transition from mixins not supporting version --output json, ignore it if a mixin
+			// doesn't handle this call
+			continue
+		}
+
+		m.VersionInfo = *v
+	}
+
+	return mixins, nil
 }
 
 func (p *Porter) InstallMixin(opts mixin.InstallOptions) error {

--- a/pkg/porter/mixins_test.go
+++ b/pkg/porter/mixins_test.go
@@ -21,9 +21,11 @@ func TestPorter_PrintMixins(t *testing.T) {
 	err := p.PrintMixins(opts)
 
 	require.Nil(t, err)
-	wantOutput := "exec\nhelm\n"
+	wantOutput := `Name   Version   Author
+exec   v1.0      Deis Labs
+`
 	gotOutput := p.TestConfig.TestContext.GetOutput()
-	assert.Contains(t, wantOutput, gotOutput)
+	assert.Equal(t, wantOutput, gotOutput)
 }
 
 func TestPorter_InstallMixin(t *testing.T) {

--- a/pkg/porter/version.go
+++ b/pkg/porter/version.go
@@ -1,53 +1,18 @@
 package porter
 
 import (
-	"fmt"
-
-	"github.com/deislabs/porter/pkg/printer"
-
 	"github.com/deislabs/porter/pkg"
+	"github.com/deislabs/porter/pkg/mixin"
+	"github.com/deislabs/porter/pkg/porter/version"
 )
 
-// VersionOptions represent generic options for use by Porter's list commands
-type VersionOptions struct {
-	printer.PrintOptions
-}
-
-var DefaultVersionFormat = printer.FormatPlaintext
-
-func (o *VersionOptions) Validate() error {
-	if o.RawFormat == "" {
-		o.RawFormat = string(DefaultVersionFormat)
+func (p *Porter) PrintVersion(opts version.Options) error {
+	metadata := mixin.Metadata{
+		Name: "porter",
+		VersionInfo: mixin.VersionInfo{
+			Version: pkg.Version,
+			Commit:  pkg.Commit,
+		},
 	}
-
-	err := o.ParseFormat()
-	if err != nil {
-		return err
-	}
-
-	switch o.Format {
-	case printer.FormatJson, printer.FormatPlaintext:
-		return nil
-	default:
-		return fmt.Errorf("unsupported format, %s. Supported formats are: %s and %s", o.Format, printer.FormatJson, printer.FormatPlaintext)
-	}
-}
-
-func (p *Porter) PrintVersion(opts VersionOptions) error {
-	switch opts.Format {
-	case printer.FormatJson:
-		v := struct {
-			Version string
-			Commit  string
-		}{
-			pkg.Version,
-			pkg.Commit,
-		}
-		return printer.PrintJson(p.Out, v)
-	case printer.FormatPlaintext:
-		_, err := fmt.Fprintf(p.Out, "porter %s (%s)\n", pkg.Version, pkg.Commit)
-		return err
-	default:
-		return fmt.Errorf("unsupported format: %s", opts.Format)
-	}
+	return version.PrintVersion(p.Context, opts, metadata)
 }

--- a/pkg/porter/version/version.go
+++ b/pkg/porter/version/version.go
@@ -1,0 +1,55 @@
+package version
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/deislabs/porter/pkg/context"
+	"github.com/deislabs/porter/pkg/mixin"
+	"github.com/deislabs/porter/pkg/printer"
+)
+
+// VersionOptions represent generic options for use by version commands
+type Options struct {
+	printer.PrintOptions
+}
+
+var DefaultVersionFormat = printer.FormatPlaintext
+var GetExecutable = os.Executable
+
+//
+func (o *Options) Validate() error {
+	if o.RawFormat == "" {
+		o.RawFormat = string(DefaultVersionFormat)
+	}
+
+	err := o.ParseFormat()
+	if err != nil {
+		return err
+	}
+
+	switch o.Format {
+	case printer.FormatJson, printer.FormatPlaintext:
+		return nil
+	default:
+		return fmt.Errorf("unsupported format, %s. Supported formats are: %s and %s", o.Format, printer.FormatJson, printer.FormatPlaintext)
+	}
+}
+
+// PrintVersion prints the version based on the version flags using the binary's metadata.
+// Suitable for any mixin to use to implement its version command.
+func PrintVersion(cxt *context.Context, opts Options, metadata mixin.Metadata) error {
+	switch opts.Format {
+	case printer.FormatJson:
+		return printer.PrintJson(cxt.Out, metadata)
+	case printer.FormatPlaintext:
+		authorship := ""
+		if metadata.VersionInfo.Author != "" {
+			authorship = " by " + metadata.VersionInfo.Author
+		}
+		_, err := fmt.Fprintf(cxt.Out, "%s %s (%s)%s\n", metadata.Name, metadata.VersionInfo.Version, metadata.VersionInfo.Commit, authorship)
+		return err
+	default:
+		return fmt.Errorf("unsupported format: %s", opts.Format)
+	}
+}

--- a/pkg/porter/version/version_test.go
+++ b/pkg/porter/version/version_test.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/deislabs/porter/pkg/printer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionOptions_Validate(t *testing.T) {
+	testcases := []struct {
+		name       string
+		opts       Options
+		wantFormat printer.Format
+		wantError  string
+	}{
+		{"json", Options{printer.PrintOptions{RawFormat: "json"}}, printer.FormatJson, ""},
+		{"plaintext", Options{printer.PrintOptions{RawFormat: "plaintext"}}, printer.FormatPlaintext, ""},
+		{"default", Options{}, printer.FormatPlaintext, ""},
+		{"yaml - unsupported", Options{printer.PrintOptions{RawFormat: "yaml"}}, printer.Format(""), "unsupported"},
+		{"oops - invalid", Options{printer.PrintOptions{RawFormat: "oops"}}, printer.Format(""), "invalid"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.Validate()
+
+			if tc.wantError == "" {
+				require.NoError(t, err, "Validate should not have returned an error")
+			} else {
+				require.Error(t, err, "Validate should have returned an error")
+				assert.Contains(t, err.Error(), tc.wantError, "Validate did not return the expected error message")
+			}
+		})
+	}
+}

--- a/pkg/porter/version_test.go
+++ b/pkg/porter/version_test.go
@@ -5,38 +5,10 @@ import (
 	"testing"
 
 	"github.com/deislabs/porter/pkg"
+	"github.com/deislabs/porter/pkg/porter/version"
 	"github.com/deislabs/porter/pkg/printer"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestVersionOptions_Validate(t *testing.T) {
-	testcases := []struct {
-		name       string
-		opts       VersionOptions
-		wantFormat printer.Format
-		wantError  string
-	}{
-		{"json", VersionOptions{printer.PrintOptions{RawFormat: "json"}}, printer.FormatJson, ""},
-		{"plaintext", VersionOptions{printer.PrintOptions{RawFormat: "plaintext"}}, printer.FormatPlaintext, ""},
-		{"default", VersionOptions{}, printer.FormatPlaintext, ""},
-		{"yaml - unsupported", VersionOptions{printer.PrintOptions{RawFormat: "yaml"}}, printer.Format(""), "unsupported"},
-		{"oops - invalid", VersionOptions{printer.PrintOptions{RawFormat: "oops"}}, printer.Format(""), "invalid"},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.opts.Validate()
-
-			if tc.wantError == "" {
-				require.NoError(t, err, "Validate should not have returned an error")
-			} else {
-				require.Error(t, err, "Validate should have returned an error")
-				assert.Contains(t, err.Error(), tc.wantError, "Validate did not return the expected error message")
-			}
-		})
-	}
-}
 
 func TestPrintVersion(t *testing.T) {
 	pkg.Commit = "abc123"
@@ -44,13 +16,37 @@ func TestPrintVersion(t *testing.T) {
 
 	p := NewTestPorter(t)
 
-	opts := VersionOptions{}
+	opts := version.Options{}
 	err := opts.Validate()
 	require.NoError(t, err)
 	p.PrintVersion(opts)
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	wantOutput := "porter v1.2.3 (abc123)"
+	if !strings.Contains(gotOutput, wantOutput) {
+		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
+	}
+}
+
+func TestPrintJsonVersion(t *testing.T) {
+	pkg.Commit = "abc123"
+	pkg.Version = "v1.2.3"
+
+	p := NewTestPorter(t)
+
+	opts := version.Options{}
+	opts.RawFormat = string(printer.FormatJson)
+	err := opts.Validate()
+	require.NoError(t, err)
+	p.PrintVersion(opts)
+
+	gotOutput := p.TestConfig.TestContext.GetOutput()
+	wantOutput := `{
+  "name": "porter",
+  "version": "v1.2.3",
+  "commit": "abc123"
+}
+`
 	if !strings.Contains(gotOutput, wantOutput) {
 		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
 	}


### PR DESCRIPTION
* Extract common version package 
* Implement `version --output json` for exec and kuberentes
* Update `porter mixins list` to include the mixin version and author if available
* Updated mixin authoring documentation for the version command is available at https://deploy-preview-588--porter.netlify.com/mixin-commands/#version

```console
$ porter mixins list
Name         Version                     Author
az
azure
exec         v0.13.1-beta.1-7-g37f3637   DeisLabs
gcloud
helm
kubernetes   v0.13.1-beta.1-7-g37f3637   DeisLabs
terraform
```
Closes #263 