### PR TITLE
feat(publish.go): print initiation status to console for publishing from an archive

### DIFF
--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -147,6 +147,8 @@ func (p *Porter) publishFromArchive(opts PublishOptions) error {
 		return err
 	}
 
+	fmt.Fprintf(p.Out, "Beginning bundle publish to %s. This may take some time.\n", opts.Tag)
+
 	// Use the ggcr client to read the extracted OCI Layout
 	client := ggcr.NewRegistryClient()
 	layout, err := client.ReadLayout(filepath.Join(extractedDir, "artifacts/layout"))
@@ -187,10 +189,6 @@ func (p *Porter) publishFromArchive(opts PublishOptions) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if p.Debug {
-		fmt.Fprintf(p.Err, "Publishing bundle %s with tag %s...\n", bun.Name, opts.Tag)
 	}
 
 	rm, err := p.Registry.PushBundle(bun, opts.Tag, opts.InsecureRegistry)


### PR DESCRIPTION
# What does this change
As the process of pushing new images for a bundle may take some time prior to the standard output from the `PushBundle(...)` call later on, I wanted to add a simple status message and not just have the command sit there blank, potentially for quite a bit.  Idea shamelessly copied from https://github.com/deislabs/porter/pull/745


# What issue does it fix
N/A
# Notes for the reviewer
N/A
# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
