### PR TITLE
Made credentials required by default by adding UnmarshalYAML method to CredentialDefinition type

### DIFF
--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -151,12 +151,31 @@ func (pd *ParameterDefinition) DeepCopy() *ParameterDefinition {
 	return &p2
 }
 
+// CredentialDefinition are
 type CredentialDefinition struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description,omitempty"`
 	Required    bool   `yaml:"required,omitempty"`
 
 	Location `yaml:",inline"`
+}
+
+func (cd *CredentialDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type rawCreds CredentialDefinition
+	rawCred := rawCreds{
+		Name:        cd.Name,
+		Description: cd.Description,
+		Required:    true,
+		Location:    cd.Location,
+	}
+
+	if err := unmarshal(&rawCred); err != nil {
+		return err
+	}
+
+	*cd = CredentialDefinition(rawCred)
+
+	return nil
 }
 
 // TODO: use cnab-go's bundle.Location instead, once yaml tags have been added

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -151,7 +151,7 @@ func (pd *ParameterDefinition) DeepCopy() *ParameterDefinition {
 	return &p2
 }
 
-// CredentialDefinition are
+// CredentialDefinition represents the structure or fields of a credential parameter
 type CredentialDefinition struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description,omitempty"`

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -75,7 +75,6 @@ func TestCredentialsDefinition_UnmarshalYAML(t *testing.T) {
 		c := NewTestConfig(t)
 		c.TestContext.AddTestFile("testdata/with-credentials.yaml", Name)
 		m, err := c.ReadManifest(Name)
-		t.Logf("%v", m.Credentials)
 		require.NoError(t, err)
 		assertAllCredentialsRequired(t, m.Credentials)
 	})

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -73,8 +73,9 @@ func TestCredentialsDefinition_UnmarshalYAML(t *testing.T) {
 	}
 	t.Run("all credentials in the generated manifest file are required", func(t *testing.T) {
 		c := NewTestConfig(t)
-		c.TestContext.AddTestFile("testdata/mixin-with-config.yaml", Name)
+		c.TestContext.AddTestFile("testdata/with-credentials.yaml", Name)
 		m, err := c.ReadManifest(Name)
+		t.Logf("%v", m.Credentials)
 		require.NoError(t, err)
 		assertAllCredentialsRequired(t, m.Credentials)
 	})

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -65,6 +65,21 @@ func TestMixinDeclaration_UnmarshalYAML_Invalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "mixin declaration contained more than one mixin")
 }
 
+func TestCredentialsDefinition_UnmarshalYAML(t *testing.T) {
+	assertAllCredentialsRequired := func(t *testing.T, creds []CredentialDefinition) {
+		for _, cred := range creds {
+			assert.EqualValuesf(t, true, cred.Required, "Credential: %s should be required", cred.Name)
+		}
+	}
+	t.Run("all credentials in the generated manifest file are required", func(t *testing.T) {
+		c := NewTestConfig(t)
+		c.TestContext.AddTestFile("testdata/mixin-with-config.yaml", Name)
+		m, err := c.ReadManifest(Name)
+		require.NoError(t, err)
+		assertAllCredentialsRequired(t, m.Credentials)
+	})
+}
+
 func TestMixinDeclaration_MarshalYAML(t *testing.T) {
 	m := struct {
 		Mixins []MixinDeclaration

--- a/pkg/config/testdata/mixin-with-config.yaml
+++ b/pkg/config/testdata/mixin-with-config.yaml
@@ -3,15 +3,3 @@ mixins:
 - az:
     extensions:
     - iot
-
-credentials:
-- name: SUBSCRIPTION_ID
-  env: AZURE_SUBSCRIPTION_ID
-- name: TENANT_ID
-  env: AZURE_TENANT_ID
-- name: CLIENT_ID
-  env: AZURE_CLIENT_ID
-- name: CLIENT_SECRET
-  env: AZURE_CLIENT_SECRET
-- name: kubeconfig
-  path: /root/.kube/config

--- a/pkg/config/testdata/mixin-with-config.yaml
+++ b/pkg/config/testdata/mixin-with-config.yaml
@@ -3,3 +3,15 @@ mixins:
 - az:
     extensions:
     - iot
+
+credentials:
+- name: SUBSCRIPTION_ID
+  env: AZURE_SUBSCRIPTION_ID
+- name: TENANT_ID
+  env: AZURE_TENANT_ID
+- name: CLIENT_ID
+  env: AZURE_CLIENT_ID
+- name: CLIENT_SECRET
+  env: AZURE_CLIENT_SECRET
+- name: kubeconfig
+  path: /root/.kube/config

--- a/pkg/config/testdata/with-credentials.yaml
+++ b/pkg/config/testdata/with-credentials.yaml
@@ -1,0 +1,40 @@
+mixins:
+- exec
+
+name: hello
+description: "An example Porter configuration"
+version: 0.1.0
+invocationImage: porter-hello:latest
+
+credentials:
+- name: SUBSCRIPTION_ID
+  env: AZURE_SUBSCRIPTION_ID
+- name: TENANT_ID
+  env: AZURE_TENANT_ID
+- name: CLIENT_ID
+  env: AZURE_CLIENT_ID
+- name: CLIENT_SECRET
+  env: AZURE_CLIENT_SECRET
+- name: kubeconfig
+  path: /root/.kube/config
+
+install:
+- exec:
+    description: "Say Hello"
+    command: bash
+    flags:
+      c: echo Hello World
+
+status:
+- exec:
+    description: "Get World Status"
+    command: bash
+    flags:
+        c: echo The world is on fire
+
+uninstall:
+- exec:
+    description: "Say Goodbye"
+    command: bash
+    flags:
+        c: echo Goodbye World


### PR DESCRIPTION
# What does this change
This PR adds a method, `UnmarshalYAML` to the CredentialDefinition struct to always mark a credential's definition as required i.e. `true` when unmarshaling from a YAML to create a manifest file. This makes credentials required by default.

# What issue does it fix
[#577](https://github.com/deislabs/porter/issues/577)

[1]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
- In the spec for this issue, it's mentioned that `THERE IS NO WARNING. The bundle just fails in odd places with unexpected errors because the bundle was written assuming credentials would be there, and they aren't.` Can this be solved within this issue?
- Also, I was not sure on how to exactly test the change made and what I did was to create a YAML file `with-credentials.yaml` with some credentials defined. Some advice here would be appreciated.

# Checklist
- [x] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
