### PR TITLE
Add image map wiring

### DIFF
--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -234,13 +234,21 @@ dependencies:
     the semantic version of the bundle.
 * `parameters`: Optionally set default values for parameters in the bundle.
 
-## Image Map
+## Images
 
-The Image Map is part of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/103-bundle-runtime.md#image-maps).
-The `imageMap` data from the manifest is made available at runtime `/cnab/app/image-map.json` where you may access it
-from a script. 
+The `images` section of the Porter manifest corresponds to the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/103-bundle-runtime.md#image-maps).
 
-Note: Neither porter nor the DeisLabs mixins use this information.
+```yaml
+images:
+  websvc:
+      description: "A simple web service"
+      imageType: "docker"
+      repository: "jeremyrickard/devops-days-msp"
+      digest: "sha256:85b1a9b4b60a4cf73a23517dad677e64edf467107fa7d58fce9c50e6a3e4c914"
+```
+
+This information is used to generate the corresponding section of the `bundle.json` and can be
+used to in [template expressions](/wiring), much like `parameters`, `credentials` and `outputs`.
 
 ## Generated Files
 
@@ -255,4 +263,4 @@ be copied into the final bundle so that you can access them at runtime. The path
 
 * [Using Mixins](/using-mixins/)
 * [Bundle Dependencies](/dependencies/)
-* [Parameters, Credentials and Outputs](/wiring/)
+* [Parameters, Credentials, Outputs, and Images in Porter](/wiring/)

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -3,9 +3,9 @@ title: Using Parameters, Credentials and Outputs
 description: How to wire parameters, credentials and outputs into steps
 ---
 
-# Parameters, Credentials and Outputs in Porter
+# Parameters, Credentials, Outputs, and Images in Porter
 
-In the Porter manifest, you can declare both parameters and credentials. In addition to providing a mechanism for declaring parameters and credentials at the bundle level, Porter provides a way to declare how each of these are provided to [mixins](/mixin-architecture). This mechanism is also applicable to declaring how output from one mixin can be passed to another, as well as how to consume parameters, credentials and outputs from bundle dependencies.
+In the Porter manifest, you can declare both parameters and credentials. In addition to providing a mechanism for declaring parameters and credentials at the bundle level, Porter provides a way to declare how each of these are provided to [mixins](/mixin-architecture). This mechanism is also applicable to declaring how output from one mixin can be passed to another, as well as how to consume parameters, credentials and outputs from bundle dependencies. Finally, you can also use this technique to reference images defined in the `images` section of the manifest.
 
 ## Parameters
 
