### PR TITLE
Add scaffolding for new porter archive command

### DIFF
--- a/cmd/porter/aliases.go
+++ b/cmd/porter/aliases.go
@@ -18,6 +18,7 @@ func buildAliasCommands(p *porter.Porter) []*cobra.Command {
 		buildPublishAlias(p),
 		buildListAlias(p),
 		buildShowAlias(p),
+		buildArchiveAlias(p),
 	}
 }
 
@@ -96,6 +97,15 @@ func buildShowAlias(p *porter.Porter) *cobra.Command {
 func buildListAlias(p *porter.Porter) *cobra.Command {
 	cmd := buildInstancesListCommand(p)
 	cmd.Example = strings.Replace(cmd.Example, "porter bundle instances list", "porter list", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildArchiveAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundleArchiveCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle archive", "porter archive", -1)
 	cmd.Annotations = map[string]string{
 		"group": "alias",
 	}

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -23,6 +23,7 @@ func buildBundleCommands(p *porter.Porter) *cobra.Command {
 	cmd.AddCommand(buildBundleUpgradeCommand(p))
 	cmd.AddCommand(buildBundleInvokeCommand(p))
 	cmd.AddCommand(buildBundleUninstallCommand(p))
+	cmd.AddCommand(buildBundleArchiveCommand(p))
 
 	return cmd
 }
@@ -276,5 +277,30 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
 	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false, "Don't require TLS for the registry.")
+	return &cmd
+}
+
+func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
+
+	opts := porter.ArchiveOptions{}
+	cmd := cobra.Command{
+		Hidden: true,
+		Use:    "archive",
+		Short:  "Archive a bundle",
+		Long:   "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
+		Example: `  porter bundle archive [FILENAME]
+  porter bundle archive --file another/porter.yaml [FILENAME]
+  porter bundle archive --cnab-file some/bundle.json [FILENAME]
+		  `,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(args, p.Context)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.Archive(opts)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
 	return &cmd
 }

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -1,0 +1,44 @@
+---
+title: "porter archive"
+slug: porter_archive
+url: /cli/porter_archive/
+---
+## porter archive
+
+Archive a bundle
+
+### Synopsis
+
+Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.
+
+```
+porter archive [flags]
+```
+
+### Examples
+
+```
+  porter archive [FILENAME]
+  porter archive --file another/porter.yaml [FILENAME]
+  porter archive --cnab-file some/bundle.json [FILENAME]
+		  
+```
+
+### Options
+
+```
+      --cnab-file string   Path to the CNAB bundle.json file.
+  -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+  -h, --help               help for archive
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug logging
+```
+
+### SEE ALSO
+
+* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -1,0 +1,44 @@
+---
+title: "porter bundles archive"
+slug: porter_bundles_archive
+url: /cli/porter_bundles_archive/
+---
+## porter bundles archive
+
+Archive a bundle
+
+### Synopsis
+
+Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.
+
+```
+porter bundles archive [flags]
+```
+
+### Examples
+
+```
+  porter bundle archive [FILENAME]
+  porter bundle archive --file another/porter.yaml [FILENAME]
+  porter bundle archive --cnab-file some/bundle.json [FILENAME]
+		  
+```
+
+### Options
+
+```
+      --cnab-file string   Path to the CNAB bundle.json file.
+  -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+  -h, --help               help for archive
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug logging
+```
+
+### SEE ALSO
+
+* [porter bundles](/cli/porter_bundles/)	 - Bundle commands
+

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -1,0 +1,23 @@
+package porter
+
+import (
+	"github.com/deislabs/porter/pkg/context"
+)
+
+// ArchiveOptions defines the valid options for performing an archive operation
+type ArchiveOptions struct {
+	bundleFileOptions
+	File string
+}
+
+// Validate performs validation on the publish options
+func (o *ArchiveOptions) Validate(args []string, cxt *context.Context) error {
+	return nil
+}
+
+// Archive is a composite function that generates a CNAB thick bundle. It will pull the invocation image, and
+// any referenced images locally (if needed), export them to individual layers, generate a bundle.json and
+// then generate a gzipped tar archive containing the bundle.json and the images
+func (p *Porter) Archive(opts ArchiveOptions) error {
+	return nil
+}

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -1,6 +1,8 @@
 package porter
 
 import (
+	"fmt"
+
 	"github.com/deislabs/porter/pkg/context"
 )
 
@@ -19,5 +21,5 @@ func (o *ArchiveOptions) Validate(args []string, cxt *context.Context) error {
 // any referenced images locally (if needed), export them to individual layers, generate a bundle.json and
 // then generate a gzipped tar archive containing the bundle.json and the images
 func (p *Porter) Archive(opts ArchiveOptions) error {
-	return nil
+	return fmt.Errorf("archive is not yet implemented")
 }


### PR DESCRIPTION
This adds the scaffolding for the new Porter archive command. It's currently hidden, but I wanted to open a PR that introduced it so we could figure out if these options/command experience are correct.

