### PR TITLE
Bundle Copy

### DIFF
--- a/cmd/porter/aliases.go
+++ b/cmd/porter/aliases.go
@@ -20,6 +20,7 @@ func buildAliasCommands(p *porter.Porter) []*cobra.Command {
 		buildShowAlias(p),
 		buildArchiveAlias(p),
 		buildExplainAlias(p),
+		buildCopyAlias(p),
 	}
 }
 
@@ -116,6 +117,15 @@ func buildArchiveAlias(p *porter.Porter) *cobra.Command {
 func buildExplainAlias(p *porter.Porter) *cobra.Command {
 	cmd := buildBundleExplainCommand(p)
 	cmd.Example = strings.Replace(cmd.Example, "porter bundle explain", "porter explain", -1)
+	cmd.Annotations = map[string]string{
+		"group": "alias",
+	}
+	return cmd
+}
+
+func buildCopyAlias(p *porter.Porter) *cobra.Command {
+	cmd := buildBundleCopyCommand(p)
+	cmd.Example = strings.Replace(cmd.Example, "porter bundle copy", "porter copy", -1)
 	cmd.Annotations = map[string]string{
 		"group": "alias",
 	}

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -25,6 +25,7 @@ func buildBundleCommands(p *porter.Porter) *cobra.Command {
 	cmd.AddCommand(buildBundleUninstallCommand(p))
 	cmd.AddCommand(buildBundleArchiveCommand(p))
 	cmd.AddCommand(buildBundleExplainCommand(p))
+	cmd.AddCommand(buildBundleCopyCommand(p))
 
 	return cmd
 }

--- a/cmd/porter/copy.go
+++ b/cmd/porter/copy.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/deislabs/porter/pkg/porter"
+)
+
+func buildBundleCopyCommand(p *porter.Porter) *cobra.Command {
+
+	opts := &porter.CopyOpts{}
+
+	cmd := cobra.Command{
+		Use:   "copy",
+		Short: "Copy a bundle",
+		Long: `Copy a published bundle from one registry to another.
+		
+		Source bundle can be either a tagged reference or a digest reference.
+
+		Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
+		If the source bundle is a digest reference, destination must be a tagged reference.
+		`,
+		Example: `  porter bundle copy
+  porter bundle copy --source deislabs/porter-bundle:v0.1.0 --destination portersh
+  porter bundle copy --source deislabs/porter-bundle:v0.1.0 --destination portersh --insecure-registry
+		  `,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.CopyBundle(opts)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVarP(&opts.Source, "source", "", "", " The fully qualified source bundle, including tag or digest.")
+	f.StringVarP(&opts.Destination, "destination", "", "", "The registry to copy the bundle to. Can be registry name, registry plus a repo prefix, or a new tagged reference. All images and the bundle will be prefixed with registry.")
+	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false, "Don't require TLS for registries")
+	return &cmd
+}

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -237,15 +237,20 @@ defaultContentLanguage = "en"
     parent = "authoring-bundles"
 
 [[menu.main]]
-    name = "Distributing Bundles"
+  name = "Distributing Bundles"
+  identifier = "distributing-bundles"
+  weight = 310
+  [[menu.main]]
+    name = "Overview"
     url = "/distributing-bundles"
-    identifier = "distributing-bundles"
-    weight = 310
+    identifier = "distributing-bundles-overview"
+    weight = 311
+    parent = "distributing-bundles"
   [[menu.main]]
     name = "Copying Bundles"
     identifier = "copying-bundles"
     url = "/copying-bundles"
-    weight = 311
+    weight = 312
     parent = "distributing-bundles"
 
 [[menu.main]]

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -229,12 +229,24 @@ defaultContentLanguage = "en"
     identifier = "wiring"
     weight = 303
     parent = "authoring-bundles"
+  [[menu.main]]
+    name = "Distributing Bundles"
+    url = "/distributing-bundles"
+    identifier = "distributing-bundles"
+    weight = 304
+    parent = "authoring-bundles"
 
 [[menu.main]]
   name = "Examining Bundles"
   identifier = "examining-bundles"
   url = "/examining-bundles"
   weight = 325
+
+[[menu.main]]
+  name = "Copying Bundles"
+  identifier = "copying-bundles"
+  url = "/copying-bundles"
+  weight = 326
 
 [[menu.main]]
   name = "Developing Mixins"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -130,6 +130,12 @@ defaultContentLanguage = "en"
     weight = 151
     parent = "cli"
   [[menu.main]]
+    name = "porter copy"
+    url = "/cli#porter-copy"
+    identifier = "cli-copy"
+    weight = 160
+    parent = "cli"
+  [[menu.main]]
     name = "porter schema"
     url = "/cli#porter-schema"
     identifier = "cli-schema"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -235,12 +235,18 @@ defaultContentLanguage = "en"
     identifier = "wiring"
     weight = 303
     parent = "authoring-bundles"
-  [[menu.main]]
+
+[[menu.main]]
     name = "Distributing Bundles"
     url = "/distributing-bundles"
     identifier = "distributing-bundles"
-    weight = 304
-    parent = "authoring-bundles"
+    weight = 310
+  [[menu.main]]
+    name = "Copying Bundles"
+    identifier = "copying-bundles"
+    url = "/copying-bundles"
+    weight = 311
+    parent = "distributing-bundles"
 
 [[menu.main]]
   name = "Examining Bundles"
@@ -248,11 +254,6 @@ defaultContentLanguage = "en"
   url = "/examining-bundles"
   weight = 325
 
-[[menu.main]]
-  name = "Copying Bundles"
-  identifier = "copying-bundles"
-  url = "/copying-bundles"
-  weight = 326
 
 [[menu.main]]
   name = "Developing Mixins"

--- a/docs/content/authoring-bundles.md
+++ b/docs/content/authoring-bundles.md
@@ -260,7 +260,14 @@ images:
 ```
 
 This information is used to generate the corresponding section of the `bundle.json` and can be
-used to in [template expressions](/wiring), much like `parameters`, `credentials` and `outputs`.
+used to in [template expressions](/wiring), much like `parameters`, `credentials` and `outputs`, allowing you to build image references using 
+the `repository` and `digest` attributes. For example:
+
+```
+image: "{{bundle.images.websvc.repository}}@{{bundle.images.websvc.digest}}"
+```
+
+At runtime, these will be updated appropriately if a bundle has been [copied](/copying-bundles). Note that while `tag` is available, you should prefer the use of `digest`.
 
 ## Generated Files
 

--- a/docs/content/cli/bundles.md
+++ b/docs/content/cli/bundles.md
@@ -27,6 +27,7 @@ Commands for working with bundles. These all have shortcuts so that you can call
 
 * [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
 * [porter bundles build](/cli/porter_bundles_build/)	 - Build a bundle
+* [porter bundles copy](/cli/porter_bundles_copy/)	 - Copy a bundle
 * [porter bundles create](/cli/porter_bundles_create/)	 - Create a bundle
 * [porter bundles explain](/cli/porter_bundles_explain/)	 - Explain a bundle
 * [porter bundles install](/cli/porter_bundles_install/)	 - Install a new instance of a bundle

--- a/docs/content/cli/bundles_copy.md
+++ b/docs/content/cli/bundles_copy.md
@@ -1,0 +1,51 @@
+---
+title: "porter bundles copy"
+slug: porter_bundles_copy
+url: /cli/porter_bundles_copy/
+---
+## porter bundles copy
+
+Copy a bundle
+
+### Synopsis
+
+Copy a published bundle from one registry to another.
+		
+		Source bundle can be either a tagged reference or a digest reference.
+
+		Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
+		If the source bundle is a digest reference, destination must be a tagged reference.
+		
+
+```
+porter bundles copy [flags]
+```
+
+### Examples
+
+```
+  porter bundle copy
+  porter bundle copy --source deislabs/porter-bundle:v0.1.0 --destination portersh
+  porter bundle copy --source deislabs/porter-bundle:v0.1.0 --destination portersh --insecure-registry
+		  
+```
+
+### Options
+
+```
+      --destination string   The registry to copy the bundle to. Can be registry name, registry plus a repo prefix, or a new tagged reference. All images and the bundle will be prefixed with registry.
+  -h, --help                 help for copy
+      --insecure-registry    Don't require TLS for registries
+      --source string         The fully qualified source bundle, including tag or digest.
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug logging
+```
+
+### SEE ALSO
+
+* [porter bundles](/cli/porter_bundles/)	 - Bundle commands
+

--- a/docs/content/cli/copy.md
+++ b/docs/content/cli/copy.md
@@ -1,0 +1,51 @@
+---
+title: "porter copy"
+slug: porter_copy
+url: /cli/porter_copy/
+---
+## porter copy
+
+Copy a bundle
+
+### Synopsis
+
+Copy a published bundle from one registry to another.
+		
+		Source bundle can be either a tagged reference or a digest reference.
+
+		Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
+		If the source bundle is a digest reference, destination must be a tagged reference.
+		
+
+```
+porter copy [flags]
+```
+
+### Examples
+
+```
+  porter copy
+  porter copy --source deislabs/porter-bundle:v0.1.0 --destination portersh
+  porter copy --source deislabs/porter-bundle:v0.1.0 --destination portersh --insecure-registry
+		  
+```
+
+### Options
+
+```
+      --destination string   The registry to copy the bundle to. Can be registry name, registry plus a repo prefix, or a new tagged reference. All images and the bundle will be prefixed with registry.
+  -h, --help                 help for copy
+      --insecure-registry    Don't require TLS for registries
+      --source string         The fully qualified source bundle, including tag or digest.
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug logging
+```
+
+### SEE ALSO
+
+* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+

--- a/docs/content/cli/porter.md
+++ b/docs/content/cli/porter.md
@@ -31,6 +31,7 @@ I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
 
 * [porter build](/cli/porter_build/)	 - Build a bundle
 * [porter bundles](/cli/porter_bundles/)	 - Bundle commands
+* [porter copy](/cli/porter_copy/)	 - Copy a bundle
 * [porter create](/cli/porter_create/)	 - Create a bundle
 * [porter credentials](/cli/porter_credentials/)	 - Credentials commands
 * [porter explain](/cli/porter_explain/)	 - Explain a bundle

--- a/docs/content/copying-bundles.md
+++ b/docs/content/copying-bundles.md
@@ -3,7 +3,25 @@ title: Copying Bundles
 description: How to copy a bundle from one registry to another
 ---
 
-Porter allows you to copy a bundle, and all associated images, from one registry to another. This is useful when you have restrictions on where you can pull Docker images from or would otherwise like to have control over assets you will be using. Any operation on the copied bundle will utilize these copied images as well. If you'd like to rename something within a registry, Porter also allows you to copy from one bundle tag to another bundle tag inside the same registry.
+Porter allows you to copy a bundle, and all associated images, from one registry to another. This includes both the invocation images and the images defined in the `images` section of the bundle. For example, consider the following `images` map:
+
+```yaml
+images:
+  backend:
+      description: "A complicated backend service"
+      imageType: "docker"
+      repository: "jeremyrickard/backend-svc"
+      digest: "sha256:decafebad60a4cf73a23517dad677e64edf467107fa7d58fce9c50e6a3e4c914"
+  websvc:
+      description: "A simple web service"
+      imageType: "docker"
+      repository: "jeremyrickard/devops-days-msp"
+      digest: "sha256:85b1a9b4b60a4cf73a23517dad677e64edf467107fa7d58fce9c50e6a3e4c914"
+```
+
+When this bundle is copied, the invocation image, along with the `backend` and `websvc` images will be copied to the new repository. If the bundle author has properly used image (wiring)[/wiring#wiring-images], the new image references will be available within the bundle at run-time.
+
+This is useful when you have restrictions on where you can pull Docker images from or would otherwise like to have control over assets you will be using. Any operation on the copied bundle will utilize these copied images as well. IIf you'd like to rename something within a registry, Porter also allows you to copy from one bundle tag to another bundle tag inside the same registry.
 
 ## Copy A Bundle From One Registry to Another
 

--- a/docs/content/copying-bundles.md
+++ b/docs/content/copying-bundles.md
@@ -1,0 +1,38 @@
+---
+title: Copying Bundles
+description: How to copy a bundle from one registry to another
+---
+
+Porter allows you to copy a bundle, and all associated images, from one registry to another. This is useful when you have restrictions on where you can pull Docker images from or would otherwise like to have control over assets you will be using. Any operation on the copied bundle will utilize these copied images as well. If you'd like to rename something within a registry, Porter also allows you to copy from one bundle tag to another bundle tag inside the same registry.
+
+## Copy A Bundle From One Registry to Another
+
+The first way that you can use the `copy` command is to copy a bundle to a new registry. This command will result in the `source` bundle being copied to the specified registry. The `name:tag` of the source bundle will be used to name the new bundle copy. For example:
+
+```
+$ porter copy --source jeremyrickard/porter-do-bundle:v0.4.6 --destination jrrporter.azurecr.io
+Beginning bundle copy to jrrporter.azurecr.io/porter-do-bundle:v0.4.6. This may take some time.
+Starting to copy image jeremyrickard/porter-do:v0.4.6...
+Completed image jeremyrickard/porter-do:v0.4.6 copy
+Starting to copy image jeremyrickard/spring-music@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f...
+Completed image jeremyrickard/spring-music@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f copy
+Bundle tag jrrporter.azurecr.io/porter-do-bundle:v0.4.6 pushed successfully, with digest "sha256:38d08d6e1ecc97dbf22c630309c2ad37e5af6c092b02826aa4285ec24b4765b9"
+```
+
+In this case, we copied `jeremyrickard/porter-do-bundle:v0.4.6` to the new registry `jrrporter.azurecr.io`, resulting in the new bundle reference `jrrporter.azurecr.io/porter-do-bundle:v0.4.6`.
+
+## Copy A Bundle From One Registry to Another With Specific Tag
+
+In addition to specifying only the new registry, you can also specify a new tagged reference for the bundle:
+
+```
+$ porter copy --source jeremyrickard/porter-do-bundle:v0.4.6 --destination jrrporter.azurecr.io/do-bundle:v0.1.0
+Beginning bundle copy to jrrporter.azurecr.io/porter-do-bundle:v0.4.6. This may take some time.
+Starting to copy image jeremyrickard/porter-do:v0.4.6...
+Completed image jeremyrickard/porter-do:v0.4.6 copy
+Starting to copy image jeremyrickard/spring-music@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f...
+Completed image jeremyrickard/spring-music@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f copy
+Bundle tag jrrporter.azurecr.io/porter-do-bundle:v0.4.6 pushed successfully, with digest "sha256:38d08d6e1ecc97dbf22c630309c2ad37e5af6c092b02826aa4285ec24b4765b9"
+```
+
+This results in `jeremyrickard/porter-do-bundle:v0.4.6` being copied to `jrrporter.azurecr.io/do-bundle:v0.1.0`.

--- a/pkg/porter/copy.go
+++ b/pkg/porter/copy.go
@@ -1,0 +1,68 @@
+package porter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
+)
+
+type CopyOpts struct {
+	Source           string
+	Destination      string
+	InsecureRegistry bool
+}
+
+// Validate performs validation logic on the options specified for a bundle copy
+func (c *CopyOpts) Validate() error {
+	if c.Destination == "" {
+		return errors.New("--destination is required")
+	}
+	source, err := reference.ParseNormalizedNamed(c.Source)
+	if err != nil {
+		return errors.Wrap(err, "invalid value for --source, specified value should be of the form REGISTRY/bundle:tag or REGISTRY/bundle@sha")
+	}
+	if isCopyDigestReference(source) && isCopyReferenceOnly(c.Destination) {
+		return errors.New("--destination must be tagged reference when --source is digested reference")
+	}
+	return nil
+}
+
+func isCopyDigestReference(source reference.Named) bool {
+	if _, ok := source.(reference.Canonical); ok {
+		return true
+	}
+	return false
+}
+
+func isCopyReferenceOnly(dest string) bool {
+	named, err := reference.ParseNormalizedNamed(dest)
+	if err != nil {
+		return false
+	}
+	return reference.IsNameOnly(named)
+}
+
+func generateNewBundleRef(source, dest string) string {
+	if isCopyReferenceOnly(dest) {
+		bundleNameTag := source[strings.LastIndex(source, "/")+1:]
+		return fmt.Sprintf("%s/%s", dest, bundleNameTag)
+	}
+	return dest
+}
+
+// CopyBundle copies a CNAB bundle from one repository to another
+func (p *Porter) CopyBundle(c *CopyOpts) error {
+	destinationTag := generateNewBundleRef(c.Source, c.Destination)
+	fmt.Fprintf(p.Out, "Beginning bundle copy to %s. This may take some time.\n", destinationTag)
+	bun, _, err := p.Registry.PullBundle(c.Source, c.InsecureRegistry)
+	if err != nil {
+		return errors.Wrap(err, "unable to pull bundle before copying")
+	}
+	err = p.Registry.PushBundle(bun, destinationTag, c.InsecureRegistry)
+	if err != nil {
+		return errors.Wrap(err, "unable to copy bundle to new location")
+	}
+	return nil
+}

--- a/pkg/porter/copy.go
+++ b/pkg/porter/copy.go
@@ -60,7 +60,7 @@ func (p *Porter) CopyBundle(c *CopyOpts) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before copying")
 	}
-	err = p.Registry.PushBundle(bun, destinationTag, c.InsecureRegistry)
+	_, err = p.Registry.PushBundle(bun, destinationTag, c.InsecureRegistry)
 	if err != nil {
 		return errors.Wrap(err, "unable to copy bundle to new location")
 	}

--- a/pkg/porter/copy.go
+++ b/pkg/porter/copy.go
@@ -52,7 +52,7 @@ func generateNewBundleRef(source, dest string) string {
 	return dest
 }
 
-// CopyBundle copies a CNAB bundle from one repository to another
+// CopyBundle copies a bundle from one repository to another
 func (p *Porter) CopyBundle(c *CopyOpts) error {
 	destinationTag := generateNewBundleRef(c.Source, c.Destination)
 	fmt.Fprintf(p.Out, "Beginning bundle copy to %s. This may take some time.\n", destinationTag)

--- a/pkg/porter/copy_test.go
+++ b/pkg/porter/copy_test.go
@@ -1,0 +1,150 @@
+package porter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/docker/distribution/reference"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeNamed(ref string) reference.Named {
+	n, _ := reference.ParseNormalizedNamed(ref)
+	return n
+}
+func TestCopyCheckDigestedTest(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Ref      reference.Named
+		Expected bool
+	}{
+		{
+			"valid digested reference",
+			makeNamed("jeremyrickard/porter-do-bundle@sha256:a808aa4e3508d7129742eefda938249574447cce5403dc12d4cbbfe7f4f31e58"),
+			true,
+		},
+		{
+			"tagged reference",
+			makeNamed("jeremyrickard/porter-do-bundle:v0.1.0"),
+			false,
+		},
+		{
+			"no tag",
+			makeNamed("jeremyrickard/porter-do-bundle"),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		ref := isCopyDigestReference(test.Ref)
+		assert.Equal(t, test.Expected, ref, fmt.Sprintf("%s, expected %t, got %t", test.Name, test.Expected, ref))
+	}
+}
+
+func TestCopyReferenceOnly(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Ref      string
+		Expected bool
+	}{
+		{
+			"valid digested reference",
+			"jeremyrickard/porter-do-bundle@sha256:a808aa4e3508d7129742eefda938249574447cce5403dc12d4cbbfe7f4f31e58",
+			false,
+		},
+		{
+			"tagged reference",
+			"jeremyrickard/porter-do-bundle:v0.1.0",
+			false,
+		},
+		{
+			"no tag or digest",
+			"porter-do-bundle",
+			true,
+		},
+		{
+			"no tag or digest",
+			"jeremy/rickard/porter-do-bundle",
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		ref := isCopyReferenceOnly(test.Ref)
+		assert.Equal(t, test.Expected, ref, fmt.Sprintf("%s, expected %t, got %t", test.Name, test.Expected, ref))
+	}
+}
+
+func TestValidateCopyArgs(t *testing.T) {
+
+	tests := []struct {
+		Name          string
+		Opts          CopyOpts
+		ExpectError   bool
+		ExpectedError string
+	}{
+		{
+			"valid source and dest",
+			CopyOpts{
+				Source:      "deislabs/mybuns:v0.1.0",
+				Destination: "blah.acr.io",
+			},
+			false,
+			"",
+		},
+		{
+			"valid source digest and tagged destination",
+			CopyOpts{
+				Source:      "deislabs/mybuns@sha256:bb9b47bb07e8c2f62ea1f617351739b35264f8a6121d79e989cd4e81743afe0a",
+				Destination: "blah.acr.io:v0.1.0",
+			},
+			false,
+			"",
+		},
+		{
+			"valid source, empty dest",
+			CopyOpts{
+				Source: "deislabs/mybuns:v0.1.0",
+			},
+			true,
+			"--destination is required",
+		},
+		{
+			"missing source",
+			CopyOpts{
+				Source:      "",
+				Destination: "blah.acr.io",
+			},
+			true,
+			"invalid value for --source, specified value should be of the form REGISTRY/bundle:tag or REGISTRY/bundle@sha: invalid reference format",
+		},
+		{
+			"bad source, invalid digest ref",
+			CopyOpts{
+				Source:      "deislabs/mybuns@v0.1.0",
+				Destination: "blah.acr.io",
+			},
+			true,
+			"invalid value for --source, specified value should be of the form REGISTRY/bundle:tag or REGISTRY/bundle@sha: invalid reference format",
+		},
+		{
+			"digest to reference only should fail",
+			CopyOpts{
+				Source:      "jeremyrickard/porter-do@sha256:bb9b47bb07e8c2f62ea1f617351739b35264f8a6121d79e989cd4e81743afe0a",
+				Destination: "blah.acr.io",
+			},
+			true,
+			"--destination must be tagged reference when --source is digested reference",
+		},
+	}
+
+	for _, test := range tests {
+		err := test.Opts.Validate()
+		if test.ExpectError {
+			assert.Error(t, err)
+			assert.EqualError(t, err, test.ExpectedError)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/pkg/porter/copy_test.go
+++ b/pkg/porter/copy_test.go
@@ -148,3 +148,40 @@ func TestValidateCopyArgs(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyGenerateBundleRef(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Opts     CopyOpts
+		Expected string
+	}{
+		{
+			"tag source and dest repo",
+			CopyOpts{
+				Source:      "deislabs/mybuns:v0.1.0",
+				Destination: "blah.acr.io",
+			},
+			"blah.acr.io/mybuns:v0.1.0",
+		},
+		{
+			"tag source and dest tag",
+			CopyOpts{
+				Source:      "deislabs/mybuns:v0.1.0",
+				Destination: "blah.acr.io/blah:v0.10",
+			},
+			"blah.acr.io/blah:v0.10",
+		},
+		{
+			"valid source digest and tagged destination",
+			CopyOpts{
+				Source:      "deislabs/mybuns@sha256:bb9b47bb07e8c2f62ea1f617351739b35264f8a6121d79e989cd4e81743afe0a",
+				Destination: "blah.acr.io:v0.1.0",
+			},
+			"blah.acr.io:v0.1.0",
+		},
+	}
+	for _, test := range tests {
+		newRef := generateNewBundleRef(test.Opts.Source, test.Opts.Destination)
+		assert.Equal(t, test.Expected, newRef, fmt.Sprintf("%s: expected %s got %s", test.Name, test.Expected, newRef))
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jeremy Rickard <jeremy.rickard@microsoft.com>

# What does this change

This PR adds a new `bundle copy` command that will copy a bundle and it's images from one registry to another.

Also added a side bar link for distributing bundles, since we didn't have that.


```
$ porter copy --source jeremyrickard/porter-do-bundle:v0.4.6 --destination jrrporter.azurecr.io/do-music-bundle:v1.0.0
Beginning bundle copy to jrrporter.azurecr.io/do-music-bundle:v1.0.0. This may take some time.
Starting to copy image jeremyrickard/porter-do:v0.4.6...
Completed image jeremyrickard/porter-do:v0.4.6 copy
Starting to copy image jeremyrickard/spring-music@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f...
Completed image jeremyrickard/spring-music@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f copy
Bundle tag jrrporter.azurecr.io/do-music-bundle:v1.0.0 pushed successfully, with digest "sha256:38d08d6e1ecc97dbf22c630309c2ad37e5af6c092b02826aa4285ec24b4765b9"
```

# What issue does it fix
Closes #733 

# Notes for the reviewer

💐 🔢 🐐

# Checklist
- [x] Unit Tests
- [x] Documentation