### PR TITLE
Control mixins dockerlines

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -19,4 +19,7 @@ var (
 
 	// BUNDLE_DIR is the directory where the bundle is located in the CNAB execution environment.
 	BUNDLE_DIR = "/cnab/app"
+
+	// INJECT_PORTER_MIXINS_TOKEN can control where mixin instructions will be placed in Dockerfile.
+	INJECT_PORTER_MIXINS_TOKEN = "# PORTER_MIXINS"
 )

--- a/pkg/build/dockerfile-generater.go
+++ b/pkg/build/dockerfile-generater.go
@@ -67,8 +67,10 @@ func (g *DockerfileGenerator) buildDockerfile() ([]string, error) {
 	if mixinsTokenIndex == -1 {
 		lines = append(lines, mixinLines...)
 	} else {
-		postTokenLines := lines[mixinsTokenIndex+1:]
-		lines = append(append(lines[:mixinsTokenIndex], mixinLines...), postTokenLines...)
+		pretoken := make([]string, mixinsTokenIndex)
+		copy(pretoken, lines)
+		posttoken := lines[mixinsTokenIndex+1:]
+		lines = append(pretoken, append(mixinLines, posttoken...)...)
 	}
 
 	// The template dockerfile copies everything by default, but if the user

--- a/pkg/build/dockerfile-generater.go
+++ b/pkg/build/dockerfile-generater.go
@@ -62,7 +62,14 @@ func (g *DockerfileGenerator) buildDockerfile() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating Dockefile content for mixins")
 	}
-	lines = append(lines, mixinLines...)
+
+	mixinsTokenIndex := g.getIndexOfPorterMixinsToken(lines)
+	if mixinsTokenIndex == -1 {
+		lines = append(lines, mixinLines...)
+	} else {
+		postTokenLines := lines[mixinsTokenIndex+1:]
+		lines = append(append(lines[:mixinsTokenIndex], mixinLines...), postTokenLines...)
+	}
 
 	// The template dockerfile copies everything by default, but if the user
 	// supplied their own, copy over cnab/ and porter.yaml
@@ -271,4 +278,13 @@ func (g *DockerfileGenerator) copyMixin(mixin string) error {
 
 	err = g.Context.CopyDirectory(mixinDir, filepath.Join(LOCAL_APP, "mixins"), true)
 	return errors.Wrapf(err, "could not copy mixin directory contents for %s", mixin)
+}
+
+func (g *DockerfileGenerator) getIndexOfPorterMixinsToken(a []string) int {
+	for i, n := range a {
+		if INJECT_PORTER_MIXINS_TOKEN == strings.TrimSpace(n) {
+			return i
+		}
+	}
+	return -1
 }

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -254,9 +254,9 @@ func TestPorter_replacePorterMixinTokenWithBuildInstructions(t *testing.T) {
 	// Use a custom dockerfile template
 	m.Dockerfile = "Dockerfile.template"
 	customFrom := `FROM ubuntu:light
-    # PORTER_MIXINS
+ARG BUNDLE_DIR
+# PORTER_MIXINS
 COPY mybin /cnab/app/
-
 `
 	c.TestContext.AddTestFileContents([]byte(customFrom), "Dockerfile.template")
 
@@ -269,8 +269,8 @@ COPY mybin /cnab/app/
 
 	wantLines := []string{
 		"FROM ubuntu:light",
+		"ARG BUNDLE_DIR",
 		"COPY mybin /cnab/app/",
-		"",
 		"COPY .cnab/ /cnab/",
 		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 		"WORKDIR $BUNDLE_DIR",

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -240,3 +240,43 @@ func TestDockerFileGenerator_getMixinBuildInput(t *testing.T) {
 	input = g.getMixinBuildInput("az")
 	assert.Equal(t, map[interface{}]interface{}{"extensions": []interface{}{"iot"}}, input.Config, "az mixin should have config")
 }
+
+func TestPorter_replacePorterMixinTokenWithBuildInstructions(t *testing.T) {
+	c := config.NewTestConfig(t)
+	tmpl := templates.NewTemplates()
+	configTpl, err := tmpl.GetManifest()
+	require.Nil(t, err)
+	c.TestContext.AddTestFileContents(configTpl, config.Name)
+
+	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	require.NoError(t, err, "could not load manifest")
+
+	// Use a custom dockerfile template
+	m.Dockerfile = "Dockerfile.template"
+	customFrom := `FROM ubuntu:light
+    # PORTER_MIXINS
+COPY mybin /cnab/app/
+
+`
+	c.TestContext.AddTestFileContents([]byte(customFrom), "Dockerfile.template")
+
+	m.Mixins = []manifest.MixinDeclaration{}
+	mp := &mixin.TestMixinProvider{}
+	g := NewDockerfileGenerator(c.Config, m, tmpl, mp)
+
+	gotlines, err := g.buildDockerfile()
+	require.NoError(t, err)
+
+	wantLines := []string{
+		"FROM ubuntu:light",
+		"COPY mybin /cnab/app/",
+		"",
+		"COPY .cnab/ /cnab/",
+		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
+		"WORKDIR $BUNDLE_DIR",
+		"CMD [\"/cnab/app/run\"]",
+	}
+	// testcase did not specify build instructions
+	// however, the # PORTER_MIXINS token should be removed
+	assert.Equal(t, wantLines, gotlines)
+}

--- a/pkg/mixin/helpers.go
+++ b/pkg/mixin/helpers.go
@@ -1,6 +1,7 @@
 package mixin
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/deislabs/porter/pkg/context"
@@ -42,6 +43,9 @@ func (p *TestMixinProvider) Uninstall(o UninstallOptions) (*Metadata, error) {
 func (p *TestMixinProvider) Run(mixinCxt *context.Context, mixinName string, commandOpts CommandOptions) error {
 	for _, assert := range p.RunAssertions {
 		assert(mixinCxt, mixinName, commandOpts)
+	}
+	if commandOpts.Command == "build" {
+		fmt.Fprintln(mixinCxt.Out, "# exec mixin has no buildtime dependencies")
 	}
 	return nil
 }


### PR DESCRIPTION
# What does this change

This change gives users more control over the generated `Dockerfile` if the local `Dockerfile.tmpl` contains the `# PORTER_MIXINS` instruction, it will be replaced with all mixin docker lines.

If the custom `Dockerfile.tmpl` doesn't container the `INJECT_PORTER_MIXINS_TOKEN`, mixin docker lines will be appended at the end.

# What issue does it fix
Closes #707 

# Notes for the reviewer

I struggled a bit with the unit test, I wasn't sure how to put a mixin (that will generate docker lines) in the test context. However, the existing test "somehow" validates the implementation because the `INJECT_PORTER_MIXINS_TOKEN` will be replaced with nothing - which turns out to be correct if mixin doesn't specify docker lines.  I'd love to hear someone's feedback regarding my changes to improve my still very basic golang skills 😄 👼 

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