@@ -152,6 +152,32 @@ For example, given the install step above, we can use the `MYSQL_URL` with the h
 ```
 
 Just like in the case of credentials and parameters, the value of the `bundle.outputs.MYSQL_URL` reference will be rewritten in the YAML before the helm mixin is invoked.
+
+## Wiring Images
+
+In the `porter.yaml`, you can define what images will be used within the bundle with the `images` section:
+
+```yaml
+images:
+  ALIAS:
+    description: A very useful image
+    imageType: docker # porter.yaml can default this to docker if we aren't already
+    repository: gcr.io/mcguffin-co/mcguffin
+    digest: sha256:85b1a9 # this is what bundle.json allows
+    tag: v1.1.0 # we can collect this and make it available but it won't land into bundle.json
+```
+
+These images will be used to build the `bundle.json` images section, but can also be referenced using the same syntax you would use for referencing `parameters`, `credentials`, and `outputs`.
+
+```yaml
+- description: "Helm Install Wordpress"
+    helm:
+      name: porter-ci-wordpress
+      chart: stable/wordpress
+      set:
+        image.repository: "{{ bundle.parameters.ALIAS.repository }}"
+        image.tag: "{{ bundle.parameters.ALIAS.tag }}"
+```
 
 ## Using Parameters, Credentials, and Outputs from Bundle Dependencies
 

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -1,9 +1,7 @@
 ---
-title: Using Parameters, Credentials and Outputs
+title: Parameters, Credentials, Outputs, and Images in Porter
 description: How to wire parameters, credentials and outputs into steps
 ---
-
-# Parameters, Credentials, Outputs, and Images in Porter
 
 In the Porter manifest, you can declare both parameters and credentials. In addition to providing a mechanism for declaring parameters and credentials at the bundle level, Porter provides a way to declare how each of these are provided to [mixins](/mixin-architecture). This mechanism is also applicable to declaring how output from one mixin can be passed to another, as well as how to consume parameters, credentials and outputs from bundle dependencies. Finally, you can also use this technique to reference images defined in the `images` section of the manifest.
 
@@ -161,10 +159,10 @@ In the `porter.yaml`, you can define what images will be used within the bundle 
 images:
   ALIAS:
     description: A very useful image
-    imageType: docker # porter.yaml can default this to docker if we aren't already
+    imageType: docker
     repository: gcr.io/mcguffin-co/mcguffin
-    digest: sha256:85b1a9 # this is what bundle.json allows
-    tag: v1.1.0 # we can collect this and make it available but it won't land into bundle.json
+    digest: sha256:85b1a9
+    tag: v1.1.0
 ```
 
 These images will be used to build the `bundle.json` images section, but can also be referenced using the same syntax you would use for referencing `parameters`, `credentials`, and `outputs`.

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -229,10 +229,18 @@ func (c *ManifestConverter) generateBundleImages() map[string]bundle.Image {
 	images := make(map[string]bundle.Image, len(c.Manifest.ImageMap))
 
 	for i, refImage := range c.Manifest.ImageMap {
+		imgRefStr := refImage.Repository
+		if refImage.Digest != "" {
+			imgRefStr = fmt.Sprintf("%s@%s", imgRefStr, refImage.Digest)
+		} else if refImage.Tag != "" {
+			imgRefStr = fmt.Sprintf("%s:%s", imgRefStr, refImage.Tag)
+		} else { // default to `latest` if no tag is provided
+			imgRefStr = fmt.Sprintf("%s:latest", imgRefStr)
+		}
 		img := bundle.Image{
 			Description: refImage.Description,
 			BaseImage: bundle.BaseImage{
-				Image:     refImage.Image,
+				Image:     imgRefStr,
 				Digest:    refImage.Digest,
 				ImageType: refImage.ImageType,
 				MediaType: refImage.MediaType,

--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -237,12 +237,16 @@ func (c *ManifestConverter) generateBundleImages() map[string]bundle.Image {
 		} else { // default to `latest` if no tag is provided
 			imgRefStr = fmt.Sprintf("%s:latest", imgRefStr)
 		}
+		imgType := refImage.ImageType
+		if imgType == "" {
+			imgType = "docker"
+		}
 		img := bundle.Image{
 			Description: refImage.Description,
 			BaseImage: bundle.BaseImage{
 				Image:     imgRefStr,
 				Digest:    refImage.Digest,
-				ImageType: refImage.ImageType,
+				ImageType: imgType,
 				MediaType: refImage.MediaType,
 				Size:      refImage.Size,
 				Labels:    refImage.Labels,

--- a/pkg/cnab/config_adapter/adapter_test.go
+++ b/pkg/cnab/config_adapter/adapter_test.go
@@ -1,6 +1,7 @@
 package configadapter
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/deislabs/cnab-go/bundle"
@@ -221,7 +222,7 @@ func TestManifestConverter_generateImages(t *testing.T) {
 
 	mappedImage := config.MappedImage{
 		Description:   "un petite server",
-		Image:         "deislabs/myserver:1.0.0",
+		Repository:    "deislabs/myserver",
 		ImageType:     "docker",
 		Digest:        "abc123",
 		Size:          12,
@@ -241,7 +242,7 @@ func TestManifestConverter_generateImages(t *testing.T) {
 	require.Len(t, images, 1)
 	img := images["server"]
 	assert.Equal(t, mappedImage.Description, img.Description)
-	assert.Equal(t, mappedImage.Image, img.Image)
+	assert.Equal(t, fmt.Sprintf("%s@%s", mappedImage.Repository, mappedImage.Digest), img.Image)
 	assert.Equal(t, mappedImage.ImageType, img.ImageType)
 	assert.Equal(t, mappedImage.Digest, img.Digest)
 	assert.Equal(t, mappedImage.Size, img.Size)
@@ -261,7 +262,8 @@ func TestManifestConverter_generateBundleImages_EmptyLabels(t *testing.T) {
 
 	mappedImage := config.MappedImage{
 		Description: "un petite server",
-		Image:       "deislabs/myserver:1.0.0",
+		Repository:  "deislabs/myserver",
+		Tag:         "1.0.0",
 		ImageType:   "docker",
 		Labels:      nil,
 	}
@@ -273,6 +275,7 @@ func TestManifestConverter_generateBundleImages_EmptyLabels(t *testing.T) {
 	require.Len(t, images, 1)
 	img := images["server"]
 	assert.Nil(t, img.Labels)
+	assert.Equal(t, fmt.Sprintf("%s:%s", mappedImage.Repository, mappedImage.Tag), img.Image)
 }
 
 func TestManifestConverter_generateBundleOutputs(t *testing.T) {

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -41,10 +41,11 @@ type Manifest struct {
 	Dependencies map[string]Dependency  `yaml:"dependencies,omitempty"`
 	Outputs      []OutputDefinition     `yaml:"outputs,omitempty"`
 
-	// ImageMap is a map of images referenced in the bundle. The mappings are mounted as a file at runtime to
-	// /cnab/app/image-map.json. This data is not used by porter or any of the deislabs mixins, so only populate when you
-	// plan on manually using this data in your own scripts.
-	ImageMap map[string]MappedImage `yaml:"imageMap,omitempty"`
+	// ImageMap is a map of images referenced in the bundle. If image relocation mapping occurs, that
+	// file will be mounted at as a file at runtime to /cnab/app/relocation-mapping.json.
+	// TODO: porter should handle the relocation and overwrite the repository and tag (if present), and
+	// populate originalImage
+	ImageMap map[string]MappedImage `yaml:"images,omitempty"`
 }
 
 func (m *Manifest) Validate() error {
@@ -127,12 +128,13 @@ func (l Location) IsEmpty() bool {
 type MappedImage struct {
 	Description   string            `yaml:"description"`
 	ImageType     string            `yaml:"imageType"`
-	Image         string            `yaml:"image"`
+	Repository    string            `yaml:"repository"`
 	OriginalImage string            `yaml:"originalImage,omitempty"`
 	Digest        string            `yaml:"digest,omitempty"`
 	Size          uint64            `yaml:"size,omitempty"`
 	MediaType     string            `yaml:"mediaType,omitempty"`
 	Labels        map[string]string `yaml:"labels,omitempty"`
+	Tag           string            `yaml:"tag,omitempty"`
 }
 
 type Dependency struct {

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -41,8 +41,8 @@ type Manifest struct {
 	Dependencies map[string]Dependency  `yaml:"dependencies,omitempty"`
 	Outputs      []OutputDefinition     `yaml:"outputs,omitempty"`
 
-	// ImageMap is a map of images referenced in the bundle. If image relocation mapping occurs, that
-	// file will be mounted at as a file at runtime to /cnab/app/relocation-mapping.json.
+	// ImageMap is a map of images referenced in the bundle. If an image relocation mapping is later provided, that
+	// will be mounted at as a file at runtime to /cnab/app/relocation-mapping.json.
 	// TODO: porter should handle the relocation and overwrite the repository and tag (if present), and
 	// populate originalImage
 	ImageMap map[string]MappedImage `yaml:"images,omitempty"`

--- a/pkg/config/testdata/porter-images.yaml
+++ b/pkg/config/testdata/porter-images.yaml
@@ -1,0 +1,30 @@
+name: some-test
+version: 0.3.11
+description: "Test some things"
+invocationImage: deislabs/test-io:v0.3.11
+tag: deislabs/test-bundle:v0.3.11
+
+images:
+  something:
+      description: "Something"
+      imageType: "docker"
+      repository: "deislabs/mcguffin"
+      digest: "sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f"
+
+mixins:
+- searcher
+
+install:
+  - searcher:
+      description: "A Step"
+      image: "{{bundle.images.something.repository}}@{{bundle.images.something.digest}}"
+      repo: "{{bundle.images.something.repository}}"
+      digest: "{{bundle.images.something.digest}}"
+      tag: "{{bundle.images.something.tag}}"
+uninstall:
+  - searcher:
+      description: "A Step"
+      image: "{{bundle.images.something.repository}}@{{bundle.images.something.digest}}"
+      repo: "{{bundle.images.something.repository}}"
+      digest: "{{bundle.images.something.digest}}"
+      tag: "{{bundle.images.something.tag}}"

--- a/workshop/porter-tf-aci/azure/bundle/porter.yaml
+++ b/workshop/porter-tf-aci/azure/bundle/porter.yaml
@@ -54,11 +54,11 @@ outputs:
   - name: STORAGE_ACCOUNT_KEY
     type: string
 
-imageMap:
+images:
   websvc:
       description: "A simple web service"
       imageType: "docker"
-      image: "jeremyrickard/devops-days-msp@sha256:85b1a9b4b60a4cf73a23517dad677e64edf467107fa7d58fce9c50e6a3e4c914"
+      repository: "jeremyrickard/devops-days-msp"
       digest: "sha256:85b1a9b4b60a4cf73a23517dad677e64edf467107fa7d58fce9c50e6a3e4c914"
 
 install:
@@ -102,7 +102,7 @@ install:
       parameters:
         containerName: "{{ bundle.parameters.server-name }}-aci-go"
         location: "{{ bundle.parameters.location }}"
-        imageName: "jeremyrickard/devops-days-msp@sha256:85b1a9b4b60a4cf73a23517dad677e64edf467107fa7d58fce9c50e6a3e4c914"
+        imageName: "{{bundle.images.websvc.repository}}@{{bundle.images.websvc.digest}}"
         mysqlFQDN: "{{bundle.outputs.mysql_fqdn}}"
         port: "8080"
       outputs:


### PR DESCRIPTION
# What does this change

This PR adds image map wiring / interpolation into Porter's bag of tricks. It changes the `imageMap` part of the porter.yaml to `images` to match the issue comments and does some various cleanup. 

# What issue does it fix
Closes #501

# Notes
Since mustache template interpolation is case sensitive, I decided to use `reflect` to iterate the MappedImage struct and `strings.ToLower` the name of the field, that way it matches up against the yaml. Otherwise, we ended up with references like `{{bundle.images.thing.Repository}}`, which bugged me. 

# Checklist
- [x] Unit Tests
- [x] Documentation
