### PR TITLE
feat(cmd): add --force flag to action commands

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -103,6 +103,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Use a bundle in an OCI registry specified by the given tag")
 	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
 		"Don't require TLS for the registry")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle and all dependencies")
 	return cmd
 }
 
@@ -152,6 +154,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Use a bundle in an OCI registry specified by the given tag")
 	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
 		"Don't require TLS for the registry")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle and all dependencies")
 
 	return cmd
 }
@@ -201,6 +205,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Use a bundle in an OCI registry specified by the given tag")
 	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
 		"Don't require TLS for the registry")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle and all dependencies")
 
 	return cmd
 }
@@ -252,6 +258,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Use a bundle in an OCI registry specified by the given tag")
 	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
 		"Don't require TLS for the registry")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle and all dependencies")
 
 	return cmd
 }

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -40,6 +40,7 @@ porter bundles install [INSTANCE] [flags]
   -c, --cred strings         Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string        Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string          Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                Force a fresh pull of the bundle and all dependencies
   -h, --help                 help for install
       --insecure             Allow working with untrusted bundles (default true)
       --insecure-registry    Don't require TLS for the registry

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -40,6 +40,7 @@ porter bundles invoke [INSTANCE] --action ACTION [flags]
   -c, --cred strings         Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string        Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string          Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                Force a fresh pull of the bundle and all dependencies
   -h, --help                 help for invoke
       --insecure-registry    Don't require TLS for the registry
       --param strings        Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -41,6 +41,7 @@ porter bundles uninstall [INSTANCE] [flags]
   -c, --cred strings         Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string        Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string          Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
+      --force                Force a fresh pull of the bundle and all dependencies
   -h, --help                 help for uninstall
       --insecure             Allow working with untrusted bundles (default true)
       --insecure-registry    Don't require TLS for the registry

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -40,6 +40,7 @@ porter bundles upgrade [INSTANCE] [flags]
   -c, --cred strings         Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string        Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string          Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                Force a fresh pull of the bundle and all dependencies
   -h, --help                 help for upgrade
       --insecure             Allow working with untrusted bundles (default true)
       --insecure-registry    Don't require TLS for the registry

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -40,6 +40,7 @@ porter install [INSTANCE] [flags]
   -c, --cred strings         Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string        Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string          Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                Force a fresh pull of the bundle and all dependencies
   -h, --help                 help for install
       --insecure             Allow working with untrusted bundles (default true)
       --insecure-registry    Don't require TLS for the registry

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -40,6 +40,7 @@ porter invoke [INSTANCE] --action ACTION [flags]
   -c, --cred strings         Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string        Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string          Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                Force a fresh pull of the bundle and all dependencies
   -h, --help                 help for invoke
       --insecure-registry    Don't require TLS for the registry
       --param strings        Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -41,6 +41,7 @@ porter uninstall [INSTANCE] [flags]
   -c, --cred strings         Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string        Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string          Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
+      --force                Force a fresh pull of the bundle and all dependencies
   -h, --help                 help for uninstall
       --insecure             Allow working with untrusted bundles (default true)
       --insecure-registry    Don't require TLS for the registry

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -40,6 +40,7 @@ porter upgrade [INSTANCE] [flags]
   -c, --cred strings         Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string        Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string          Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                Force a fresh pull of the bundle and all dependencies
   -h, --help                 help for upgrade
       --insecure             Allow working with untrusted bundles (default true)
       --insecure-registry    Don't require TLS for the registry

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -155,6 +155,7 @@ func (e *dependencyExecutioner) prepareDependency(dep *queuedDependency) error {
 	pullOpts := BundlePullOptions{
 		Tag:              dep.Tag,
 		InsecureRegistry: e.parentOpts.InsecureRegistry,
+		Force:            e.parentOpts.Force,
 	}
 	dep.CNABFile, dep.RelocationMapping, err = e.Resolver.Resolve(pullOpts)
 	if err != nil {


### PR DESCRIPTION
# What does this change
This adds a `--force` flag to the standard action commands (install, upgrade, uninstall, --invoke) to enforce pulling a bundle (and all dependency bundles, if applicable).

A potential complement to https://github.com/deislabs/porter/pull/741

# What issue does it fix
N/A
# Notes for the reviewer

# Checklist
- [ ] Unit Tests
- [x] Documentation (auto-generated)
  - [ ] Documentation Not Impacted
