### PR TITLE
chore(adapter.go): update schema version for generated bundles

### DIFF
--- a/pkg/cnab/config_adapter/adapter.go
+++ b/pkg/cnab/config_adapter/adapter.go
@@ -11,7 +11,7 @@ import (
 	"github.com/deislabs/porter/pkg/config"
 )
 
-const SchemaVersion = "v1.0.0-WD"
+const SchemaVersion = "v1.0.0"
 
 // ManifestConverter converts from a porter manifest to a CNAB bundle definition.
 type ManifestConverter struct {


### PR DESCRIPTION
# What does this change
Updates schema version for generated bundles to reflect the [v1.0.0 release](https://github.com/deislabs/cnab-spec/releases/tag/cnab-core-1.0)

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
