### PR TITLE
Pass build context to mixins

### DIFF
--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -62,6 +62,16 @@ mixins:
 - helm
 ```
 
+Some mixins allow you to specify configuration data that is provided to the mixin during `porter build`. Each mixin
+has its own format for the configuration. For example, the az mixin allows you to specify extensions to install:
+
+```yaml
+mixins:
+- az:
+    extensions:
+    - azure-cli-iot-ext
+```
+
 See [Using Mixins](/using-mixins) to learn more about how mixins work.
 
 ## Parameters

--- a/docs/content/mixin-commands.md
+++ b/docs/content/mixin-commands.md
@@ -24,19 +24,34 @@ recommended so that your mixin has a good user experience.
 # build
 
 The build command (required) is called on the local machine during the `porter
-build` command. The mixin should return lines for the Dockerfile on stdout.
+build` command. Any mixin configuration and all usages of the mixin are passed
+on stdin. The mixin should return lines for the Dockerfile on stdout.
 
 Example:
 
+**stdin**
+
+```yaml
+config:
+  extensions:
+  - iot
+actions:
+  install:
+  - az:
+      arguments:
+      - login
+      description: Login
+  uninstall: []
+  upgrade: []
+```
+
+**stdout**
 ```console
-$ helm build
-RUN apt-get update && \
-    apt-get install -y curl && \
-    curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v2.12.3-linux-amd64.tar.gz && \
-    tar -xzf helm.tgz && \
-    mv linux-amd64/helm /usr/local/bin && \
-    rm helm.tgz
-RUN helm init --client-only
+RUN apt-get update && apt-get install -y apt-transport-https lsb-release gnupg curl
+RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg
+RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
+RUN apt-get update && apt-get install -y azure-cli
+RUN az extension add --name azure-cli-iot-ext 
 ```
 
 # schema

