### PR TITLE
Return relocation map for both push and pull

### DIFF
--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -61,7 +61,8 @@ func (p *Porter) Publish(opts PublishOptions) error {
 		return err
 	}
 
-	return p.Registry.PushBundle(bun, p.Manifest.BundleTag, opts.InsecureRegistry)
+	_, err = p.Registry.PushBundle(bun, p.Manifest.BundleTag, opts.InsecureRegistry)
+	return err
 }
 
 func (p *Porter) rewriteBundleWithInvocationImageDigest(digest string) (*bundle.Bundle, error) {

--- a/pkg/porter/registry.go
+++ b/pkg/porter/registry.go
@@ -6,11 +6,11 @@ import (
 
 // Registry handles talking with an OCI registry.
 type Registry interface {
-	// PullBundle pulls a bundle from an OCI registry.
-	PullBundle(tag string, insecureRegistry bool) (*bundle.Bundle, error)
+	// PullBundle pulls a bundle from an OCI registry and returns the relocation map
+	PullBundle(tag string, insecureRegistry bool) (*bundle.Bundle, map[string]string, error)
 
-	// PushBundle pushes a bundle to an OCI registry.
-	PushBundle(bun *bundle.Bundle, tag string, insecureRegistry bool) error
+	// PushBundle pushes a bundle to an OCI registry and returns the relocation map
+	PushBundle(bun *bundle.Bundle, tag string, insecureRegistry bool) (map[string]string, error)
 
 	// PushInvocationImage pushes the invocation image from the Docker image cache to the specified location
 	// the expected format of the invocationImage is REGISTRY/NAME:TAG.

--- a/pkg/porter/resolver.go
+++ b/pkg/porter/resolver.go
@@ -22,7 +22,7 @@ func (r *BundleResolver) Resolve(opts BundlePullOptions) (string, error) {
 		return path, nil
 	}
 
-	b, err := r.Registry.PullBundle(opts.Tag, opts.InsecureRegistry)
+	b, _, err := r.Registry.PullBundle(opts.Tag, opts.InsecureRegistry)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR continues #639 and returns the relocation map for the push and pull operations.
It does not use the relocation yet - hence the draft status of the PR.

Up to you whether you think this should be implemented in this PR, or a follow-up.