### PR TITLE
Update cnab-to-oci to v0.2.0-beta1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -327,15 +327,16 @@
   revision = "f95ca8e1ba6c22c9abcdbf65e8dcc39c53958bba"
 
 [[projects]]
-  branch = "master"
-  digest = "1:a9d1406d7380d50675fddc88442cecdbfbdd069bc24191171ae901719cd4c79b"
+  digest = "1:51fef110ff737b08bebfa091471714db028ebcbeda6a3cad8ca4512b39b34581"
   name = "github.com/docker/cnab-to-oci"
   packages = [
     "converter",
+    "relocation",
     "remotes",
   ]
   pruneopts = "NUT"
-  revision = "85061934a54630aec0dd4adbe6427c10bd09a658"
+  revision = "c33e316902ce0e44adc6e14731c7241286d17d8e"
+  version = "v0.2.0-beta1"
 
 [[projects]]
   digest = "1:95f17095fc25ae7c9de6adbe34c048ea6102b0a3999c6fcf03fc663ab536c602"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,10 +8,9 @@
   source = "github.com/vdice/cnab-go"
   branch = "fix/custom-validators"
 
-# Using master until there is a release of cnab-to-oci
 [[constraint]]
   name = "github.com/docker/cnab-to-oci"
-  branch = "master"
+  version = "v0.2.0-beta1"
 
 [[constraint]]
   name = "github.com/carolynvs/datetime-printer"

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -43,7 +43,7 @@ func (r *Registry) PullBundle(tag string, insecureRegistry bool) (*bundle.Bundle
 		insecureRegistries = append(insecureRegistries, reg)
 	}
 
-	bun, err := remotes.Pull(context.Background(), ref, r.createResolver(insecureRegistries))
+	bun, _, err := remotes.Pull(context.Background(), ref, r.createResolver(insecureRegistries))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to pull remote bundle")
 	}
