### PR TITLE
Inject mixins dockerfile lines before copying bundle files

### DIFF
--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -37,6 +37,7 @@ func TestPorter_buildDockerfile(t *testing.T) {
 		"",
 		"RUN apt-get update && apt-get install -y ca-certificates",
 		"",
+		"",
 		"COPY .cnab /cnab",
 		"COPY . $BUNDLE_DIR",
 		"RUN rm -fr $BUNDLE_DIR/.cnab",
@@ -139,6 +140,7 @@ FROM debian:stretch
 ARG BUNDLE_DIR
 
 RUN apt-get update && apt-get install -y ca-certificates
+
 
 COPY .cnab /cnab
 COPY . $BUNDLE_DIR

--- a/pkg/templates/templates/build/Dockerfile
+++ b/pkg/templates/templates/build/Dockerfile
@@ -4,6 +4,8 @@ ARG BUNDLE_DIR
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+# PORTER_MIXINS
+
 COPY .cnab /cnab
 COPY . $BUNDLE_DIR
 RUN rm -fr $BUNDLE_DIR/.cnab

--- a/pkg/templates/templates/create/Dockerfile.tmpl
+++ b/pkg/templates/templates/create/Dockerfile.tmpl
@@ -13,5 +13,9 @@ ARG BUNDLE_DIR
 # Add the following line to porter.yaml to instruct Porter to use this template
 # dockerfile: Dockerfile.tmpl
 
+# You can control where the mixin's Dockerfile lines are inserted into this file by moving "# PORTER_MIXINS" line
+# another location in this file. If you remove that line, the mixins generated content is appended to this file.
+# PORTER_MIXINS
+
 # Use the BUNDLE_DIR build argument to copy files into the bundle
 # COPY . $BUNDLE_DIR


### PR DESCRIPTION
# What does this change
By default inject the mixin dockerfile lines before we copy the bundle files to avoid longer docker build times.

This adds the `# PORTER_MIXINS` line before `COPY . $BUNDLE_DIR` in both the **Dockerfile.tmpl** generated during `porter create` and the **Dockerfile** used during `porter build` when a custom dockerfile wasn't specified.

# What issue does it fix
Follow-up to #707 making the default behavior most likely what the user wanted.

# Notes for the reviewer
I am writing up full documentation for how to use a custom dockerfile in a separate PR.

# Checklist
- [x] Unit Tests
- [ ] Documentation 
  - [ ] Documentation Not Impacted
