### PR TITLE
Pass full plugin key to plugins

### DIFF
--- a/cmd/porter/plugins.go
+++ b/cmd/porter/plugins.go
@@ -44,16 +44,11 @@ func buildPluginsListCommand(p *porter.Porter) *cobra.Command {
 }
 
 func buildPluginRunCommand(p *porter.Porter) *cobra.Command {
-	var opts porter.RunInternalPluginOpts
-
 	cmd := &cobra.Command{
-		Use:   "run",
+		Use:   "run KEY",
 		Short: "Serve internal plugins",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args)
-		},
 		Run: func(cmd *cobra.Command, args []string) {
-			p.RunInternalPlugins(opts)
+			p.RunInternalPlugins(args)
 		},
 		Hidden: true, // This should ALWAYS be hidden, it is not a user-facing command
 	}

--- a/pkg/instance-storage/filesystem/plugin.go
+++ b/pkg/instance-storage/filesystem/plugin.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 )
 
-const PluginKey = claimstore.PluginKey + ".filesystem"
+const PluginKey = claimstore.PluginKey + ".porter.filesystem"
 
 var _ crud.Store = &Plugin{}
 

--- a/pkg/instance-storage/provider/provider.go
+++ b/pkg/instance-storage/provider/provider.go
@@ -1,6 +1,7 @@
 package instancestorageprovider
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -53,21 +54,23 @@ func (d *PluginDelegator) connect() (crud.Store, func(), error) {
 	var pluginCommand *exec.Cmd
 	if isInternal {
 		pluginImpl := parts[0]
+		pluginKey := fmt.Sprintf("%s.porter.%s", claimstore.PluginKey, pluginImpl)
 		porterPath, err := d.GetPorterPath()
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "could not determine the path to the porter client")
 		}
 
-		pluginCommand = d.NewCommand(porterPath, "plugin", "run", pluginImpl)
+		pluginCommand = d.NewCommand(porterPath, "plugin", "run", pluginKey)
 	} else {
 		pluginBinary := parts[0]
 		pluginImpl := parts[1]
+		pluginKey := fmt.Sprintf("%s.%s.%s", claimstore.PluginKey, pluginBinary, pluginImpl)
 		pluginPath, err := d.GetPluginPath(pluginBinary)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		pluginCommand = d.NewCommand(pluginPath, "run", pluginImpl)
+		pluginCommand = d.NewCommand(pluginPath, "run", pluginKey)
 	}
 
 	// Create an hclog.Logger

--- a/pkg/plugins/server.go
+++ b/pkg/plugins/server.go
@@ -5,11 +5,11 @@ import (
 )
 
 // Serve a single named plugin.
-func Serve(name string, p plugin.Plugin) {
-	ServeMany(map[string]plugin.Plugin{name: p})
+func Serve(interfaceName string, pluginImplementation plugin.Plugin) {
+	ServeMany(map[string]plugin.Plugin{interfaceName: pluginImplementation})
 }
 
-// Serve many plugins that the client will select by name.
+// Serve many plugins that the client will select by named interface.
 func ServeMany(pluginMap map[string]plugin.Plugin) {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: HandshakeConfig,

--- a/pkg/porter/plugins_test.go
+++ b/pkg/porter/plugins_test.go
@@ -1,0 +1,41 @@
+package porter
+
+import (
+	"testing"
+
+	"github.com/deislabs/porter/pkg/config"
+	"github.com/deislabs/porter/pkg/instance-storage/claimstore"
+	"github.com/deislabs/porter/pkg/instance-storage/filesystem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunInternalPluginOpts_Validate(t *testing.T) {
+	cfg := config.NewTestConfig(t)
+	var opts RunInternalPluginOpts
+
+	t.Run("no key", func(t *testing.T) {
+		err := opts.Validate(nil, cfg.Config)
+		require.Error(t, err)
+		assert.Equal(t, err.Error(), "The positional argument KEY was not specified")
+	})
+
+	t.Run("too many keys", func(t *testing.T) {
+		err := opts.Validate([]string{"foo", "bar"}, cfg.Config)
+		require.Error(t, err)
+		assert.Equal(t, err.Error(), "Multiple positional arguments were specified but only one, KEY is expected")
+	})
+
+	t.Run("valid key", func(t *testing.T) {
+		err := opts.Validate([]string{filesystem.PluginKey}, cfg.Config)
+		require.NoError(t, err)
+		assert.Equal(t, opts.selectedInterface, claimstore.PluginKey)
+		assert.NotNil(t, opts.selectedPlugin)
+	})
+
+	t.Run("invalid key", func(t *testing.T) {
+		err := opts.Validate([]string{"foo"}, cfg.Config)
+		require.Error(t, err)
+		assert.Equal(t, err.Error(), `invalid plugin key specified: "foo"`)
+	})
+}


### PR DESCRIPTION
When we run a plugin, pass the full key so that it knows which implementation to host

`INTERFACE.BINARY.IMPLEMENTATION`