### PR TITLE
feat(pkg/exec): add overrideable Dash property to Flag

### DIFF
--- a/pkg/exec/builder/flags.go
+++ b/pkg/exec/builder/flags.go
@@ -11,6 +11,7 @@ import (
 type Flag struct {
 	Name   string
 	Values []string
+	Dash   string
 }
 
 // NewFlag creates an instance of a Flag.
@@ -28,9 +29,13 @@ func NewFlag(name string, values ...string) Flag {
 // ToSlice converts to a string array suitable of command arguments suitable for passing to exec.Command
 func (flag Flag) ToSlice() []string {
 	var flagName string
-	dash := "--"
-	if len(flag.Name) == 1 {
-		dash = "-"
+	dash := flag.Dash
+
+	if dash == "" {
+		dash = "--"
+		if len(flag.Name) == 1 {
+			dash = "-"
+		}
 	}
 	flagName = fmt.Sprintf("%s%s", dash, flag.Name)
 

--- a/pkg/exec/builder/flags_test.go
+++ b/pkg/exec/builder/flags_test.go
@@ -63,6 +63,13 @@ func TestFlag_ToSlice(t *testing.T) {
 		args := f.ToSlice()
 		assert.Equal(t, []string{"--repeated", "FOO=BAR", "--repeated", "STUFF=THINGS"}, args)
 	})
+
+	t.Run("flag with non-default dash", func(t *testing.T) {
+		f := NewFlag("full", "abc")
+		f.Dash = "---"
+		args := f.ToSlice()
+		assert.Equal(t, []string{"---full", "abc"}, args)
+	})
 }
 
 func TestFlags_ToSlice(t *testing.T) {


### PR DESCRIPTION
# What does this change

Adds a `Dash` property to the `Flag` struct in the `exec/builder` package, for optional overriding of the dash appended to a given flag.  See https://github.com/deislabs/porter-terraform/pull/25 for example use/scenario.

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
