### PR TITLE
Set Default InvocationImage

### DIFF
--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -34,10 +34,12 @@ dockerfile: dockerfile.tmpl
 * `name`: The name of the bundle
 * `description`: A description of the bundle
 * `version`: The version of the bundle, uses [semver](https://semver.org)
-* `invocationImage`: The name of the container image to tag the invocation image with when it is built. The format is
-    `REGISTRY/IMAGE:TAG`. Porter will push to this location during `porter publish` so select a location that you have access to.
 * `tag`: The tag to use when the bundle is published to an OCI registry. The format is `REGISTRY/IMAGE:TAG` where TAG is 
     the semantic version of the bundle.
+* `invocationImage`: The name of the container image to tag the invocation image with when it is built. The format is
+    `REGISTRY/IMAGE:TAG`. Porter will push to this location during `porter publish` so select a location that you have access to.
+    The `invocationImage` defaults to `tag`-installer. For example if the `tag` is `deislabs/porter-hello:latest`, then the 
+    `invocationImage` will default to `deislabs/porter-hello-installer:latest`
 * `dockerfile`: OPTIONAL. The relative path to a Dockerfile to use as a template during `porter build`. It is your responsibility
     to provide a suitable base image, for example one that has root ssl certificates installed. When a Dockerfile template is
     not specified, Porter automatically copies the contents of the current directory into `$BUNDLE_DIR` of the invocation image. 

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -446,6 +446,7 @@ func (c *Config) readFromFile(path string) (*Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
+	m.SetDefaults()
 
 	return m, nil
 }
@@ -499,4 +500,11 @@ func (c *Config) LoadManifestFrom(file string) error {
 	c.ManifestPath = file
 
 	return nil
+}
+
+func (m *Manifest) SetDefaults() {
+	if m.Image == "" {
+		registry_tag := strings.Split(m.BundleTag, ":")
+		m.Image = strings.Join([]string{registry_tag[0] + "-installer",registry_tag[1]}, ":")
+	}
 }

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -502,9 +502,9 @@ func (c *Config) LoadManifestFrom(file string) error {
 	return nil
 }
 
-func (m *Manifest) SetDefaults() {
+func (m *Manifest) SetDefaults(){
 	if m.Image == "" && m.BundleTag != "" {
-		registry_tag := strings.Split(m.BundleTag, ":")
-		m.Image = strings.Join([]string{registry_tag[0] + "-installer",registry_tag[1]}, ":")
+		registry := strings.Split(m.BundleTag, ":")[0]
+		m.Image = strings.Join([]string{registry + "-installer", m.Version}, ":")
 	}
 }

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -503,7 +503,7 @@ func (c *Config) LoadManifestFrom(file string) error {
 }
 
 func (m *Manifest) SetDefaults() {
-	if m.Image == "" {
+	if m.Image == "" && m.BundleTag != "" {
 		registry_tag := strings.Split(m.BundleTag, ":")
 		m.Image = strings.Join([]string{registry_tag[0] + "-installer",registry_tag[1]}, ":")
 	}

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -446,7 +446,6 @@ func (c *Config) readFromFile(path string) (*Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
-	m.SetDefaults()
 
 	return m, nil
 }
@@ -474,11 +473,22 @@ func (c *Config) readFromURL(path string) (*Manifest, error) {
 // ReadManifest determines if specified path is a URL or a filepath.
 // After reading the data in the path it returns a Manifest and any errors
 func (c *Config) ReadManifest(path string) (*Manifest, error) {
+	var (
+		m   *Manifest
+		err error
+	)
+
 	if strings.HasPrefix(path, "http") {
-		return c.readFromURL(path)
+		m, err = c.readFromURL(path)
+	} else {
+		m, err = c.readFromFile(path)
 	}
 
-	return c.readFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+	m.SetDefaults()
+	return m, nil
 }
 
 func (c *Config) LoadManifest() error {
@@ -502,7 +512,7 @@ func (c *Config) LoadManifestFrom(file string) error {
 	return nil
 }
 
-func (m *Manifest) SetDefaults(){
+func (m *Manifest) SetDefaults() {
 	if m.Image == "" && m.BundleTag != "" {
 		registry := strings.Split(m.BundleTag, ":")[0]
 		m.Image = strings.Join([]string{registry + "-installer", m.Version}, ":")

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -37,6 +37,14 @@ func TestReadManifest_File(t *testing.T) {
 	assert.Equal(t, "hello", m.Name)
 }
 
+func TestSetDefaultInvocationImage(t *testing.T) {
+	c := NewTestConfig(t)
+	c.TestContext.AddTestFile("testdata/missing-invocation-image.porter.yaml", Name)
+	m, err := c.ReadManifest(Name)
+	require.NoError(t, err)
+	assert.Equal(t, "deislabs/missing-invocation-image-installer:latest", m.Image)
+}
+
 func TestReadManifest_Validate_MissingFile(t *testing.T) {
 	c := NewTestConfig(t)
 	_, err := c.ReadManifest("fake-porter.yaml")

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -42,7 +42,7 @@ func TestSetDefaultInvocationImage(t *testing.T) {
 	c.TestContext.AddTestFile("testdata/missing-invocation-image.porter.yaml", Name)
 	m, err := c.ReadManifest(Name)
 	require.NoError(t, err)
-	assert.Equal(t, "deislabs/missing-invocation-image-installer:latest", m.Image)
+	assert.Equal(t, "deislabs/missing-invocation-image-installer:" + m.Version, m.Image)
 }
 
 func TestReadManifest_Validate_MissingFile(t *testing.T) {

--- a/pkg/config/testdata/missing-invocation-image.porter.yaml
+++ b/pkg/config/testdata/missing-invocation-image.porter.yaml
@@ -1,0 +1,28 @@
+mixins:
+  - exec
+
+name: hello
+description: "An example Porter with missing Invocation Image"
+version: 0.1.0
+tag: deislabs/missing-invocation-image:latest
+
+install:
+  - exec:
+      description: "Say Hello"
+      command: bash
+      flags:
+        c: echo Hello World
+
+status:
+  - exec:
+      description: "Get World Status"
+      command: bash
+      flags:
+        c: echo The world is on fire
+
+uninstall:
+  - exec:
+      description: "Say Goodbye"
+      command: bash
+      flags:
+        c: echo Goodbye World


### PR DESCRIPTION
# What does this change
Adds a function `SetDefaults`, that is called after we load the manifest from the filesystem. It checks if `invocationImage` is empty and defaults it to `tag`-installer. For example, if `manifest.Tag` is `deislabs/porter-hello:latest`, then `manifest.InvocationImage` will be defaulted to `deislabs/porter-hello-installer:latest`.

# What issue does it fix
Closes #383

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation
 - [ ] Documentation Not Impacted