### PR TITLE
Check dockerfile for ARG BUILD_DIR

### DIFF
--- a/pkg/build/dockerfile-generater.go
+++ b/pkg/build/dockerfile-generater.go
@@ -22,7 +22,6 @@ type DockerfileGenerator struct {
 	*manifest.Manifest
 	*templates.Templates
 	mixin.MixinProvider
-	hasBuildArg bool
 }
 
 func NewDockerfileGenerator(config *config.Config, m *manifest.Manifest, tmpl *templates.Templates, mp mixin.MixinProvider) *DockerfileGenerator {
@@ -31,7 +30,6 @@ func NewDockerfileGenerator(config *config.Config, m *manifest.Manifest, tmpl *t
 		Manifest:      m,
 		Templates:     tmpl,
 		MixinProvider: mp,
-		hasBuildArg:   false,
 	}
 }
 
@@ -90,16 +88,17 @@ Dockerfile.tmpl must declare the build argument BUNDLE_DIR.
 Add the following line to the file and re-run porter build: ARG BUNDLE_DIR`
 
 func (g *DockerfileGenerator) readAndValidateDockerfile(s *bufio.Scanner) ([]string, error) {
+	hasBuildArg := false
 	buildArg := "ARG BUNDLE_DIR"
 	var lines []string
 	for s.Scan() {
 		if strings.TrimSpace(s.Text()) == buildArg {
-			g.hasBuildArg = true
+			hasBuildArg = true
 		}
 		lines = append(lines, s.Text())
 	}
 
-	if !g.hasBuildArg {
+	if !hasBuildArg {
 		return nil, errors.New(ErrorMessage)
 	}
 

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +29,6 @@ func TestPorter_buildDockerfile(t *testing.T) {
 	g := NewDockerfileGenerator(c.Config, m, tmpl, mp)
 	gotlines, err := g.buildDockerfile()
 	require.NoError(t, err)
-	fmt.Println(gotlines)
 
 	wantlines := []string{
 		"FROM debian:stretch",

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -61,7 +61,7 @@ func TestPorter_buildCustomDockerfile(t *testing.T) {
 	t.Run("build from custom docker without supplying ARG BUNDLE_DIR", func(t *testing.T) {
 
 		// Use a custom dockerfile template
-		c.Manifest.Dockerfile = "Dockerfile.template"
+		m.Dockerfile = "Dockerfile.template"
 		customFrom := `FROM ubuntu:latest
 COPY mybin /cnab/app/
 
@@ -69,10 +69,9 @@ COPY mybin /cnab/app/
 		c.TestContext.AddTestFileContents([]byte(customFrom), "Dockerfile.template")
 
 		// ignore mixins in the unit tests
-		c.Manifest.Mixins = []config.MixinDeclaration{}
-
+		m.Mixins = []manifest.MixinDeclaration{}
 		mp := &mixin.TestMixinProvider{}
-		g := NewDockerfileGenerator(c.Config, tmpl, mp)
+		g := NewDockerfileGenerator(c.Config, m, tmpl, mp)
 		gotlines, err := g.buildDockerfile()
 
 		// We expect an error when ARG BUNDLE_DIR is not in Dockerfile
