### PR TITLE
Command driver support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -266,7 +266,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:b6893d684f9f344938f9e020a2be731e11592e65200e4cfb82425bc4956e1e79"
+  digest = "1:36efeedc5d1c77d0df776b4e54a12f709ea456ac6d3ccb07a0b9ef0b450dc2e0"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -287,8 +287,8 @@
     "utils/crud",
   ]
   pruneopts = "NT"
-  revision = "406808480de1f033040608d1924f96dcd662c2d0"
-  version = "v0.6.0-beta1"
+  revision = "26ed63f06aff506ab4bfea63a2a83d341f987580"
+  version = "v0.7.0-beta1"
 
 [[projects]]
   digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"
@@ -1692,6 +1692,7 @@
     "github.com/deislabs/cnab-go/claim",
     "github.com/deislabs/cnab-go/credentials",
     "github.com/deislabs/cnab-go/driver",
+    "github.com/deislabs/cnab-go/driver/command",
     "github.com/deislabs/cnab-go/driver/docker",
     "github.com/deislabs/cnab-go/driver/lookup",
     "github.com/deislabs/cnab-go/imagestore",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,10 +1,10 @@
 [[constraint]]
   name = "github.com/deislabs/cnab-go"
-  version = "v0.6.0-beta1"
+  version = "v0.7.0-beta1"
 
 [[override]]
   name = "github.com/deislabs/cnab-go"
-  version = "v0.6.0-beta1"
+  version = "v0.7.0-beta1"
 
 
 [[constraint]]

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -2,11 +2,13 @@ package porter
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/claim"
+	"github.com/deislabs/cnab-go/driver/command"
 	"github.com/deislabs/porter/pkg/build"
 	cnabprovider "github.com/deislabs/porter/pkg/cnab/provider"
 	"github.com/deislabs/porter/pkg/config"
@@ -307,6 +309,11 @@ func (o *sharedOptions) validateDriver() error {
 	case "docker", "debug":
 		return nil
 	default:
-		return errors.Errorf("unsupported driver provided: %s", o.Driver)
+		cmddriver := &command.Driver{Name: o.Driver}
+		if cmddriver.CheckDriverExists() {
+			return nil
+		}
+
+		return fmt.Errorf("unsupported driver or driver not found in PATH: %s", o.Driver)
 	}
 }

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -171,7 +171,7 @@ func TestInstallOptions_validateDriver(t *testing.T) {
 	}{
 		{"debug", "debug", "debug", ""},
 		{"docker", "docker", "docker", ""},
-		{"invalid driver provided", "dbeug", "", "unsupported driver provided: dbeug"},
+		{"invalid driver provided", "dbeug", "", "unsupported driver or driver not found in PATH: dbeug"},
 	}
 
 	for _, tc := range testcases {

--- a/vendor/github.com/deislabs/cnab-go/driver/command/command.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/command/command.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 
 	"github.com/deislabs/cnab-go/driver"
@@ -14,7 +16,8 @@ import (
 
 // Driver relies upon a system command to provide a driver implementation
 type Driver struct {
-	Name string
+	Name          string
+	outputDirName string
 }
 
 // Run executes the command
@@ -56,14 +59,27 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
 		added = append(added, k)
 	}
+	// Create a directory that can be used for outputs and then pass it as a command line argument
+	if len(op.Outputs) > 0 {
+		var err error
+		d.outputDirName, err = ioutil.TempDir("", "bundleoutput")
+		if err != nil {
+			return driver.OperationResult{}, err
+		}
+		defer os.RemoveAll(d.outputDirName)
+		// Set the env var CNAB_OUTPUT_DIR to the location of the folder
+		pairs = append(pairs, fmt.Sprintf("%s=%s", "CNAB_OUTPUT_DIR", d.outputDirName))
+		added = append(added, "CNAB_OUTPUT_DIR")
+	}
+
 	// CNAB_VARS is a list of variables we added to the env. This is to make
 	// it easier for shell script drivers to clone the env vars.
 	pairs = append(pairs, fmt.Sprintf("CNAB_VARS=%s", strings.Join(added, ",")))
-
 	data, err := json.Marshal(op)
 	if err != nil {
 		return driver.OperationResult{}, err
 	}
+
 	args := []string{}
 	cmd := exec.Command(d.cliName(), args...)
 	cmd.Dir, err = os.Getwd()
@@ -72,9 +88,7 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	}
 	cmd.Env = pairs
 	cmd.Stdin = bytes.NewBuffer(data)
-
 	// Make stdout and stderr from driver available immediately
-
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return driver.OperationResult{}, fmt.Errorf("Setting up output handling for driver (%s) failed: %v", d.Name, err)
@@ -90,6 +104,7 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	if err != nil {
 		return driver.OperationResult{}, fmt.Errorf("Setting up error output handling for driver (%s) failed: %v", d.Name, err)
 	}
+
 	go func() {
 
 		// Errors not handled here as they only prevent output from the driver being shown, errors in the command execution are handled when command is executed
@@ -101,5 +116,48 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 		return driver.OperationResult{}, fmt.Errorf("Start of driver (%s) failed: %v", d.Name, err)
 	}
 
-	return driver.OperationResult{}, cmd.Wait()
+	if err = cmd.Wait(); err != nil {
+		return driver.OperationResult{}, fmt.Errorf("Command driver (%s) failed executing bundle: %v", d.Name, err)
+	}
+
+	result, err := d.getOperationResult(op)
+	if err != nil {
+		return driver.OperationResult{}, fmt.Errorf("Command driver (%s) failed getting operation result: %v", d.Name, err)
+	}
+	return result, nil
+}
+func (d *Driver) getOperationResult(op *driver.Operation) (driver.OperationResult, error) {
+	opResult := driver.OperationResult{
+		Outputs: map[string]string{},
+	}
+	for _, item := range op.Outputs {
+		fileName := path.Join(d.outputDirName, item)
+		_, err := os.Stat(fileName)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return opResult, fmt.Errorf("Command driver (%s) failed checking for output file: %s Error: %v", d.Name, item, err)
+		}
+
+		contents, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			return opResult, fmt.Errorf("Command driver (%s) failed reading output file: %s Error: %v", d.Name, item, err)
+		}
+
+		opResult.Outputs[item] = string(contents)
+	}
+	// Check if there are missing outputs and get default values if any
+	for name, output := range op.Bundle.Outputs {
+		if output.AppliesTo(op.Action) {
+			if _, exists := opResult.Outputs[output.Path]; !exists {
+				if outputDefinition, exists := op.Bundle.Definitions[output.Definition]; exists && outputDefinition.Default != nil {
+					opResult.Outputs[output.Path] = fmt.Sprintf("%v", outputDefinition.Default)
+				} else {
+					return opResult, fmt.Errorf("Command driver (%s) failed - required output %s for action %s is missing and has no default is defined", d.Name, name, op.Action)
+				}
+			}
+		}
+	}
+	return opResult, nil
 }


### PR DESCRIPTION
# What does this change
Adds support to Porter for Command Driver.
Updates cnab-go dependency to v0.7.0-beta1 

