### PR TITLE
Fix release pipeline

### DIFF
--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -92,7 +92,7 @@ stages:
     - script: build/azure-pipelines.setup-go-workspace.sh
       displayName: 'Set up the Go workspace'
     
-    - script: make xbuild-all
+    - script: make build xbuild-all
       workingDirectory: '$(MODULE_PATH)'
       displayName: 'Cross Compile'
 
@@ -121,7 +121,7 @@ stages:
         dockerRegistryEndpoint: deislabs-registry
         command: login
 
-    - script: publish-bundle
+    - script: make publish-bundle
       workingDirectory: '$(MODULE_PATH)'
       condition: and(and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')),eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       displayName: 'Publish Example Bundles'


### PR DESCRIPTION
I can't type and testing the release pipeline is hard...

https://dev.azure.com/deislabs/porter/_build/results?buildId=3774&view=logs&jobId=8561663e-1bfb-5abd-6b97-f5ad2d809477

* The job where we publish porter binaries uses porter, so we need to do a normal `make build`
* The job where we publish example bundles was missing a call to make before `publish-bundle`