@@ -86,7 +85,7 @@ COPY mybin /cnab/app/
 	t.Run("build from custom docker with ARG BUNDLE_DIR supplied", func(t *testing.T) {
 
 		// Use a custom dockerfile template
-		c.Manifest.Dockerfile = "Dockerfile.template"
+		m.Dockerfile = "Dockerfile.template"
 		customFrom := `FROM ubuntu:latest
 ARG BUNDLE_DIR
 COPY mybin /cnab/app/
@@ -95,10 +94,9 @@ COPY mybin /cnab/app/
 		c.TestContext.AddTestFileContents([]byte(customFrom), "Dockerfile.template")
 
 		// ignore mixins in the unit tests
-		c.Manifest.Mixins = []config.MixinDeclaration{}
-
+		m.Mixins = []manifest.MixinDeclaration{}
 		mp := &mixin.TestMixinProvider{}
-		g := NewDockerfileGenerator(c.Config, tmpl, mp)
+		g := NewDockerfileGenerator(c.Config, m, tmpl, mp)
 		gotlines, err := g.buildDockerfile()
 
 		// We expect no error when ARG BUNDLE_DIR is in Dockerfile

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -29,6 +30,7 @@ func TestPorter_buildDockerfile(t *testing.T) {
 	g := NewDockerfileGenerator(c.Config, m, tmpl, mp)
 	gotlines, err := g.buildDockerfile()
 	require.NoError(t, err)
+	fmt.Println(gotlines)
 
 	wantlines := []string{
 		"FROM debian:stretch",
@@ -56,32 +58,64 @@ func TestPorter_buildCustomDockerfile(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	// Use a custom dockerfile template
-	m.Dockerfile = "Dockerfile.template"
-	customFrom := `FROM ubuntu:latest
+	t.Run("build from custom docker without supplying ARG BUNDLE_DIR", func(t *testing.T) {
+
+		// Use a custom dockerfile template
+		c.Manifest.Dockerfile = "Dockerfile.template"
+		customFrom := `FROM ubuntu:latest
 COPY mybin /cnab/app/
 
 `
-	c.TestContext.AddTestFileContents([]byte(customFrom), "Dockerfile.template")
+		c.TestContext.AddTestFileContents([]byte(customFrom), "Dockerfile.template")
 
-	// ignore mixins in the unit tests
-	m.Mixins = []manifest.MixinDeclaration{}
+		// ignore mixins in the unit tests
+		c.Manifest.Mixins = []config.MixinDeclaration{}
 
-	mp := &mixin.TestMixinProvider{}
-	g := NewDockerfileGenerator(c.Config, m, tmpl, mp)
-	gotlines, err := g.buildDockerfile()
-	require.NoError(t, err)
+		mp := &mixin.TestMixinProvider{}
+		g := NewDockerfileGenerator(c.Config, tmpl, mp)
+		gotlines, err := g.buildDockerfile()
 
-	wantLines := []string{
-		"FROM ubuntu:latest",
-		"COPY mybin /cnab/app/",
-		"",
-		"COPY .cnab/ /cnab/",
-		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
-		"WORKDIR $BUNDLE_DIR",
-		"CMD [\"/cnab/app/run\"]",
-	}
-	assert.Equal(t, wantLines, gotlines)
+		// We expect an error when ARG BUNDLE_DIR is not in Dockerfile
+		require.EqualError(t, err, ErrorMessage)
+
+		wantLines := []string(nil)
+		assert.Equal(t, wantLines, gotlines)
+
+	})
+
+	t.Run("build from custom docker with ARG BUNDLE_DIR supplied", func(t *testing.T) {
+
+		// Use a custom dockerfile template
+		c.Manifest.Dockerfile = "Dockerfile.template"
+		customFrom := `FROM ubuntu:latest
+ARG BUNDLE_DIR
+COPY mybin /cnab/app/
+
+`
+		c.TestContext.AddTestFileContents([]byte(customFrom), "Dockerfile.template")
+
+		// ignore mixins in the unit tests
+		c.Manifest.Mixins = []config.MixinDeclaration{}
+
+		mp := &mixin.TestMixinProvider{}
+		g := NewDockerfileGenerator(c.Config, tmpl, mp)
+		gotlines, err := g.buildDockerfile()
+
+		// We expect no error when ARG BUNDLE_DIR is in Dockerfile
+		require.NoError(t, err)
+
+		wantLines := []string{
+			"FROM ubuntu:latest",
+			"ARG BUNDLE_DIR",
+			"COPY mybin /cnab/app/",
+			"",
+			"COPY .cnab/ /cnab/",
+			"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
+			"WORKDIR $BUNDLE_DIR",
+			"CMD [\"/cnab/app/run\"]",
+		}
+		assert.Equal(t, wantLines, gotlines)
+	})
 }
 
 func TestPorter_buildDockerfile_output(t *testing.T) {


### PR DESCRIPTION
# What does this change
This change adds a method `readAndValidateDockerfile` to the `type` `*DockerfileGenerator` in order to check for `ARG BUILD_DIR` in the Dockerfile during the building of a bundle. If `ARG BUILD_DIR` is not found, an error message is returned.

# What issue does it fix
Closes [#655](https://github.com/deislabs/porter/issues/655)

[1]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#when-to-open-a-pull-request

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [x] Documentation Not Impacted
