### PR TITLE
Fix publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAKE_OPTS ?= --no-print-directory
 
 REGISTRY ?= $(USER)
 VERSION ?= $(shell git describe --tags 2> /dev/null || echo v0)
-PERMALINK ?= $(shell git name-rev --name-only --tags --no-undefined HEAD &> /dev/null && echo latest || echo canary)
+PERMALINK ?= $(shell git describe --tags --exact-match 2> /dev/null && echo latest || echo canary)
 
 KUBECONFIG  ?= $(HOME)/.kube/config
 PORTER_HOME = bin

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -105,7 +105,7 @@ stages:
         export AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING)
         make publish
       workingDirectory: '$(MODULE_PATH)'
-      condition: and(and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')),eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Publish Porter Binaries'
 
   - job: publish_example_bundles
@@ -128,5 +128,5 @@ stages:
 
     - script: make publish-bundle
       workingDirectory: '$(MODULE_PATH)'
-      condition: and(and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')),eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Publish Example Bundles'


### PR DESCRIPTION
# What does this change
* Fix release permalink
    if a tag has been made before the build then theold way of detecting canary picked up the tag and reported a relative ref, e.g. v0.18.0-beta.1~1 This tests for an exact tag on the current commit.
* Publish tagged builds
    Accidentally excluded tags when trying to prevent publishes from kicking on a PR

Need to update mixin makefiles with the permalink fix