### PR TITLE
Do not import pkg/config from pkg/mixins

### DIFF
--- a/pkg/build/dockerfile-generater.go
+++ b/pkg/build/dockerfile-generater.go
@@ -165,7 +165,7 @@ func (g *DockerfileGenerator) buildMixinsSection() ([]string, error) {
 
 func (g *DockerfileGenerator) getMixinBuildInput(m string) mixin.BuildInput {
 	input := mixin.BuildInput{
-		Actions: make(map[string]config.Steps, 3),
+		Actions: make(map[string]interface{}, 3),
 	}
 
 	for _, mixinDecl := range g.Manifest.Mixins {

--- a/pkg/mixin/buildInput.go
+++ b/pkg/mixin/buildInput.go
@@ -1,10 +1,6 @@
 package mixin
 
-import (
-	"github.com/deislabs/porter/pkg/config"
-)
-
 type BuildInput struct {
-	Config  interface{}             `yaml:"config,omitempty"`
-	Actions map[string]config.Steps `yaml:"actions"`
+	Config  interface{}            `yaml:"config,omitempty"`
+	Actions map[string]interface{} `yaml:"actions"`
 }


### PR DESCRIPTION
# What does this change
When I implemented build context I imported `pkg/config` into a package used by all the mixins. This makes them have to depend on a bunch of unnecessary packages.

I really didn't need to import config.Step so I undid that change so that mixins don't need to have a bunch more dependencies.

# What issue does it fix
N/A


# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [x] Documentation Not Impacted
