### PR TITLE
chore(*): remove autoApprove property in tf examples

### DIFF
--- a/build/testdata/bundles/terraform/porter.yaml
+++ b/build/testdata/bundles/terraform/porter.yaml
@@ -16,7 +16,6 @@ parameters:
 install:
   - terraform:
       description: "Install Terraform assets"
-      autoApprove: true
       vars:
         file_contents: "{{bundle.parameters.file_contents}}"
       outputs:
@@ -25,7 +24,6 @@ install:
 upgrade:
   - terraform:
       description: "Upgrade Terraform assets"
-      autoApprove: true
       vars:
         file_contents: "{{ bundle.parameters.file_contents }}"
       outputs:
@@ -37,7 +35,6 @@ status:
 
 uninstall:
   - terraform:
-      autoApprove: true
       description: "Uninstall Terraform assets"
       vars:
         file_contents: "{{bundle.parameters.file_contents}}"

--- a/docs/content/mixins/terraform.md
+++ b/docs/content/mixins/terraform.md
@@ -20,7 +20,6 @@ porter mixin install terraform
 install:
   - terraform:
       description: "Install Azure Key Vault"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"

--- a/examples/azure-tf-example/README.md
+++ b/examples/azure-tf-example/README.md
@@ -85,7 +85,6 @@ Finally, please note how the `porter-terraform` mixin is used:
 ```yaml
 - terraform:
       description: "Create Azure CosmosDB and Event Hubs"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"

--- a/examples/azure-tf-example/porter.yaml
+++ b/examples/azure-tf-example/porter.yaml
@@ -83,7 +83,6 @@ install:
   
   - terraform:
       description: "Create Azure CosmosDB and Event Hubs"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
@@ -105,7 +104,6 @@ install:
 upgrade:
   - terraform:
       description: "Update Azure CosmosDB and Event Hubs"
-      autoApprove: true
       input: false
       vars:
         subscription_id: "{{bundle.credentials.subscription_id}}"
@@ -124,7 +122,6 @@ upgrade:
 uninstall:
   - terraform:
       description: "Remove Azure CosmosDB and Event Hubs"
-      autoApprove: true
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
         storage_account_name: "{{ bundle.parameters.storage_account_name }}"

--- a/workshop/porter-tf-aci/azure/bundle/porter.yaml
+++ b/workshop/porter-tf-aci/azure/bundle/porter.yaml
@@ -76,7 +76,6 @@ install:
         key: "STORAGE_ACCOUNT_KEY"
    - terraform:
       description: "Create Azure MySQL With Terraform"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"

--- a/workshop/porter-tf/azure/porter.yaml
+++ b/workshop/porter-tf/azure/porter.yaml
@@ -67,7 +67,6 @@ install:
         key: "STORAGE_ACCOUNT_KEY"
    - terraform:
       description: "Create Azure MySQL With Terraform"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"


### PR DESCRIPTION
# What does this change
Removes the unnecessary/deprecated `autoApprove` property from examples utilizing the `terraform` mixin, per https://github.com/deislabs/porter-terraform/pull/22

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
