### PR TITLE
Move dep override file

### DIFF
--- a/pkg/dep/dep.go
+++ b/pkg/dep/dep.go
@@ -1,4 +1,4 @@
-package pkg
+package dep
 
 // These imports turn transitive dependencies into direct dependencies
 // so that we can control then using "constraint" in our dep manifest.


### PR DESCRIPTION
Move the file into a package that no one imports. That way consumers of dep aren't forced to pick up dependencies listed in that file.