--- a/pkg/build/dockerfile-generater.go
+++ b/pkg/build/dockerfile-generater.go
@@ -13,6 +13,7 @@ import (
 	"github.com/deislabs/porter/pkg/mixin"
 	"github.com/deislabs/porter/pkg/templates"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 type DockerfileGenerator struct {
@@ -141,10 +142,17 @@ func (g *DockerfileGenerator) buildMixinsSection() ([]string, error) {
 		mixinContext = *g.Context
 		mixinContext.Out = mixinStdout   // mixin stdout -> dockerfile lines
 		mixinContext.Err = g.Context.Out // mixin stderr -> logs
-		mixinContext.In = nil            // TODO: let the mixin know about which steps will be executed so that it can be more selective about copying into the invocation image
 
-		cmd := mixin.CommandOptions{Command: "build"}
-		err := g.MixinProvider.Run(&mixinContext, m, cmd)
+		inputB, err := yaml.Marshal(g.getMixinBuildInput(m.Name))
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not marshal mixin build input for %s", m.Name)
+		}
+
+		cmd := mixin.CommandOptions{
+			Command: "build",
+			Input:   string(inputB),
+		}
+		err = g.MixinProvider.Run(&mixinContext, m.Name, cmd)
 		if err != nil {
 			return nil, err
 		}
@@ -160,7 +168,11 @@ func (g *DockerfileGenerator) getMixinBuildInput(m string) mixin.BuildInput {
 		Actions: make(map[string]config.Steps, 3),
 	}
 
-	// TODO: populate config once we are storing it in porter.yaml
+	for _, mixinDecl := range g.Manifest.Mixins {
+		if m == mixinDecl.Name {
+			input.Config = mixinDecl.Config
+		}
+	}
 
 	filterSteps := func(action config.Action, steps config.Steps) {
 		mixinSteps := config.Steps{}
@@ -215,8 +227,8 @@ func (g *DockerfileGenerator) PrepareFilesystem() error {
 	}
 
 	fmt.Fprintf(g.Out, "Copying mixins ===> \n")
-	for _, mixin := range g.Manifest.Mixins {
-		err := g.copyMixin(mixin)
+	for _, m := range g.Manifest.Mixins {
+		err := g.copyMixin(m.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -22,7 +22,7 @@ func TestPorter_buildDockerfile(t *testing.T) {
 	require.NoError(t, err)
 
 	// ignore mixins in the unit tests
-	c.Manifest.Mixins = []string{}
+	c.Manifest.Mixins = []config.MixinDeclaration{}
 
 	mp := &mixin.TestMixinProvider{}
 	g := NewDockerfileGenerator(c.Config, tmpl, mp)
@@ -64,7 +64,7 @@ COPY mybin /cnab/app/
 	c.TestContext.AddTestFileContents([]byte(customFrom), "Dockerfile.template")
 
 	// ignore mixins in the unit tests
-	c.Manifest.Mixins = []string{}
+	c.Manifest.Mixins = []config.MixinDeclaration{}
 
 	mp := &mixin.TestMixinProvider{}
 	g := NewDockerfileGenerator(c.Config, tmpl, mp)
@@ -94,7 +94,7 @@ func TestPorter_buildDockerfile_output(t *testing.T) {
 	require.NoError(t, err)
 
 	// ignore mixins in the unit tests
-	c.Manifest.Mixins = []string{}
+	c.Manifest.Mixins = []config.MixinDeclaration{}
 
 	mp := &mixin.TestMixinProvider{}
 	g := NewDockerfileGenerator(c.Config, tmpl, mp)
@@ -129,7 +129,7 @@ func TestPorter_generateDockerfile(t *testing.T) {
 	require.NoError(t, err)
 
 	// ignore mixins in the unit tests
-	c.Manifest.Mixins = []string{}
+	c.Manifest.Mixins = []config.MixinDeclaration{}
 
 	mp := &mixin.TestMixinProvider{}
 	g := NewDockerfileGenerator(c.Config, tmpl, mp)
@@ -191,6 +191,7 @@ func TestDockerFileGenerator_getMixinBuildInput(t *testing.T) {
 
 	input := g.getMixinBuildInput("exec")
 
+	assert.Nil(t, input.Config, "exec mixin should have no config")
 	assert.Len(t, input.Actions, 4, "expected 4 actions")
 
 	require.Contains(t, input.Actions, "install")
@@ -204,4 +205,7 @@ func TestDockerFileGenerator_getMixinBuildInput(t *testing.T) {
 
 	require.Contains(t, input.Actions, "status")
 	assert.Len(t, input.Actions["status"], 1, "expected 1 exec status steps")
+
+	input = g.getMixinBuildInput("az")
+	assert.Equal(t, map[interface{}]interface{}{"extensions": []interface{}{"iot"}}, input.Config, "az mixin should have config")
 }

--- a/pkg/build/testdata/multiple-mixins.yaml
+++ b/pkg/build/testdata/multiple-mixins.yaml
@@ -1,6 +1,9 @@
 mixins:
   - exec
-  - az
+  - az:
+      extensions:
+        - iot
+
 
 install:
   - exec:

--- a/pkg/build/testdata/multiple-mixins.yaml
+++ b/pkg/build/testdata/multiple-mixins.yaml
@@ -1,0 +1,55 @@
+mixins:
+  - exec
+  - az
+
+install:
+  - exec:
+      description: Install something
+      command: bash
+      arguments:
+        - install1.sh
+  - az:
+      description: Install something
+      arguments:
+        - login
+  - exec:
+      description: Install something else
+      command: bash
+      arguments:
+        - install2.sh
+
+upgrade:
+  - exec:
+      description: Upgrade it
+      command: bash
+      arguments:
+        - upgrade.sh
+  - az:
+      description: create a vm
+      arguments:
+        - vm
+        - create
+
+status:
+  - exec:
+      description: check the status
+      command: bash
+      arguments:
+        - status.sh
+  - az:
+      description: list the vms
+      arguments:
+        - vm
+        - list
+
+uninstall:
+  - exec:
+      description: uninstall everything
+      command: bash
+      arguments:
+        - uninstall.sh
+  - az:
+      description: delete the vm
+      arguments:
+        - vm
+        - delete

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -6,11 +6,10 @@ import (
 	"reflect"
 	"strings"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/deislabs/cnab-go/bundle/definition"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
-
-	"github.com/deislabs/cnab-go/bundle/definition"
 )
 
 type Manifest struct {
@@ -27,7 +26,7 @@ type Manifest struct {
 	// Dockerfile is the relative path to the Dockerfile template for the invocation image
 	Dockerfile string `yaml:"dockerfile,omitempty"`
 
-	Mixins []string `yaml:"mixins,omitempty"`
+	Mixins []MixinDeclaration `yaml:"mixins,omitempty"`
 
 	Install   Steps `yaml:"install"`
 	Uninstall Steps `yaml:"uninstall"`
@@ -124,6 +123,69 @@ func (l Location) IsEmpty() bool {
 	return l == empty
 }
 
+type MixinDeclaration struct {
+	Name   string
+	Config interface{}
+}
+
+// UnmarshalYAML allows mixin declarations to either be a normal list of strings
+// mixins:
+// - exec
+// - helm
+// or allow some entries to have config data defined
+// - az:
+//     extensions:
+//       - iot
+func (m *MixinDeclaration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// First try to just read the mixin name
+	var mixinNameOnly string
+	err := unmarshal(&mixinNameOnly)
+	if err == nil {
+		m.Name = mixinNameOnly
+		m.Config = nil
+		return nil
+	}
+
+	// Next try to read a mixin name with config defined
+	mixinWithConfig := map[string]interface{}{}
+	err = unmarshal(&mixinWithConfig)
+	if err != nil {
+		return errors.Wrap(err, "could not unmarshal raw yaml of mixin declarations")
+	}
+
+	if len(mixinWithConfig) == 0 {
+		return errors.New("mixin declaration was empty")
+	} else if len(mixinWithConfig) > 1 {
+		return errors.New("mixin declaration contained more than one mixin")
+	}
+
+	for mixinName, config := range mixinWithConfig {
+		m.Name = mixinName
+		m.Config = config
+		break // There is only one mixin anyway but break for clarity
+	}
+	return nil
+}
+
+// MarshalYAML allows mixin declarations to either be a normal list of strings
+// mixins:
+// - exec
+// - helm
+// or allow some entries to have config data defined
+// - az:
+//     extensions:
+//       - iot
+func (m MixinDeclaration) MarshalYAML() (interface{}, error) {
+	if m.Config == nil {
+		return m.Name, nil
+	}
+
+	raw := map[string]interface{}{
+		m.Name: m.Config,
+	}
+	return raw, nil
+}
+
 type MappedImage struct {
 	Description   string            `yaml:"description"`
 	ImageType     string            `yaml:"imageType"`
@@ -215,7 +277,7 @@ func (s *Step) Validate(m *Manifest) error {
 	mixinDeclared := false
 	mixinType := s.GetMixinName()
 	for _, mixin := range m.Mixins {
-		if mixin == mixinType {
+		if mixin.Name == mixinType {
 			mixinDeclared = true
 			break
 		}

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -55,6 +55,15 @@ func TestMixinDeclaration_UnmarshalYAML(t *testing.T) {
 	assert.Equal(t, map[interface{}]interface{}{"extensions": []interface{}{"iot"}}, m.Mixins[1].Config)
 }
 
+func TestMixinDeclaration_UnmarshalYAML_Invalid(t *testing.T) {
+	c := NewTestConfig(t)
+	c.TestContext.AddTestFile("testdata/mixin-with-bad-config.yaml", Name)
+	_, err := c.ReadManifest(Name)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mixin declaration contained more than one mixin")
+}
+
 func TestMixinDeclaration_MarshalYAML(t *testing.T) {
 	m := struct {
 		Mixins []MixinDeclaration

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"io/ioutil"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,4 +41,35 @@ func TestReadManifest_Validate_MissingFile(t *testing.T) {
 	_, err := c.ReadManifest("fake-porter.yaml")
 
 	assert.EqualError(t, err, "the specified porter configuration file fake-porter.yaml does not exist")
+}
+
+func TestMixinDeclaration_UnmarshalYAML(t *testing.T) {
+	c := NewTestConfig(t)
+	c.TestContext.AddTestFile("testdata/mixin-with-config.yaml", Name)
+	m, err := c.ReadManifest(Name)
+
+	require.NoError(t, err)
+	assert.Len(t, m.Mixins, 2, "expected 2 mixins")
+	assert.Equal(t, "exec", m.Mixins[0].Name)
+	assert.Equal(t, "az", m.Mixins[1].Name)
+	assert.Equal(t, map[interface{}]interface{}{"extensions": []interface{}{"iot"}}, m.Mixins[1].Config)
+}
+
+func TestMixinDeclaration_MarshalYAML(t *testing.T) {
+	m := struct {
+		Mixins []MixinDeclaration
+	}{
+		[]MixinDeclaration{
+			{Name: "exec"},
+			{Name: "az", Config: map[interface{}]interface{}{"extensions": []interface{}{"iot"}}},
+		},
+	}
+
+	gotYaml, err := yaml.Marshal(m)
+	require.NoError(t, err, "could not marshal data")
+
+	wantYaml, err := ioutil.ReadFile("testdata/mixin-with-config.yaml")
+	require.NoError(t, err, "could not read testdata")
+
+	assert.Equal(t, string(wantYaml), string(gotYaml))
 }

--- a/pkg/config/runtime-manifest_test.go
+++ b/pkg/config/runtime-manifest_test.go
@@ -22,7 +22,7 @@ func TestLoadManifest(t *testing.T) {
 	require.NoError(t, c.LoadManifest(), "could not load manifest")
 
 	require.NotNil(t, c.Manifest, "manifest was nil")
-	assert.Equal(t, []string{"exec"}, c.Manifest.Mixins, "expected manifest to declare the exec mixin")
+	assert.Equal(t, []MixinDeclaration{{Name: "exec"}}, c.Manifest.Mixins, "expected manifest to declare the exec mixin")
 	require.Len(t, c.Manifest.Install, 1, "expected 1 install step")
 
 	installStep := c.Manifest.Install[0]
@@ -53,7 +53,7 @@ func TestLoadManifestWithDependencies(t *testing.T) {
 	require.NoError(t, c.LoadManifest())
 
 	assert.NotNil(t, c.Manifest)
-	assert.Equal(t, []string{"exec"}, c.Manifest.Mixins)
+	assert.Equal(t, []MixinDeclaration{{Name: "exec"}}, c.Manifest.Mixins)
 	assert.Len(t, c.Manifest.Install, 1)
 
 	installStep := c.Manifest.Install[0]
@@ -74,7 +74,7 @@ func TestAction_Validate_RequireMixinDeclaration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Sabotage!
-	c.Manifest.Mixins = []string{}
+	c.Manifest.Mixins = []MixinDeclaration{}
 
 	err = c.Manifest.Install.Validate(c.Manifest)
 	assert.EqualError(t, err, "mixin (exec) was not declared")
@@ -491,7 +491,7 @@ func TestResolveMultipleStepOutputs(t *testing.T) {
 
 	c := NewTestConfig(t)
 	m := &Manifest{
-		Mixins: []string{"helm"},
+		Mixins: []MixinDeclaration{{Name: "helm"}},
 		Install: Steps{
 			s,
 		},
@@ -526,7 +526,7 @@ func TestResolveMissingStepOutputs(t *testing.T) {
 
 	c := NewTestConfig(t)
 	m := &Manifest{
-		Mixins: []string{"helm"},
+		Mixins: []MixinDeclaration{{Name: "helm"}},
 		Install: Steps{
 			s,
 		},
@@ -559,7 +559,7 @@ func TestResolveDependencyParam(t *testing.T) {
 				Tag: "deislabs/porter-mysql",
 			},
 		},
-		Mixins: []string{"helm"},
+		Mixins: []MixinDeclaration{{Name: "helm"}},
 		Install: Steps{
 			s,
 		},
@@ -597,7 +597,7 @@ func TestResolveMissingDependencyParam(t *testing.T) {
 				Tag: "deislabs/porter-mysql",
 			},
 		},
-		Mixins: []string{"helm"},
+		Mixins: []MixinDeclaration{{Name: "helm"}},
 		Install: Steps{
 			s,
 		},

--- a/pkg/config/testdata/mixin-with-bad-config.yaml
+++ b/pkg/config/testdata/mixin-with-bad-config.yaml
@@ -1,0 +1,4 @@
+mixins:
+  - name: az
+    extensions:
+    - iot

--- a/pkg/config/testdata/mixin-with-config.yaml
+++ b/pkg/config/testdata/mixin-with-config.yaml
@@ -1,0 +1,5 @@
+mixins:
+- exec
+- az:
+    extensions:
+    - iot

--- a/pkg/mixin/buildInput.go
+++ b/pkg/mixin/buildInput.go
@@ -1,0 +1,10 @@
+package mixin
+
+import (
+	"github.com/deislabs/porter/pkg/config"
+)
+
+type BuildInput struct {
+	Config  map[string]interface{}  `yaml:"config"`
+	Actions map[string]config.Steps `yaml:"actions"`
+}

--- a/pkg/mixin/buildInput.go
+++ b/pkg/mixin/buildInput.go
@@ -5,6 +5,6 @@ import (
 )
 
 type BuildInput struct {
-	Config  map[string]interface{}  `yaml:"config"`
+	Config  interface{}             `yaml:"config,omitempty"`
 	Actions map[string]config.Steps `yaml:"actions"`
 }


### PR DESCRIPTION
# What does this change
Passes context to mixins when we ask them to build Dockerfile lines to inject into the invocation image. The mixin always gets the usage of the mixin in the manifest. Also if the mixin declaration contains any configuration data, then that is passed along as well.

The context is sent via stdin when we call `mixin build` just like we do with the other mixin commands like `mixin install`.

```yaml
mixins:
  - exec
  - az:
      extensions:
        - iot

install:
  - az:
      description: Login
      arguments:
      - login

uninstall:
  - exec:
      description: "Uninstall stuff"
      command: "bash"
      arguments:
      - echo bye
```


The `az build` command would receive this on stdin:

```yaml
config:
  extensions:
  - iot
actions:
  install:
  - az:
      arguments:
      - login
      description: Login
  uninstall: []
  upgrade: []
```

The `exec build` command would receive this on stdin:

```yaml
actions:
  install: []
  uninstall:
  - exec:
      arguments:
      - echo bye
      command: bash
      description: Uninstall stuff
  upgrade: []
```
# What issue does it fix
Closes #262 
Closes #583

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
