### PR TITLE
fix(test-terraform.sh): remove fragile, redundant file contents check

### DIFF
--- a/scripts/test/test-terraform.sh
+++ b/scripts/test/test-terraform.sh
@@ -20,16 +20,9 @@ cp ${REPO_DIR}/build/testdata/bundles/terraform/porter.yaml .
 sed -i "s/porter-terraform:latest/${REGISTRY}\/porter-terraform:latest/g" porter.yaml
 sed -i "s/deislabs\/porter-terraform-bundle/${REGISTRY}\/porter-terraform-bundle/g" porter.yaml
 
-porter_output=$(mktemp)
-
 ${PORTER_HOME}/porter build
 
-${PORTER_HOME}/porter install --insecure --debug --param file_contents='foo!' 2>&1 | tee ${porter_output}
-
-if ! cat ${porter_output} | grep -q 'content:  "" => "foo!"'; then
-  echo "ERROR: File contents not created properly"
-  exit 1
-fi
+${PORTER_HOME}/porter install --insecure --debug --param file_contents='foo!'
 
 echo "Verifying instance output(s) via 'porter instance outputs list' after install"
 list_outputs=$(${PORTER_HOME}/porter instance outputs list)


### PR DESCRIPTION
# What does this change

Removes a fragile check (based on literal text output which is subject to change) in the terraform portion of the cli test.  It is now redundant as we've since added `porter instance outputs list` checks to verify the expected file contents value.  

# What issue does it fix
Fixes the `test-cli` target in CI.

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
