### PR TITLE
Get rid of command name in prettyCmd #651

### DIFF
--- a/pkg/exec/builder/execute.go
+++ b/pkg/exec/builder/execute.go
@@ -69,7 +69,7 @@ func ExecuteStep(cxt *context.Context, step ExecutableStep) (string, error) {
 	cmd.Stdout = io.MultiWriter(cxt.Out, output)
 	cmd.Stderr = cxt.Err
 
-	prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 	if cxt.Debug {
 		fmt.Fprintln(cxt.Out, prettyCmd)
 	}

--- a/pkg/kubernetes/execute.go
+++ b/pkg/kubernetes/execute.go
@@ -94,12 +94,12 @@ func (m *Mixin) Execute() error {
 
 		err = cmd.Start()
 		if err != nil {
-			prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+			prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 			return errors.Wrap(err, fmt.Sprintf("couldn't run command %s", prettyCmd))
 		}
 		err = cmd.Wait()
 		if err != nil {
-			prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+			prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 			return errors.Wrap(err, fmt.Sprintf("error running command %s", prettyCmd))
 		}
 	}

--- a/pkg/kubernetes/install.go
+++ b/pkg/kubernetes/install.go
@@ -62,12 +62,12 @@ func (m *Mixin) Install() error {
 
 		err = cmd.Start()
 		if err != nil {
-			prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+			prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 			return errors.Wrap(err, fmt.Sprintf("couldn't run command %s", prettyCmd))
 		}
 		err = cmd.Wait()
 		if err != nil {
-			prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+			prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 			return errors.Wrap(err, fmt.Sprintf("error running command %s", prettyCmd))
 		}
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -97,7 +97,7 @@ func (m *Mixin) getOutput(resourceType, resourceName, namespace, jsonPath string
 	cmd.Stderr = m.Err
 	out, err := cmd.Output()
 	if err != nil {
-		prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+		prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 		return nil, errors.Wrap(err, fmt.Sprintf("couldn't run command %s", prettyCmd))
 	}
 	return out, nil

--- a/pkg/kubernetes/uninstall.go
+++ b/pkg/kubernetes/uninstall.go
@@ -65,12 +65,12 @@ func (m *Mixin) Uninstall() error {
 		cmd.Stderr = m.Err
 		err = cmd.Start()
 		if err != nil {
-			prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+			prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 			return errors.Wrap(err, fmt.Sprintf("couldn't run command %s", prettyCmd))
 		}
 		err = cmd.Wait()
 		if err != nil {
-			prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+			prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 			return errors.Wrap(err, fmt.Sprintf("error running command %s", prettyCmd))
 		}
 	}

--- a/pkg/mixin/provider/runner.go
+++ b/pkg/mixin/provider/runner.go
@@ -93,7 +93,7 @@ func (r *Runner) Run(commandOpts mixin.CommandOptions) error {
 		}()
 	}
 
-	prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 	if r.Debug {
 		fmt.Fprintln(r.Err, prettyCmd)
 	}


### PR DESCRIPTION
# What does this change
https://github.com/deislabs/porter/blob/7da5cffdf3581c27dfab03af88df2df005baa02d/pkg/exec/builder/execute.go#L72-L75

`cmd.Path` is including application name, and the first argument of `cmd.Args` is also apps name , So it change to `cmd.Dir` and get rid of space of `%s%s`

# What issue does it fix
Closes #651 

# Notes for the reviewer
Nil

# Checklist
- [x] Unit Tests
- [x] Documentation
 - [x] Documentation Not Impacted