### PR TITLE
feat(exec/builder): add GetDashes method to ExecutableStep interface

### DIFF
--- a/pkg/exec/action.go
+++ b/pkg/exec/action.go
@@ -38,7 +38,6 @@ func (a Action) GetSteps() []builder.ExecutableStep {
 }
 
 var _ builder.ExecutableStep = Step{}
-var _ builder.HasCustomDashes = Step{}
 var _ builder.StepWithOutputs = Step{}
 
 type Step struct {
@@ -63,10 +62,6 @@ func (s Step) GetArguments() []string {
 
 func (s Step) GetFlags() builder.Flags {
 	return s.Flags
-}
-
-func (s Step) GetDashes() builder.Dashes {
-	return builder.DefaultFlagDashes
 }
 
 func (s Step) GetOutputs() []builder.Output {

--- a/pkg/exec/action.go
+++ b/pkg/exec/action.go
@@ -38,6 +38,7 @@ func (a Action) GetSteps() []builder.ExecutableStep {
 }
 
 var _ builder.ExecutableStep = Step{}
+var _ builder.HasCustomDashes = Step{}
 var _ builder.StepWithOutputs = Step{}
 
 type Step struct {
@@ -62,6 +63,10 @@ func (s Step) GetArguments() []string {
 
 func (s Step) GetFlags() builder.Flags {
 	return s.Flags
+}
+
+func (s Step) GetDashes() builder.Dashes {
+	return builder.DefaultFlagDashes
 }
 
 func (s Step) GetOutputs() []builder.Output {

--- a/pkg/exec/builder/flags.go
+++ b/pkg/exec/builder/flags.go
@@ -13,6 +13,11 @@ type Flag struct {
 	Values []string
 }
 
+type Dashes struct {
+	Long  string
+	Short string
+}
+
 // NewFlag creates an instance of a Flag.
 func NewFlag(name string, values ...string) Flag {
 	f := Flag{
@@ -26,11 +31,11 @@ func NewFlag(name string, values ...string) Flag {
 }
 
 // ToSlice converts to a string array suitable of command arguments suitable for passing to exec.Command
-func (flag Flag) ToSlice() []string {
+func (flag Flag) ToSlice(dashes Dashes) []string {
 	var flagName string
-	dash := "--"
+	dash := dashes.Long
 	if len(flag.Name) == 1 {
-		dash = "-"
+		dash = dashes.Short
 	}
 	flagName = fmt.Sprintf("%s%s", dash, flag.Name)
 
@@ -49,12 +54,12 @@ func (flag Flag) ToSlice() []string {
 type Flags []Flag
 
 // ToSlice converts to a string array suitable of command arguments suitable for passing to exec.Command
-func (flags *Flags) ToSlice() []string {
+func (flags *Flags) ToSlice(dashes Dashes) []string {
 	result := make([]string, 0, 2*len(*flags))
 
 	sort.Sort(flags)
 	for _, flag := range *flags {
-		result = append(result, flag.ToSlice()...)
+		result = append(result, flag.ToSlice(dashes)...)
 	}
 
 	return result

--- a/pkg/exec/builder/flags_test.go
+++ b/pkg/exec/builder/flags_test.go
@@ -10,6 +10,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+var testStep = TestStep{}
+
 func TestFlags_UnmarshalYAML(t *testing.T) {
 	b, err := ioutil.ReadFile("testdata/flags-input.yaml")
 	require.NoError(t, err, "could not read the input file")
@@ -42,26 +44,30 @@ func TestFlags_Sort(t *testing.T) {
 func TestFlag_ToSlice(t *testing.T) {
 	t.Run("short flag", func(t *testing.T) {
 		f := NewFlag("f", "abc")
-		args := f.ToSlice()
+		args := f.ToSlice(testStep.GetDashes())
 		assert.Equal(t, []string{"-f", "abc"}, args)
 	})
 
 	t.Run("long flag", func(t *testing.T) {
 		f := NewFlag("full", "abc")
-		args := f.ToSlice()
+		args := f.ToSlice(testStep.GetDashes())
 		assert.Equal(t, []string{"--full", "abc"}, args)
 	})
 
 	t.Run("valueless flag", func(t *testing.T) {
 		f := NewFlag("l")
-		args := f.ToSlice()
+		args := f.ToSlice(testStep.GetDashes())
 		assert.Equal(t, []string{"-l"}, args)
 	})
 
-	t.Run("repeated flag", func(t *testing.T) {
-		f := NewFlag("repeated", "FOO=BAR", "STUFF=THINGS")
-		args := f.ToSlice()
-		assert.Equal(t, []string{"--repeated", "FOO=BAR", "--repeated", "STUFF=THINGS"}, args)
+	dashes := Dashes{
+		Long:  "---",
+		Short: "-",
+	}
+	t.Run("flag with non-default dashes", func(t *testing.T) {
+		f := NewFlag("full", "abc")
+		args := f.ToSlice(dashes)
+		assert.Equal(t, []string{"---full", "abc"}, args)
 	})
 }
 
@@ -71,7 +77,7 @@ func TestFlags_ToSlice(t *testing.T) {
 		NewFlag("a", "1"),
 	}
 
-	args := flags.ToSlice()
+	args := flags.ToSlice(testStep.GetDashes())
 
 	// Flags should be sorted and sliced up on a platter
 	assert.Equal(t, []string{"-a", "1", "--bull", "2"}, args)

--- a/pkg/exec/builder/output_jsonpath_test.go
+++ b/pkg/exec/builder/output_jsonpath_test.go
@@ -29,6 +29,10 @@ func (s TestStep) GetFlags() Flags {
 	return s.Flags
 }
 
+func (s TestStep) GetDashes() Dashes {
+	return DefaultFlagDashes
+}
+
 func (s TestStep) GetOutputs() []Output {
 	return s.Outputs
 }


### PR DESCRIPTION
# What does this change
Adds a `GetDashes()` method to the `ExecutableStep` interface such that implementations can modify the dashes appended to flags.

As proposed in https://github.com/deislabs/porter/pull/681#issuecomment-539102454

# What issue does it fix
N/A, but used by https://github.com/deislabs/porter-terraform/pull/25

# Notes for the reviewer
Is there a way to have this new method be "optional"? Or will we need to add implementations of the method in the other mixins that implement `ExecutableStep`?

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
