### PR TITLE
feat(publish): refresh local cache if newly published bundle exists

### DIFF
--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -53,10 +53,10 @@ func (r *Registry) PullBundle(tag string, insecureRegistry bool) (*bundle.Bundle
 	return bun, reloMap, nil
 }
 
-func (r *Registry) PushBundle(bun *bundle.Bundle, tag string, insecureRegistry bool) error {
+func (r *Registry) PushBundle(bun *bundle.Bundle, tag string, insecureRegistry bool) (relocation.ImageRelocationMap, error) {
 	ref, err := ParseOCIReference(tag) //tag from manifest
 	if err != nil {
-		return errors.Wrap(err, "invalid bundle tag reference. expected value is REGISTRY/bundle:tag")
+		return nil, errors.Wrap(err, "invalid bundle tag reference. expected value is REGISTRY/bundle:tag")
 	}
 	var insecureRegistries []string
 	if insecureRegistry {
@@ -68,14 +68,14 @@ func (r *Registry) PushBundle(bun *bundle.Bundle, tag string, insecureRegistry b
 
 	rm, err := remotes.FixupBundle(context.Background(), bun, ref, resolver, remotes.WithEventCallback(r.displayEvent), remotes.WithAutoBundleUpdate())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	d, err := remotes.Push(context.Background(), bun, rm, ref, resolver, true)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	fmt.Fprintf(r.Out, "Bundle tag %s pushed successfully, with digest %q\n", ref, d.Digest)
-	return nil
+	return rm, nil
 }
 
 // PushInvocationImage pushes the invocation image from the Docker image cache to the specified location

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -9,6 +9,7 @@ import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/bundle/loader"
 	"github.com/deislabs/cnab-go/packager"
+	"github.com/docker/cnab-to-oci/relocation"
 	"github.com/docker/distribution/reference"
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/registry"
@@ -103,7 +104,14 @@ func (p *Porter) publishFromFile(opts PublishOptions) error {
 		return err
 	}
 
-	return p.Registry.PushBundle(bun, tag, opts.InsecureRegistry)
+	rm, err := p.Registry.PushBundle(bun, tag, opts.InsecureRegistry)
+	if err != nil {
+		return err
+	}
+
+	// Perhaps we have a cached version of a bundle with the same tag, previously pulled
+	// If so, replace it, as it is most likely out-of-date per this publish
+	return p.refreshCachedBundle(bun, tag, rm)
 }
 
 // publishFromArchive (re-)publishes a bundle, provided by the archive file, using the provided tag.
@@ -185,7 +193,14 @@ func (p *Porter) publishFromArchive(opts PublishOptions) error {
 		fmt.Fprintf(p.Err, "Publishing bundle %s with tag %s...\n", bun.Name, opts.Tag)
 	}
 
-	return p.Registry.PushBundle(bun, opts.Tag, opts.InsecureRegistry)
+	rm, err := p.Registry.PushBundle(bun, opts.Tag, opts.InsecureRegistry)
+	if err != nil {
+		return err
+	}
+
+	// Perhaps we have a cached version of a bundle with the same tag, previously pulled
+	// If so, replace it, as it is most likely out-of-date per this publish
+	return p.refreshCachedBundle(bun, opts.Tag, rm)
 }
 
 // extractBundle extracts a bundle using the provided opts and returnsthe extracted bundle
@@ -327,4 +342,15 @@ func (p *Porter) rewriteImageWithDigest(InvocationImage string, digest string) (
 		return "", fmt.Errorf("had an issue with the docker image")
 	}
 	return fmt.Sprintf("%s@%s", named.Name(), digest), nil
+}
+
+// refreshCachedBundle will store a bundle anew, if a bundle with the same tag is found in the cache
+func (p *Porter) refreshCachedBundle(bun *bundle.Bundle, tag string, rm relocation.ImageRelocationMap) error {
+	if _, _, found, _ := p.Cache.FindBundle(tag); found {
+		_, _, err := p.Cache.StoreBundle(tag, bun, rm)
+		if err != nil {
+			return errors.Wrapf(err, "unable to update cache for bundle %s", tag)
+		}
+	}
+	return nil
 }

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -349,7 +349,7 @@ func (p *Porter) refreshCachedBundle(bun *bundle.Bundle, tag string, rm relocati
 	if _, _, found, _ := p.Cache.FindBundle(tag); found {
 		_, _, err := p.Cache.StoreBundle(tag, bun, rm)
 		if err != nil {
-			return errors.Wrapf(err, "unable to update cache for bundle %s", tag)
+			fmt.Fprintf(p.Err, "warning: unable to update cache for bundle %s: %s\n", tag, err)
 		}
 	}
 	return nil

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -160,7 +160,7 @@ func TestPublish_RefreshCachedBundle_OnlyWarning(t *testing.T) {
 	rm := relocation.ImageRelocationMap{}
 
 	err := p.refreshCachedBundle(bun, tag, rm)
-	require.NoError(t, err, "should have not errored out if bundle does not yet exist in cache")
+	require.NoError(t, err, "should have not errored out even if cache.StoreBundle does")
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	require.Equal(t, "warning: unable to update cache for bundle myreg/mybuns: error trying to store bundle\n", gotOutput)

--- a/pkg/porter/registry.go
+++ b/pkg/porter/registry.go
@@ -11,7 +11,7 @@ type Registry interface {
 	PullBundle(tag string, insecureRegistry bool) (*bundle.Bundle, relocation.ImageRelocationMap, error)
 
 	// PushBundle pushes a bundle to an OCI registry.
-	PushBundle(bun *bundle.Bundle, tag string, insecureRegistry bool) error
+	PushBundle(bun *bundle.Bundle, tag string, insecureRegistry bool) (relocation.ImageRelocationMap, error)
 
 	// PushInvocationImage pushes the invocation image from the Docker image cache to the specified location
 	// the expected format of the invocationImage is REGISTRY/NAME:TAG.


### PR DESCRIPTION
# What does this change
Refreshes Porter's bundle cache with a newly published bundle, if it existed previously.

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/678

# Notes for the reviewer
This is one approach to fixing https://github.com/deislabs/porter/issues/678.  Here we actually refresh the cache so that the next pull of the bundle with the same tag will use the refreshed cache.

Another approach would be to just remove the cached entry on publish.  Then, a subsequent pull would actually need to pull from remote.  The benefit here would be simplified logic, though again, would be forced to re-pull.

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
