### PR TITLE
Added missing BUILD_DIR arg to Dockerfile.tmpl

### DIFF
--- a/workshop/azure-cli/Dockerfile.tmpl
+++ b/workshop/azure-cli/Dockerfile.tmpl
@@ -1,1 +1,2 @@
 FROM mcr.microsoft.com/azure-cli
+ARG BUNDLE_DIR


### PR DESCRIPTION
This fix is for issue #652 to allow `porter build` to succeed in `azure-cli` workshop exercise.

# What does this change
Adds missing Dockerfile stanza required for `porter build` to succeed.

# What issue does it fix
Closes #652
