### PR TITLE
Use trailing slash on baseurl

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://porter.sh"
+baseURL = "https://porter.sh/"
 languageCode = "en-us"
 title = "Porter"
 theme = "porter"


### PR DESCRIPTION
We aren't consistent about when we join paths with a slash. For now
use a trailing slash but later we should cleanup the theme and wherever we use
site.baseurl, always join with a /.
