### PR TITLE
feat(docs): Validate if destination exists before invoking command

### DIFF
--- a/cmd/porter/docs.go
+++ b/cmd/porter/docs.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"github.com/deislabs/porter/pkg/docs"
+	"github.com/deislabs/porter/pkg/porter"
 	"github.com/spf13/cobra"
 )
 
-func buildDocsCommand() *cobra.Command {
+func buildDocsCommand(p *porter.Porter) *cobra.Command {
 	opts := &docs.DocsOptions{}
 
 	cmd := &cobra.Command{
@@ -14,7 +15,7 @@ func buildDocsCommand() *cobra.Command {
 		Long:  "Generate markdown docs for https://porter.sh/cli",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RootCommand = cmd.Root()
-			return opts.Validate()
+			return opts.Validate(p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return docs.GenerateCliDocs(opts)

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -69,7 +69,7 @@ func buildRootCommand() *cobra.Command {
 	cobra.AddTemplateFunc("ShouldShowUngroupedCommand", ShouldShowUngroupedCommand)
 
 	if includeDocsCommand {
-		cmd.AddCommand(buildDocsCommand())
+		cmd.AddCommand(buildDocsCommand(p))
 	}
 
 	return cmd

--- a/pkg/docs/generator.go
+++ b/pkg/docs/generator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/deislabs/porter/pkg/context"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -19,15 +20,18 @@ type DocsOptions struct {
 
 const DefaultDestination = "./docs/content/cli/"
 
-func (o *DocsOptions) Validate() error {
+func (o *DocsOptions) Validate(cxt *context.Context) error {
 	if o.Destination == "" {
 		o.Destination = DefaultDestination
-    }
+	}
 
-    _, err := os.Stat(o.Destination)
-    if err != nil {
-        return errors.New(fmt.Sprintf("error generating the markdown documentation; desitination '%s' doesn't exist", o.Destination))
-    }
+	exists, err := cxt.FileSystem.Exists(o.Destination)
+	if err != nil {
+		return errors.Wrapf(err, "error checking if --destination exists: %q", o.Destination)
+	}
+	if !exists {
+		return errors.Errorf("--destination %q doesn't exist", o.Destination)
+	}
 
 	return nil
 }

--- a/pkg/docs/generator.go
+++ b/pkg/docs/generator.go
@@ -22,7 +22,12 @@ const DefaultDestination = "./docs/content/cli/"
 func (o *DocsOptions) Validate() error {
 	if o.Destination == "" {
 		o.Destination = DefaultDestination
-	}
+    }
+
+    _, err := os.Stat(o.Destination)
+    if err != nil {
+        return errors.New(fmt.Sprintf("error generating the markdown documentation; desitination '%s' doesn't exist", o.Destination))
+    }
 
 	return nil
 }

--- a/pkg/docs/generator_test.go
+++ b/pkg/docs/generator_test.go
@@ -1,0 +1,38 @@
+package docs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/deislabs/porter/pkg/porter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDocsCommand(t *testing.T) {
+
+	testcases := []struct {
+		name        string
+		destination string
+		wantError   string
+	}{
+		{"should return error if destination doesn't exist", "./no-existing/destination/directory", "--destination %q doesn't exist"},
+		{"should not return error if destination exists", ".", ""},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := porter.NewTestPorter(t)
+			opts := DocsOptions{
+				Destination: tc.destination,
+			}
+			err := opts.Validate(p.Context)
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, err.Error(), fmt.Sprintf(tc.wantError, tc.destination))
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
# What does this change

As part of validation, `porter docs` checks if the destination folder exists. If the destination doesn't exist, execution is canceled and a proper error message is presented to the user.

# What issue does it fix
Closes #685 

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ X ] Documentation Not Impacted