@@ -63,11 +63,11 @@ func (r *Registry) PushBundle(bun *bundle.Bundle, tag string, insecureRegistry b
 
 	resolver := r.createResolver(insecureRegistries)
 
-	err = remotes.FixupBundle(context.Background(), bun, ref, resolver, remotes.WithEventCallback(r.displayEvent))
+	rm, err := remotes.FixupBundle(context.Background(), bun, ref, resolver, remotes.WithEventCallback(r.displayEvent), remotes.WithAutoBundleUpdate())
 	if err != nil {
 		return err
 	}
-	d, err := remotes.Push(context.Background(), bun, ref, resolver, true)
+	d, err := remotes.Push(context.Background(), bun, rm, ref, resolver, true)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/docker/cnab-to-oci/converter/convert.go
+++ b/vendor/github.com/docker/cnab-to-oci/converter/convert.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/containerd/images"
 	"github.com/deislabs/cnab-go/bundle"
+	"github.com/docker/cnab-to-oci/relocation"
 	"github.com/docker/distribution/reference"
 	ocischema "github.com/opencontainers/image-spec/specs-go"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -60,12 +61,13 @@ func GetBundleConfigManifestDescriptor(ix *ocischemav1.Index) (ocischemav1.Descr
 }
 
 // ConvertBundleToOCIIndex converts a CNAB bundle into an OCI Index representation
-func ConvertBundleToOCIIndex(b *bundle.Bundle, targetRef reference.Named, bundleConfigManifestRef ocischemav1.Descriptor) (*ocischemav1.Index, error) {
+func ConvertBundleToOCIIndex(b *bundle.Bundle, targetRef reference.Named,
+	bundleConfigManifestRef ocischemav1.Descriptor, relocationMap relocation.ImageRelocationMap) (*ocischemav1.Index, error) {
 	annotations, err := makeAnnotations(b)
 	if err != nil {
 		return nil, err
 	}
-	manifests, err := makeManifests(b, targetRef, bundleConfigManifestRef)
+	manifests, err := makeManifests(b, targetRef, bundleConfigManifestRef, relocationMap)
 	if err != nil {
 		return nil, err
 	}
@@ -79,24 +81,59 @@ func ConvertBundleToOCIIndex(b *bundle.Bundle, targetRef reference.Named, bundle
 	return &result, nil
 }
 
-// ConvertOCIIndexToBundle converts an OCI index to a CNAB bundle representation
-func ConvertOCIIndexToBundle(ix *ocischemav1.Index, config *BundleConfig, originRepo reference.Named) (*bundle.Bundle, error) {
-	b := &bundle.Bundle{
-		SchemaVersion: CNABVersion,
-		Actions:       config.Actions,
-		Credentials:   config.Credentials,
-		Definitions:   config.Definitions,
-		Parameters:    config.Parameters,
-		Outputs:       config.Outputs,
-		Custom:        config.Custom,
+// GenerateRelocationMap generates the bundle relocation map
+func GenerateRelocationMap(ix *ocischemav1.Index, b *bundle.Bundle, originRepo reference.Named) (relocation.ImageRelocationMap, error) {
+	relocationMap := relocation.ImageRelocationMap{}
+
+	for _, d := range ix.Manifests {
+		switch d.MediaType {
+		case ocischemav1.MediaTypeImageManifest, ocischemav1.MediaTypeImageIndex:
+		case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema2ManifestList:
+		default:
+			return nil, fmt.Errorf("unsupported manifest descriptor %q with mediatype %q", d.Digest, d.MediaType)
+		}
+		descriptorType, ok := d.Annotations[CNABDescriptorTypeAnnotation]
+		if !ok {
+			return nil, fmt.Errorf("manifest descriptor %q has no CNAB descriptor type annotation %q", d.Digest, CNABDescriptorTypeAnnotation)
+		}
+		if descriptorType == CNABDescriptorTypeConfig {
+			continue
+		}
+		// strip tag/digest from originRepo
+		originRepo, err := reference.ParseNormalizedNamed(originRepo.Name())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create a digested reference for manifest descriptor %q: %s", d.Digest, err)
+		}
+		ref, err := reference.WithDigest(originRepo, d.Digest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create a digested reference for manifest descriptor %q: %s", d.Digest, err)
+		}
+		refFamiliar := reference.FamiliarString(ref)
+		switch descriptorType {
+		// The current descriptor is an invocation image
+		case CNABDescriptorTypeInvocation:
+			if len(b.InvocationImages) == 0 {
+				return nil, fmt.Errorf("unknown invocation image: %q", d.Digest)
+			}
+			relocationMap[b.InvocationImages[0].Image] = refFamiliar
+
+		// The current descriptor is a component image
+		case CNABDescriptorTypeComponent:
+			componentName, ok := d.Annotations[CNABDescriptorComponentNameAnnotation]
+			if !ok {
+				return nil, fmt.Errorf("component name missing in descriptor %q", d.Digest)
+			}
+			c, ok := b.Images[componentName]
+			if !ok {
+				return nil, fmt.Errorf("component %q not found in bundle", componentName)
+			}
+			relocationMap[c.Image] = refFamiliar
+		default:
+			return nil, fmt.Errorf("invalid CNAB descriptor type %q in descriptor %q", descriptorType, d.Digest)
+		}
 	}
-	if err := parseTopLevelAnnotations(ix.Annotations, b); err != nil {
-		return nil, err
-	}
-	if err := parseManifests(ix.Manifests, b, originRepo); err != nil {
-		return nil, err
-	}
-	return b, nil
+
+	return relocationMap, nil
 }
 
 func makeAnnotations(b *bundle.Bundle) (map[string]string, error) {
@@ -124,29 +161,8 @@ func makeAnnotations(b *bundle.Bundle) (map[string]string, error) {
 	return result, nil
 }
 
-func parseTopLevelAnnotations(annotations map[string]string, into *bundle.Bundle) error {
-	var ok bool
-	if into.Name, ok = annotations[ocischemav1.AnnotationTitle]; !ok {
-		return errors.New("manifest is missing title annotation " + ocischemav1.AnnotationTitle)
-	}
-	if into.Version, ok = annotations[ocischemav1.AnnotationVersion]; !ok {
-		return errors.New("manifest is missing version annotation " + ocischemav1.AnnotationVersion)
-	}
-	into.Description = annotations[ocischemav1.AnnotationDescription]
-	if maintainersJSON, ok := annotations[ocischemav1.AnnotationAuthors]; ok {
-		if err := json.Unmarshal([]byte(maintainersJSON), &into.Maintainers); err != nil {
-			return fmt.Errorf("unable to parse maintainers: %s", err)
-		}
-	}
-	if keywordsJSON, ok := annotations[CNABKeywordsAnnotation]; ok {
-		if err := json.Unmarshal([]byte(keywordsJSON), &into.Keywords); err != nil {
-			return fmt.Errorf("unable to parse keywords: %s", err)
-		}
-	}
-	return nil
-}
-
-func makeManifests(b *bundle.Bundle, targetReference reference.Named, bundleConfigManifestReference ocischemav1.Descriptor) ([]ocischemav1.Descriptor, error) {
+func makeManifests(b *bundle.Bundle, targetReference reference.Named,
+	bundleConfigManifestReference ocischemav1.Descriptor, relocationMap relocation.ImageRelocationMap) ([]ocischemav1.Descriptor, error) {
 	if len(b.InvocationImages) != 1 {
 		return nil, errors.New("only one invocation image supported")
 	}
@@ -155,7 +171,7 @@ func makeManifests(b *bundle.Bundle, targetReference reference.Named, bundleConf
 	}
 	bundleConfigManifestReference.Annotations[CNABDescriptorTypeAnnotation] = CNABDescriptorTypeConfig
 	manifests := []ocischemav1.Descriptor{bundleConfigManifestReference}
-	invocationImage, err := makeDescriptor(b.InvocationImages[0].BaseImage, targetReference)
+	invocationImage, err := makeDescriptor(b.InvocationImages[0].BaseImage, targetReference, relocationMap)
 	if err != nil {
 		return nil, fmt.Errorf("invalid invocation image: %s", err)
 	}
@@ -166,7 +182,7 @@ func makeManifests(b *bundle.Bundle, targetReference reference.Named, bundleConf
 	images := makeSortedImages(b.Images)
 	for _, name := range images {
 		img := b.Images[name]
-		image, err := makeDescriptor(img.BaseImage, targetReference)
+		image, err := makeDescriptor(img.BaseImage, targetReference, relocationMap)
 		if err != nil {
 			return nil, fmt.Errorf("invalid image: %s", err)
 		}
@@ -188,92 +204,57 @@ func makeSortedImages(images map[string]bundle.Image) []string {
 	return result
 }
 
-func parseManifests(descriptors []ocischemav1.Descriptor, into *bundle.Bundle, originRepo reference.Named) error {
-	for _, d := range descriptors {
-		var imageType string
-		switch d.MediaType {
-		case ocischemav1.MediaTypeImageManifest, ocischemav1.MediaTypeImageIndex:
-			imageType = "oci"
-		case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema2ManifestList:
-			imageType = "docker"
-		default:
-			return fmt.Errorf("unsupported manifest descriptor %q with mediatype %q", d.Digest, d.MediaType)
-		}
-		descriptorType, ok := d.Annotations[CNABDescriptorTypeAnnotation]
-		if !ok {
-			return fmt.Errorf("manifest descriptor %q has no CNAB descriptor type annotation %q", d.Digest, CNABDescriptorTypeAnnotation)
-		}
-		if descriptorType == CNABDescriptorTypeConfig {
-			continue
-		}
-		// strip tag/digest from originRepo
-		originRepo, err := reference.ParseNormalizedNamed(originRepo.Name())
-		if err != nil {
-			return fmt.Errorf("failed to create a digested reference for manifest descriptor %q: %s", d.Digest, err)
-		}
-		ref, err := reference.WithDigest(originRepo, d.Digest)
-		if err != nil {
-			return fmt.Errorf("failed to create a digested reference for manifest descriptor %q: %s", d.Digest, err)
-		}
-		refFamiliar := reference.FamiliarString(ref)
-		switch descriptorType {
-		// The current descriptor is an invocation image
-		case CNABDescriptorTypeInvocation:
-			into.InvocationImages = append(into.InvocationImages, bundle.InvocationImage{
-				BaseImage: bundle.BaseImage{
-					Image:     refFamiliar,
-					ImageType: imageType,
-					MediaType: d.MediaType,
-					Size:      uint64(d.Size),
-				},
-			})
-		// The current descriptor is a component image
-		case CNABDescriptorTypeComponent:
-			componentName, ok := d.Annotations[CNABDescriptorComponentNameAnnotation]
-			if !ok {
-				return fmt.Errorf("component name missing in descriptor %q", d.Digest)
-			}
-			if into.Images == nil {
-				into.Images = make(map[string]bundle.Image)
-			}
-			into.Images[componentName] = bundle.Image{
-				BaseImage: bundle.BaseImage{
-					Image:     refFamiliar,
-					ImageType: imageType,
-					MediaType: d.MediaType,
-					Size:      uint64(d.Size),
-				},
-			}
-		default:
-			return fmt.Errorf("invalid CNAB descriptor type %q in descriptor %q", descriptorType, d.Digest)
-		}
+func makeDescriptor(baseImage bundle.BaseImage, targetReference reference.Named, relocationMap relocation.ImageRelocationMap) (ocischemav1.Descriptor, error) {
+	relocatedImage, ok := relocationMap[baseImage.Image]
+	if !ok {
+		return ocischemav1.Descriptor{}, fmt.Errorf("image %q not present in the relocation map", baseImage.Image)
 	}
-	return nil
-}
 
-func makeDescriptor(baseImage bundle.BaseImage, targetReference reference.Named) (ocischemav1.Descriptor, error) {
-	named, err := reference.ParseNormalizedNamed(baseImage.Image)
+	named, err := reference.ParseNormalizedNamed(relocatedImage)
 	if err != nil {
-		return ocischemav1.Descriptor{}, fmt.Errorf("image %q is not a valid image reference: %s", baseImage.Image, err)
+		return ocischemav1.Descriptor{}, fmt.Errorf("image %q is not a valid image reference: %s", relocatedImage, err)
 	}
 	if named.Name() != targetReference.Name() {
-		return ocischemav1.Descriptor{}, fmt.Errorf("image %q is not in the same repository as %q", baseImage.Image, targetReference.String())
+		return ocischemav1.Descriptor{}, fmt.Errorf("image %q is not in the same repository as %q", relocatedImage, targetReference.String())
 	}
 	digested, ok := named.(reference.Digested)
 	if !ok {
-		return ocischemav1.Descriptor{}, fmt.Errorf("image %q is not a digested reference", baseImage.Image)
+		return ocischemav1.Descriptor{}, fmt.Errorf("image %q is not a digested reference", relocatedImage)
 	}
-	switch baseImage.MediaType {
+	mediaType, err := getMediaType(baseImage, relocatedImage)
+	if err != nil {
+		return ocischemav1.Descriptor{}, err
+	}
+	if baseImage.Size == 0 {
+		return ocischemav1.Descriptor{}, fmt.Errorf("image %q size is not set", relocatedImage)
+	}
+
+	return ocischemav1.Descriptor{
+		Digest:    digested.Digest(),
+		MediaType: mediaType,
+		Size:      int64(baseImage.Size),
+	}, nil
+}
+
+func getMediaType(baseImage bundle.BaseImage, relocatedImage string) (string, error) {
+	mediaType := baseImage.MediaType
+	if mediaType == "" {
+		switch baseImage.ImageType {
+		case "docker":
+			mediaType = images.MediaTypeDockerSchema2Manifest
+		case "oci":
+			mediaType = ocischemav1.MediaTypeImageManifest
+		default:
+			return "", fmt.Errorf("unsupported image type %q for image %q", baseImage.ImageType, relocatedImage)
+		}
+	}
+	switch mediaType {
 	case ocischemav1.MediaTypeImageManifest:
 	case images.MediaTypeDockerSchema2Manifest:
 	case ocischemav1.MediaTypeImageIndex:
 	case images.MediaTypeDockerSchema2ManifestList:
 	default:
-		return ocischemav1.Descriptor{}, fmt.Errorf("unsupported media type %q for image %q", baseImage.MediaType, baseImage.Image)
+		return "", fmt.Errorf("unsupported media type %q for image %q", baseImage.MediaType, relocatedImage)
 	}
-	return ocischemav1.Descriptor{
-		Digest:    digested.Digest(),
-		MediaType: baseImage.MediaType,
-		Size:      int64(baseImage.Size),
-	}, nil
+	return mediaType, nil
 }

--- a/vendor/github.com/docker/cnab-to-oci/converter/types.go
+++ b/vendor/github.com/docker/cnab-to-oci/converter/types.go
@@ -1,13 +1,10 @@
 package converter
 
 import (
-	"encoding/json"
-
-	"github.com/deislabs/cnab-go/bundle/definition"
-
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/go/canonical/json"
 	digest "github.com/opencontainers/go-digest"
 	ocischema "github.com/opencontainers/image-spec/specs-go"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -18,17 +15,6 @@ const (
 	CNABConfigMediaType = "application/vnd.cnab.config.v1+json"
 )
 
-// BundleConfig describes a cnab bundle runtime config
-type BundleConfig struct {
-	SchemaVersion string                       `json:"schemaVersion" mapstructure:"schemaVersion"`
-	Actions       map[string]bundle.Action     `json:"actions,omitempty" mapstructure:"actions,omitempty"`
-	Definitions   definition.Definitions       `json:"definitions" mapstructure:"definitions"`
-	Parameters    map[string]bundle.Parameter  `json:"parameters" mapstructure:"parameters"`
-	Outputs       map[string]bundle.Output     `json:"outputs" mapstructure:"outputs"`
-	Credentials   map[string]bundle.Credential `json:"credentials" mapstructure:"credentials"`
-	Custom        map[string]interface{}       `json:"custom,omitempty" mapstructure:"custom"`
-}
-
 // PreparedBundleConfig contains the config blob, image manifest (and fallback), and descriptors for a CNAB config
 type PreparedBundleConfig struct {
 	ConfigBlob           []byte
@@ -38,22 +24,9 @@ type PreparedBundleConfig struct {
 	Fallback             *PreparedBundleConfig
 }
 
-// CreateBundleConfig creates a bundle config from a CNAB
-func CreateBundleConfig(b *bundle.Bundle) *BundleConfig {
-	return &BundleConfig{
-		SchemaVersion: CNABVersion,
-		Actions:       b.Actions,
-		Definitions:   b.Definitions,
-		Parameters:    b.Parameters,
-		Outputs:       b.Outputs,
-		Credentials:   b.Credentials,
-		Custom:        b.Custom,
-	}
-}
-
 // PrepareForPush serializes a bundle config, generates its image manifest, and its manifest descriptor
-func (c *BundleConfig) PrepareForPush() (*PreparedBundleConfig, error) {
-	blob, err := json.Marshal(c)
+func PrepareForPush(b *bundle.Bundle) (*PreparedBundleConfig, error) {
+	blob, err := json.MarshalCanonical(b)
 	if err != nil {
 		return nil, err
 	}
@@ -109,14 +82,24 @@ func prepareOCIBundleConfig(mediaType string) bundleConfigPreparer {
 	}
 }
 
+func nonOCIDescriptorOf(blob []byte) distribution.Descriptor {
+	return distribution.Descriptor{
+		MediaType: schema2.MediaTypeImageConfig,
+		Size:      int64(len(blob)),
+		Digest:    digest.FromBytes(blob),
+	}
+}
+
 func prepareNonOCIBundleConfig(blob []byte) (*PreparedBundleConfig, error) {
+	desc := nonOCIDescriptorOf(blob)
 	man, err := schema2.FromStruct(schema2.Manifest{
 		Versioned: schema2.SchemaVersion,
-		Config: distribution.Descriptor{
-			MediaType: schema2.MediaTypeImageConfig,
-			Size:      int64(len(blob)),
-			Digest:    digest.FromBytes(blob),
+		// Add a descriptor for the configuration because some registries
+		// require the layers property to be defined and non-empty
+		Layers: []distribution.Descriptor{
+			desc,
 		},
+		Config: desc,
 	})
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/docker/cnab-to-oci/relocation/types.go
+++ b/vendor/github.com/docker/cnab-to-oci/relocation/types.go
@@ -1,0 +1,4 @@
+package relocation
+
+// ImageRelocationMap stores the mapping between the original image reference as key, and the relocated reference as a value.
+type ImageRelocationMap map[string]string

--- a/vendor/github.com/docker/cnab-to-oci/remotes/fixuphelpers.go
+++ b/vendor/github.com/docker/cnab-to-oci/remotes/fixuphelpers.go
@@ -97,9 +97,9 @@ func makeManifestWalker(ctx context.Context, sourceFetcher remotes.Fetcher,
 	return walker.walk(scheduler.ctx(), fixupInfo.resolvedDescriptor, nil), cleaner, nil
 }
 
-func notifyError(notifyEvent eventNotifier, err error) (bundle.BaseImage, error) {
+func notifyError(notifyEvent eventNotifier, err error) error {
 	notifyEvent(FixupEventTypeCopyImageEnd, "", err)
-	return bundle.BaseImage{}, err
+	return err
 }
 
 func checkBaseImage(baseImage *bundle.BaseImage) error {
@@ -119,7 +119,7 @@ func checkBaseImage(baseImage *bundle.BaseImage) error {
 	case images.MediaTypeDockerSchema2ManifestList:
 	case "":
 	default:
-		return fmt.Errorf("image media type %q is not supported", baseImage.ImageType)
+		return fmt.Errorf("image media type %q is not supported", baseImage.MediaType)
 	}
 
 	return nil

--- a/vendor/github.com/docker/cnab-to-oci/remotes/fixupoptions.go
+++ b/vendor/github.com/docker/cnab-to-oci/remotes/fixupoptions.go
@@ -25,6 +25,7 @@ type fixupConfig struct {
 	resolver                      remotes.Resolver
 	invocationImagePlatformFilter platforms.Matcher
 	componentImagePlatformFilter  platforms.Matcher
+	autoBundleUpdate              bool
 }
 
 // FixupOption is a helper for configuring a FixupBundle
@@ -102,6 +103,14 @@ func WithParallelism(maxConcurrentJobs int, jobsBufferLength int) FixupOption {
 	return func(cfg *fixupConfig) error {
 		cfg.maxConcurrentJobs = maxConcurrentJobs
 		cfg.jobsBufferLength = jobsBufferLength
+		return nil
+	}
+}
+
+// WithAutoBundleUpdate updates the bundle with content digests and size provided by the registry
+func WithAutoBundleUpdate() FixupOption {
+	return func(cfg *fixupConfig) error {
+		cfg.autoBundleUpdate = true
 		return nil
 	}
 }


### PR DESCRIPTION
This PR updates [`cnab-to-oci` to v0.2.0-beta1](https://github.com/docker/cnab-to-oci/releases/tag/v0.2.0-beta1), which stores the entire bundle in the OCI registry.

The behaviour of `porter publish` is not changed.

