### PR TITLE
fix(mysql/porter.yaml): use same chart version in upgrade step

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -58,6 +58,7 @@ upgrade:
       name: "{{ bundle.parameters.mysql-name }}"
       namespace: "{{ bundle.parameters.namespace }}"
       chart: stable/mysql
+      version: 0.10.2
       outputs:
       - name: mysql-root-password
         secret: "{{ bundle.parameters.mysql-name }}"


### PR DESCRIPTION
# What does this change
Porter's integration tests started to [fail](https://dev.azure.com/deislabs/porter/_build/results?buildId=3557) around upgrading the MySQL bundle:
```
...
Upgrade MySQL
Tiller version (v2.12.3) does not match client version (v2.14.3); downloading a compatible client.
/usr/local/bin/helm helm upgrade porter-ci-mysql-wwwvyhwuab stable/mysql
Error: UPGRADE FAILED: Deployment.apps "porter-ci-mysql-wwwvyhwuab" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"porter-ci-mysql-wwwvyhwuab", "release":"porter-ci-mysql-wwwvyhwuab"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
Error: exit status 1
Error: mixin execution failed: exit status 1
```

My hunch is that since we didn't specify a chart version for the upgrade step (though one is spec'd on install), we inherited the latest chart, which recently introduced some [changes](https://github.com/helm/charts/commit/9e2902f1a563dc7710321050534a74c899056fcf) in this area.

We could also eliminate specifying a particular version entirely and just use the latest chart, if that'd be preferred?

# What issue does it fix

# Notes for the reviewer

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
