### PR TITLE
Fix link to Slack on CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -72,3 +72,4 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
+[slack]: https://porter.sh/community#slack


### PR DESCRIPTION
# What does this change
The link to Slack on the Code of Conduct was broken.

# What issue does it fix
N/A

# Notes for the reviewer
🤷‍♀️

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
