### PR TITLE
fix(pkg/cnab/provider): provide instanceStorage.Store() err when applicable

### DIFF
--- a/pkg/cnab/provider/install.go
+++ b/pkg/cnab/provider/install.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/porter/pkg/manifest"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
+	"github.com/deislabs/porter/pkg/manifest"
 )
 
 func (d *Runtime) Install(args ActionArguments) error {
@@ -59,13 +61,18 @@ func (d *Runtime) Install(args ActionArguments) error {
 		fmt.Fprintf(d.Err, "installing bundle %s (%s) as %s\n\tparams: %v\n\tcreds: %v\n", c.Bundle.Name, args.BundlePath, c.Name, paramKeys, credKeys)
 	}
 
+	var result *multierror.Error
 	// Install and capture error
-	runErr := i.Run(c, creds, d.ApplyConfig(args)...)
+	err = i.Run(c, creds, d.ApplyConfig(args)...)
+	if err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to install the bundle"))
+	}
 
 	// ALWAYS write out a claim, even if the installation fails
-	saveErr := d.instanceStorage.Store(*c)
-	if runErr != nil {
-		return errors.Wrap(runErr, "failed to install the bundle")
+	err = d.instanceStorage.Store(*c)
+	if err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to record the installation for the bundle"))
 	}
-	return errors.Wrap(saveErr, "failed to record the installation for the bundle")
+
+	return result.ErrorOrNil()
 }

--- a/pkg/cnab/provider/uninstall.go
+++ b/pkg/cnab/provider/uninstall.go
@@ -67,9 +67,6 @@ func (d *Runtime) Uninstall(args ActionArguments) error {
 	}
 
 	err = d.instanceStorage.Delete(args.Claim)
-	if err != nil {
-		return errors.Wrap(err, "failed to remove the record of the bundle")
-	}
 
-	return nil
+	return errors.Wrap(err, "failed to remove the record of the bundle")
 }

--- a/pkg/cnab/provider/upgrade.go
+++ b/pkg/cnab/provider/upgrade.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/porter/pkg/manifest"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
 
@@ -56,13 +57,18 @@ func (d *Runtime) Upgrade(args ActionArguments) error {
 		fmt.Fprintf(d.Err, "upgrading bundle %s (%s) as %s\n\tparams: %v\n\tcreds: %v\n", c.Bundle.Name, args.BundlePath, c.Name, paramKeys, credKeys)
 	}
 
+	var result *multierror.Error
 	// Upgrade and capture error
-	runErr := i.Run(&c, creds, d.ApplyConfig(args)...)
+	err = i.Run(&c, creds, d.ApplyConfig(args)...)
+	if err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to upgrade the bundle"))
+	}
 
 	// ALWAYS write out a claim, even if the upgrade fails
-	saveErr := d.instanceStorage.Store(c)
-	if runErr != nil {
-		return errors.Wrap(runErr, "failed to upgrade the bundle")
+	err = d.instanceStorage.Store(c)
+	if err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to record the upgrade for the bundle"))
 	}
-	return errors.Wrap(saveErr, "failed to record the upgrade for the bundle")
+
+	return result.ErrorOrNil()
 }


### PR DESCRIPTION
# What does this change
Previously, there were cases when instance storage errors were lost (on install, upgrade and invoke, we'd return the `runErr` if not nil, directly after calling `Store`).

This utilizes the `multierror` library that we've used elsewhere to gather up multiple errors when applicable (say, on run and on store) and present them to the user when finished.

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
