### PR TITLE
Include customAction definitions in schema

### DIFF
--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -47,6 +47,24 @@
       ],
       "type": "object"
     },
+    "customAction": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "description": "A description of the custom action",
+          "type": "string"
+        },
+        "modifies": {
+          "description": "Specifies that the action will modify resources in any way.",
+          "type": "boolean"
+        },
+        "stateless": {
+          "description": "Specifies that the action does not act on a claim, and does not require credentials.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "dependency": {
       "additionalProperties": false,
       "properties": {
@@ -285,6 +303,12 @@
         "$ref": "#/definitions/credential"
       },
       "type": "array"
+    },
+    "customActions": {
+      "additionalProperties": {
+        "$ref": "#/definitions/customAction"
+      },
+      "type": "object"
     },
     "dependencies": {
       "additionalProperties": {

--- a/pkg/templates/templates/schema.json
+++ b/pkg/templates/templates/schema.json
@@ -110,6 +110,24 @@
       },
       "required": ["tag"],
       "additionalProperties": false
+    },
+    "customAction": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the custom action"
+        },
+        "modifies": {
+          "type": "boolean",
+          "description": "Specifies that the action will modify resources in any way."
+        },
+        "stateless": {
+          "type": "boolean",
+          "description": "Specifies that the action does not act on a claim, and does not require credentials."
+        }
+      },
+      "additionalProperties": false
     }
   },
   "properties": {
@@ -189,6 +207,10 @@
     "dockerfile": {
       "type": "string",
       "description": "The relative path to a Dockerfile to use as a template during porter build"
+    },
+    "customActions": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/definitions/customAction"}
     }
   },
   "additionalProperties": {


### PR DESCRIPTION
# What does this change
Include customAction definitions in schema.

# What issue does it fix
Closes https://github.com/deislabs/porter-vscode/issues/18

# Notes for the reviewer


# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
