### PR TITLE
Add --tag to porter credentials generate

### DIFF
--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -78,8 +78,9 @@ credential set to determine where to read the necessary information from and
 will then provide it to the bundle in the correct location. `,
 		Example: `  porter credential generate
   porter bundle credential generate kubecred --insecure
-  porter bundle credential generate kubecred --file myapp/bundle.json
-  porter bundle credential generate kubecred --file myapp/bundle.json --dry-run
+  porter bundle credential generate kubecred --file myapp/porter.yaml
+  porter bundle credential generate kubecred --tag deislabs/cool-bundle:v1.0.1
+  porter bundle credential generate kubecred --cnab-file myapp/bundle.json --dry-run
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)
@@ -98,6 +99,8 @@ will then provide it to the bundle in the correct location. `,
 		"Path to the CNAB bundle.json file.")
 	f.BoolVar(&opts.DryRun, "dry-run", false,
 		"Generate credential but do not save it.")
+	f.StringVar(&opts.Tag, "tag", "",
+		"Use a bundle in an OCI registry specified by the given tag.")
 	return cmd
 }
 

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -36,8 +36,9 @@ porter credentials generate [NAME] [flags]
 ```
   porter credential generate
   porter bundle credential generate kubecred --insecure
-  porter bundle credential generate kubecred --file myapp/bundle.json
-  porter bundle credential generate kubecred --file myapp/bundle.json --dry-run
+  porter bundle credential generate kubecred --file myapp/porter.yaml
+  porter bundle credential generate kubecred --tag deislabs/cool-bundle:v1.0.1
+  porter bundle credential generate kubecred --cnab-file myapp/bundle.json --dry-run
 
 ```
 
@@ -49,6 +50,7 @@ porter credentials generate [NAME] [flags]
   -f, --file string        Path to the porter manifest file. Defaults to the bundle in the current directory.
   -h, --help               help for generate
       --insecure           Allow working with untrusted bundles. (default true)
+      --tag string         Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -31,7 +31,7 @@ type bundleFileOptions struct {
 	// File path to the porter manifest. Defaults to the bundle in the current directory.
 	File string
 
-	// CNABFile is the path to the bundle.json file. Cannot be specified at the same time as the porter manifest.
+	// CNABFile is the path to the bundle.json file. Cannot be specified at the same time as the porter manifest or a tag.
 	CNABFile string
 }
 


### PR DESCRIPTION
This PR adds the --tag option to credentials generate so people can install from a tag without any unpleasant work arounds. It reuses the lifecycle methods, maybe we should rename? Although I feel like generating a credential is kind of related to the lifecycle of the bundle. Ideally, we can link this in automagically to the `invoke` actions next. No credential specified? GENERATE THE HECK OUT OF ONE!!!

This also does a small fix to the help text. 

Fixes #492