### PR TITLE
Fix installation of packr2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ generate: packr2
 HAS_PACKR2 := $(shell command -v packr2)
 packr2:
 ifndef HAS_PACKR2
-	go get -u github.com/gobuffalo/packr/v2/packr2
+	curl -SLo /tmp/packr.tar.gz https://github.com/gobuffalo/packr/releases/download/v2.6.0/packr_2.6.0_$(CLIENT_PLATFORM)_$(CLIENT_ARCH).tar.gz
+	cd /tmp && tar -xzf /tmp/packr.tar.gz
+	install /tmp/packr2 $(go env GOPATH)/bin/
 endif
 
 xbuild-all: xbuild-porter xbuild-mixins


### PR DESCRIPTION
For some reason compiling packr2 suddenly broke with errors about envy:
`bash: [ENVY]: command not found`
and
`[ENVY] unable to load env file(s) on init: open .env: no such file or directory`

I opened https://github.com/gobuffalo/packr/issues/237 to figure out what changed but until then switching to binary installs.