### PR TITLE
updated mixin install process to save info

### DIFF
--- a/pkg/mixin/provider/install.go
+++ b/pkg/mixin/provider/install.go
@@ -56,11 +56,10 @@ func (fs *FileSystem) saveMixinInfo(opts mixin.InstallOptions) error {
 			return errors.Wrap(err, "error unmarshalling from mixin cache.json")
 		}
 	}
-	if len(mixinsDataJSON.Mixins) > 0 {
-		for _, mixin := range mixinsDataJSON.Mixins {
-			if mixin.Name == opts.Name {
-				return nil
-			}
+	//if a mixin exists, skip. needs to be handled via "porter mixin update" ?
+	for _, mixin := range mixinsDataJSON.Mixins {
+		if mixin.Name == opts.Name {
+			return nil
 		}
 	}
 	updatedMixinList := append(mixinsDataJSON.Mixins, mixinInfo{Name: opts.Name, FeedURL: opts.FeedURL, URL: opts.URL})


### PR DESCRIPTION
# What does this change
This PR adds the ability to save mixin source when it is installed. It saves this info to a file located at `$PORTER_HOME/mixins/cache.json`

# What issue does it fix
Closes #610 

# Notes for the reviewer

First PR  :-)

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [x] Documentation Not Impacted
