### PR TITLE
Set plugin logging to error

### DIFF
--- a/pkg/instance-storage/filesystem/plugin.go
+++ b/pkg/instance-storage/filesystem/plugin.go
@@ -25,7 +25,7 @@ func NewPlugin(c config.Config) plugin.Plugin {
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   PluginKey,
 		Output: c.Err,
-		Level:  hclog.Warn,
+		Level:  hclog.Error,
 	})
 
 	return &claimstore.Plugin{

--- a/pkg/instance-storage/provider/provider.go
+++ b/pkg/instance-storage/provider/provider.go
@@ -74,7 +74,7 @@ func (d *PluginDelegator) connect() (crud.Store, func(), error) {
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   "porter",
 		Output: d.Err,
-		Level:  hclog.Debug,
+		Level:  hclog.Error,
 	})
 
 	pluginTypes := map[string]plugin.Plugin{


### PR DESCRIPTION
# What does this change
When I merged the plugin work, I accidentally still had the plugin logging set to debug. This puts it to error where it belongs.

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [x] Documentation Not Impacted
