### PR TITLE
Cleanup gke doc

### DIFF
--- a/docs/content/best-practices/gke.md
+++ b/docs/content/best-practices/gke.md
@@ -83,7 +83,7 @@ does not contain enough information to authenticate to the cluster.
 ## Create a service account
 
 1. [Create a service account][sa].
-1. [Assign the account access to GKE][iam]], such as Kubernetes Engine
+1. [Assign the account access to GKE][iam], such as Kubernetes Engine
    Developer.
 1. Create a service account key file, e.g. service-account.json, and save the
    file locally.

--- a/docs/themes/porter/layouts/_default/section.html
+++ b/docs/themes/porter/layouts/_default/section.html
@@ -23,7 +23,7 @@
               <header>
                 <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
               </header>
-              {{ .Description }}{{ if .Truncated }}...{{ end }}
+              {{ .Description }}
             </article>
     
           {{ end }}


### PR DESCRIPTION
# What does this change
* There was an extra ] on the [GKE doc page](https://deploy-preview-674--porter.netlify.com/best-practices/gke/#create-a-service-account) in the second step.

    > Assign the account access to GKE]
* On the [Best Practices listing page](https://deploy-preview-674--porter.netlify.com/best-practices/), it was showing a "..." after the GKE description because the layout relied on Truncated even though we weren't using the summary, just the description.

    > How to connect to a GKE cluster inside a Porter bundle.... 

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
