### PR TITLE
Fix broken permalink in docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "[markdown]": {
-    "files.trimTrailingWhitespace": false
-  }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  }
+}

--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -12,7 +12,7 @@ Porter generates a bundle from its manifest, porter.yaml. The manifest is made u
 * [Credentials](#credentials)
 * [Bundle Actions](#bundle-actions)
 * [Dependencies](#dependencies)
-* [Image Map](#image-map)
+* [Images](#images)
 * [Generated Files](#generated-files)
 
 We have full [examples](https://github.com/deislabs/porter/tree/master/examples) of Porter manifests in the Porter repository.


### PR DESCRIPTION
# What does this change
Fixes broken permalink of [images](https://porter.sh/authoring-bundles/#image-map) section in [Authoring bundles](https://porter.sh/authoring-bundles)

# Steps to reproduce
 * visit https://porter.sh/authoring-bundles/
 * click on "Image Map" link
 * Nothing will happen

# Expected behaviour
Clicking on "Image Map" link should navigate to "Images" section

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
