### PR TITLE
chore(pkg/kubernetes): bump kubectl version for k8s mixin

### DIFF
--- a/pkg/kubernetes/build.go
+++ b/pkg/kubernetes/build.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const kubeVersion = "v1.13.0"
+const kubeVersion = "v1.15.5"
 const dockerFileContents = `RUN apt-get update && \
 apt-get install -y apt-transport-https curl && \
 curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl && \


### PR DESCRIPTION
# What does this change
Bumps the kubectl version installed via the kubernetes mixin to the latest (v1.15.x) [v1.15.5 release](https://github.com/kubernetes/kubernetes/releases/tag/v1.15.5)

# What issue does it fix
N/A
# Notes for the reviewer
N/A
# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
