### PR TITLE
Rename things from Duffle since we don't use it anymore

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,7 +19,7 @@
 
 #
 # SEMVER IS DEAD, LONG LIVE SEMVER
-# Use a very specific version of docker and its libraries because they aren't contained in a release yet, but duffle uses some unreleased feature/code ¯\_(ツ)_/¯
+# Use a very specific version of docker and its libraries because they aren't contained in a release yet, but cnab-go references some unreleased feature/code ¯\_(ツ)_/¯
 #
 [[constraint]]
   name = "github.com/docker/cli"

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -30,21 +30,21 @@ type ActionArguments struct {
 	Driver string
 }
 
-func (d *Duffle) ApplyConfig(args ActionArguments) action.OperationConfigs {
+func (d *Runtime) ApplyConfig(args ActionArguments) action.OperationConfigs {
 	return action.OperationConfigs{
 		d.SetOutput(),
 		d.AddFiles(args),
 	}
 }
 
-func (d *Duffle) SetOutput() action.OperationConfigFunc {
+func (d *Runtime) SetOutput() action.OperationConfigFunc {
 	return func(op *driver.Operation) error {
 		op.Out = d.Out
 		return nil
 	}
 }
 
-func (d *Duffle) AddFiles(args ActionArguments) action.OperationConfigFunc {
+func (d *Runtime) AddFiles(args ActionArguments) action.OperationConfigFunc {
 	return func(op *driver.Operation) error {
 		for k, v := range args.Files {
 			op.Files[k] = v

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -5,7 +5,7 @@ import (
 	"github.com/deislabs/cnab-go/driver"
 )
 
-// Shared arguments for all CNAB actions supported by duffle
+// Shared arguments for all CNAB actions
 type ActionArguments struct {
 	// Name of the instance.
 	Claim string

--- a/pkg/cnab/provider/bundle.go
+++ b/pkg/cnab/provider/bundle.go
@@ -9,7 +9,7 @@ import (
 // TODO: Export everything in this file from duffle cmd/duffle/pull.go
 var ErrNotSigned = errors.New("bundle is not signed")
 
-func (d *Duffle) LoadBundle(bundleFile string, insecure bool) (*bundle.Bundle, error) {
+func (d *Runtime) LoadBundle(bundleFile string, insecure bool) (*bundle.Bundle, error) {
 	// TODO: once we support secure bundles we need more logic here (it's in duffle but I didn't copy it)
 	// I'm hoping we've gotten this code exported from duffle by then though
 	if !insecure {

--- a/pkg/cnab/provider/bundle.go
+++ b/pkg/cnab/provider/bundle.go
@@ -6,12 +6,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TODO: Export everything in this file from duffle cmd/duffle/pull.go
 var ErrNotSigned = errors.New("bundle is not signed")
 
 func (d *Runtime) LoadBundle(bundleFile string, insecure bool) (*bundle.Bundle, error) {
-	// TODO: once we support secure bundles we need more logic here (it's in duffle but I didn't copy it)
-	// I'm hoping we've gotten this code exported from duffle by then though
 	if !insecure {
 		return nil, errors.New("secure bundles not implemented")
 	}

--- a/pkg/cnab/provider/claims.go
+++ b/pkg/cnab/provider/claims.go
@@ -11,7 +11,7 @@ const (
 	ClaimsDirectory = "claims"
 )
 
-func (d *Duffle) NewClaimStore() (claim.Store, error) {
+func (d *Runtime) NewClaimStore() (claim.Store, error) {
 	claimsPath, err := d.Config.GetClaimsDir()
 	if err != nil {
 		return claim.Store{}, errors.Wrap(err, "could not get path to the claims directory")
@@ -20,7 +20,7 @@ func (d *Duffle) NewClaimStore() (claim.Store, error) {
 }
 
 // FetchClaim fetches a claim from the given CNABProvider's claim store
-func (d *Duffle) FetchClaim(name string) (*claim.Claim, error) {
+func (d *Runtime) FetchClaim(name string) (*claim.Claim, error) {
 	claimStore, err := d.NewClaimStore()
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve bundle instance %s", name)

--- a/pkg/cnab/provider/credentials.go
+++ b/pkg/cnab/provider/credentials.go
@@ -13,7 +13,7 @@ const (
 	CredentialsDirectory = "credentials"
 )
 
-func (d *Duffle) loadCredentials(b *bundle.Bundle, files []string) (map[string]string, error) {
+func (d *Runtime) loadCredentials(b *bundle.Bundle, files []string) (map[string]string, error) {
 	// TODO: export back outta Compton
 
 	creds := map[string]string{}
@@ -51,7 +51,7 @@ func (d *Duffle) loadCredentials(b *bundle.Bundle, files []string) (map[string]s
 }
 
 // isPathy checks to see if a name looks like a path.
-func (d *Duffle) isPathy(name string) bool {
+func (d *Runtime) isPathy(name string) bool {
 	// TODO: export back outta Compton
 
 	return strings.Contains(name, string(filepath.Separator))

--- a/pkg/cnab/provider/credentials.go
+++ b/pkg/cnab/provider/credentials.go
@@ -26,8 +26,6 @@ func (d *Runtime) loadCredentials(b *bundle.Bundle, files []string) (map[string]
 	// in which they were supplied on the CLI.
 	for _, file := range files {
 		if !d.isPathy(file) {
-			// TODO: when we export this function, having an instance where we can set home manually
-			// instead of on an env var would be super helpful. I had to inject the homepath instead of using duffle's homepath function.
 			credsPath, err := d.Config.GetCredentialsDir()
 			if err != nil {
 				return nil, err

--- a/pkg/cnab/provider/dockerdriver_test.go
+++ b/pkg/cnab/provider/dockerdriver_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestNewDriver_Docker(t *testing.T) {
 	c := config.NewTestConfig(t)
-	d := NewDuffle(c.Config)
+	d := NewRuntime(c.Config)
 
 	driver, err := d.newDriver("docker", "myclaim", ActionArguments{})
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestNewDriver_Docker(t *testing.T) {
 
 func TestWriteClaimOutputs(t *testing.T) {
 	c := config.NewTestConfig(t)
-	d := NewDuffle(c.Config)
+	d := NewRuntime(c.Config)
 
 	homeDir, err := c.GetHomeDir()
 	require.NoError(t, err)

--- a/pkg/cnab/provider/install.go
+++ b/pkg/cnab/provider/install.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (d *Duffle) Install(args ActionArguments) error {
+func (d *Runtime) Install(args ActionArguments) error {
 	// TODO: this entire function should be exposed in a duffle sdk package e.g. duffle.Install
 	// we shouldn't be reimplementing calling all these functions all over again
 

--- a/pkg/cnab/provider/install.go
+++ b/pkg/cnab/provider/install.go
@@ -10,9 +10,6 @@ import (
 )
 
 func (d *Runtime) Install(args ActionArguments) error {
-	// TODO: this entire function should be exposed in a duffle sdk package e.g. duffle.Install
-	// we shouldn't be reimplementing calling all these functions all over again
-
 	c, err := claim.New(args.Claim)
 	if err != nil {
 		return errors.Wrap(err, "invalid bundle instance name")

--- a/pkg/cnab/provider/invoke.go
+++ b/pkg/cnab/provider/invoke.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (d *Duffle) Invoke(action string, args ActionArguments) error {
+func (d *Runtime) Invoke(action string, args ActionArguments) error {
 	claims, err := d.NewClaimStore()
 	if err != nil {
 		return errors.Wrapf(err, "could not access claim store")

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -12,7 +12,7 @@ import (
 
 // loadParameters accepts a set of string overrides and combines that with the default parameters to create
 // a full set of parameters.
-func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]string, action string) (map[string]interface{}, error) {
+func (d *Runtime) loadParameters(claim *claim.Claim, rawOverrides map[string]string, action string) (map[string]interface{}, error) {
 	overrides := make(map[string]interface{}, len(rawOverrides))
 	bun := claim.Bundle
 
@@ -70,7 +70,7 @@ func (d *Duffle) loadParameters(claim *claim.Claim, rawOverrides map[string]stri
 	return bundle.ValuesOrDefaults(overrides, bun)
 }
 
-func (d *Duffle) getUnconvertedValueFromRaw(def *definition.Schema, key, rawValue string) (string, error) {
+func (d *Runtime) getUnconvertedValueFromRaw(def *definition.Schema, key, rawValue string) (string, error) {
 	// the parameter value (via rawValue) may represent a file on the local filesystem
 	if def.Type == "string" && def.ContentEncoding == "base64" {
 		if _, err := d.FileSystem.Stat(rawValue); err == nil {

--- a/pkg/cnab/provider/parameters_test.go
+++ b/pkg/cnab/provider/parameters_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_loadParameters_paramNotDefined(t *testing.T) {
 	c := config.NewTestConfig(t)
-	d := NewDuffle(c.Config)
+	d := NewRuntime(c.Config)
 
 	claim, err := claim.New("test")
 	require.NoError(t, err)
@@ -34,7 +34,7 @@ func Test_loadParameters_paramNotDefined(t *testing.T) {
 
 func Test_loadParameters_definitionNotDefined(t *testing.T) {
 	c := config.NewTestConfig(t)
-	d := NewDuffle(c.Config)
+	d := NewRuntime(c.Config)
 
 	claim, err := claim.New("test")
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func Test_loadParameters_definitionNotDefined(t *testing.T) {
 
 func Test_loadParameters_applyToClaimDefaults(t *testing.T) {
 	c := config.NewTestConfig(t)
-	d := NewDuffle(c.Config)
+	d := NewRuntime(c.Config)
 
 	claim, err := claim.New("test")
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func Test_loadParameters_applyToClaimDefaults(t *testing.T) {
 
 func Test_loadParameters_applyToBundleDefaults(t *testing.T) {
 	c := config.NewTestConfig(t)
-	d := NewDuffle(c.Config)
+	d := NewRuntime(c.Config)
 
 	claim, err := claim.New("test")
 	require.NoError(t, err)
@@ -156,7 +156,7 @@ func Test_loadParameters_applyToBundleDefaults(t *testing.T) {
 
 func Test_loadParameters_requiredButDoesNotApply(t *testing.T) {
 	c := config.NewTestConfig(t)
-	d := NewDuffle(c.Config)
+	d := NewRuntime(c.Config)
 
 	claim, err := claim.New("test")
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func Test_loadParameters_requiredButDoesNotApply(t *testing.T) {
 
 func Test_loadParameters_fileParameter(t *testing.T) {
 	c := config.NewTestConfig(t)
-	d := NewDuffle(c.Config)
+	d := NewRuntime(c.Config)
 
 	c.TestContext.AddTestFile("testdata/file-param", "/path/to/file")
 

--- a/pkg/cnab/provider/runtime.go
+++ b/pkg/cnab/provider/runtime.go
@@ -14,17 +14,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-type Duffle struct {
+type Runtime struct {
 	*config.Config
 }
 
-func NewDuffle(c *config.Config) *Duffle {
-	return &Duffle{
+func NewRuntime(c *config.Config) *Runtime {
+	return &Runtime{
 		Config: c,
 	}
 }
 
-func (d *Duffle) newDriver(driverName string, claimName string, args ActionArguments) (driver.Driver, error) {
+func (d *Runtime) newDriver(driverName string, claimName string, args ActionArguments) (driver.Driver, error) {
 	driverImpl, err := lookup.Lookup(driverName)
 	if err != nil {
 		return driverImpl, err
@@ -51,7 +51,7 @@ func (d *Duffle) newDriver(driverName string, claimName string, args ActionArgum
 	return driverImpl, err
 }
 
-func (d *Duffle) setupOutputsMount(driverImpl driver.Driver, claimName string) error {
+func (d *Runtime) setupOutputsMount(driverImpl driver.Driver, claimName string) error {
 	// If docker driver, setup host bind mount for outputs
 	if dockerish, ok := driverImpl.(*docker.Driver); ok {
 		outputsDir, err := d.Config.GetOutputsDir()
@@ -82,7 +82,7 @@ func (d *Duffle) setupOutputsMount(driverImpl driver.Driver, claimName string) e
 
 // WriteClaimOutputs writes outputs to a claim, according to the provided bundle
 // and Duffle config
-func (d *Duffle) WriteClaimOutputs(c *claim.Claim, action string) error {
+func (d *Runtime) WriteClaimOutputs(c *claim.Claim, action string) error {
 	if c.Bundle == nil {
 		return errors.New("bundle instance has no bundle set")
 	}

--- a/pkg/cnab/provider/runtime.go
+++ b/pkg/cnab/provider/runtime.go
@@ -80,8 +80,7 @@ func (d *Runtime) setupOutputsMount(driverImpl driver.Driver, claimName string) 
 	return nil
 }
 
-// WriteClaimOutputs writes outputs to a claim, according to the provided bundle
-// and Duffle config
+// WriteClaimOutputs writes outputs to a claim, according to the provided bundle config.
 func (d *Runtime) WriteClaimOutputs(c *claim.Claim, action string) error {
 	if c.Bundle == nil {
 		return errors.New("bundle instance has no bundle set")

--- a/pkg/cnab/provider/uninstall.go
+++ b/pkg/cnab/provider/uninstall.go
@@ -10,9 +10,6 @@ import (
 )
 
 func (d *Runtime) Uninstall(args ActionArguments) error {
-	// TODO: this entire function should be exposed in a duffle sdk package e.g. duffle.Install
-	// we shouldn't be reimplementing calling all these functions all over again
-
 	claims, err := d.NewClaimStore()
 	if err != nil {
 		return errors.Wrapf(err, "could not access claim store")

--- a/pkg/cnab/provider/uninstall.go
+++ b/pkg/cnab/provider/uninstall.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (d *Duffle) Uninstall(args ActionArguments) error {
+func (d *Runtime) Uninstall(args ActionArguments) error {
 	// TODO: this entire function should be exposed in a duffle sdk package e.g. duffle.Install
 	// we shouldn't be reimplementing calling all these functions all over again
 

--- a/pkg/cnab/provider/upgrade.go
+++ b/pkg/cnab/provider/upgrade.go
@@ -9,7 +9,7 @@ import (
 	"github.com/deislabs/porter/pkg/config"
 )
 
-func (d *Duffle) Upgrade(args ActionArguments) error {
+func (d *Runtime) Upgrade(args ActionArguments) error {
 	// TODO: this entire function should be exposed in a duffle sdk package e.g. duffle.Upgrade
 	// we shouldn't be reimplementing calling all these functions all over again
 

--- a/pkg/cnab/provider/upgrade.go
+++ b/pkg/cnab/provider/upgrade.go
@@ -10,9 +10,6 @@ import (
 )
 
 func (d *Runtime) Upgrade(args ActionArguments) error {
-	// TODO: this entire function should be exposed in a duffle sdk package e.g. duffle.Upgrade
-	// we shouldn't be reimplementing calling all these functions all over again
-
 	claims, err := d.NewClaimStore()
 	if err != nil {
 		return errors.Wrapf(err, "could not access claim store")

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -186,7 +186,7 @@ func (o *bundleFileOptions) validateCNABFile(cxt *context.Context) error {
 
 	originalPath := o.CNABFile
 	if !filepath.IsAbs(o.CNABFile) {
-		// Convert to an absolute filepath because duffle needs it that way
+		// Convert to an absolute filepath because runtime needs it that way
 		pwd, err := os.Getwd()
 		if err != nil {
 			return errors.Wrap(err, "could not get current working directory")

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -78,7 +78,7 @@ func (e *dependencyExecutioner) Execute() error {
 	}
 
 	// executeDependency the requested action against all of the dependencies
-	parentArgs := e.parentOpts.ToDuffleArgs(e)
+	parentArgs := e.parentOpts.ToActionArgs(e)
 	for _, dep := range e.deps {
 		err := e.executeDependency(dep, parentArgs)
 		if err != nil {

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -38,7 +38,7 @@ func NewTestPorter(t *testing.T) *TestPorter {
 	tc := config.NewTestConfig(t)
 	p := New()
 	p.Config = tc.Config
-	p.CNAB = cnabprovider.NewDuffle(tc.Config)
+	p.CNAB = cnabprovider.NewRuntime(tc.Config)
 	p.Mixins = &mixin.TestMixinProvider{}
 	p.Cache = cache.New(tc.Config)
 	p.Builder = NewTestBuildProvider()

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -42,5 +42,5 @@ func (p *Porter) InstallBundle(opts InstallOptions) error {
 	}
 
 	fmt.Fprintf(p.Out, "installing %s...\n", opts.Name)
-	return p.CNAB.Install(opts.ToDuffleArgs(deperator))
+	return p.CNAB.Install(opts.ToActionArgs(deperator))
 }

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -56,5 +56,5 @@ func (p *Porter) InvokeBundle(opts InvokeOptions) error {
 	}
 
 	fmt.Fprintf(p.Out, "invoking custom action %s on %s...\n", opts.Action, opts.Name)
-	return p.CNAB.Invoke(opts.Action, opts.ToDuffleArgs(deperator))
+	return p.CNAB.Invoke(opts.Action, opts.ToActionArgs(deperator))
 }

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -38,7 +38,7 @@ func (o *BundleLifecycleOpts) ToActionArgs(deperator *dependencyExecutioner) cna
 		Driver:                o.Driver,
 	}
 
-	// Do a safe copy so that modifications to the duffle args aren't also made to the
+	// Do a safe copy so that modifications to the args aren't also made to the
 	// original options, which is confusing to debug
 	for k, v := range o.combinedParameters {
 		args.Params[k] = v

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -27,9 +27,8 @@ func (o *BundleLifecycleOpts) Validate(args []string, cxt *context.Context) erro
 	return nil
 }
 
-// ToDuffleArgs converts this instance of user-provided action options
-// to duffle action arguments.
-func (o *BundleLifecycleOpts) ToDuffleArgs(deperator *dependencyExecutioner) cnabprovider.ActionArguments {
+// ToActionArgs converts this instance of user-provided action options.
+func (o *BundleLifecycleOpts) ToActionArgs(deperator *dependencyExecutioner) cnabprovider.ActionArguments {
 	args := cnabprovider.ActionArguments{
 		Claim:                 o.Name,
 		BundlePath:            o.CNABFile,

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -39,7 +39,7 @@ func (l CondensedClaimList) Less(i, j int) bool {
 
 // ListInstances lists installed bundles by their claims.
 func (p *Porter) ListInstances(opts ListOptions) error {
-	cp := cnab.NewDuffle(p.Config)
+	cp := cnab.NewRuntime(p.Config)
 	claimStore, err := cp.NewClaimStore()
 	if err != nil {
 		return errors.Wrapf(err, "could not access claim store")

--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -35,6 +35,6 @@ func New() *Porter {
 		Templates: templates.NewTemplates(),
 		Builder:   buildprovider.NewDockerBuilder(c),
 		Mixins:    mixinprovider.NewFileSystem(c),
-		CNAB:      cnabprovider.NewDuffle(c),
+		CNAB:      cnabprovider.NewRuntime(c),
 	}
 }

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -37,7 +37,7 @@ func (p *Porter) UninstallBundle(opts UninstallOptions) error {
 	}
 
 	fmt.Fprintf(p.Out, "uninstalling %s...\n", opts.Name)
-	err = p.CNAB.Uninstall(opts.ToDuffleArgs(deperator))
+	err = p.CNAB.Uninstall(opts.ToActionArgs(deperator))
 	if err != nil {
 		if len(deperator.deps) > 0 {
 			return errors.Wrapf(err, "failed to uninstall the %s bundle, the remaining dependencies were not uninstalled", opts.Name)

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -42,5 +42,5 @@ func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
 	}
 
 	fmt.Fprintf(p.Out, "upgrading %s...\n", opts.Name)
-	return p.CNAB.Upgrade(opts.ToDuffleArgs(deperator))
+	return p.CNAB.Upgrade(opts.ToActionArgs(deperator))
 }


### PR DESCRIPTION
# What does this change
We used to rely on duffle and have some internal classes and comments that still use the name. I've gone through and renamed them, and updated comments to prevent any confusion.

# What issue does it fix
N/A

# Notes for the reviewer
https://www.youtube.com/watch?v=Eo-KmOd3i7s

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [x] Documentation Not Impacted
