### PR TITLE
Pass plugin config via stdin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -786,15 +786,16 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:446e0a4f73191887866ac789d1fd210e3408bb8eb8aeaf199d5f3a73ff63c108"
+  branch = "accept-stdin"
+  digest = "1:366d0ebbb08fe1b0e3b58b871d14b2a72b67fc87da712103c0340651a014cd23"
   name = "github.com/hashicorp/go-plugin"
   packages = [
     ".",
     "internal/plugin",
   ]
   pruneopts = "NUT"
-  revision = "9e3e1c37db188a1acb66561ee0ed4bf4d5e77554"
-  version = "v1.0.1"
+  revision = "8fe113736efa529bc9eb72a46ea2129e9c39011e"
+  source = "github.com/carolynvs/go-plugin"
 
 [[projects]]
   digest = "1:0b06ffe0c0764e413a6738e3f045d6bb14117359aef80a09f8c60fbff2ecad6b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -98,7 +98,9 @@
 
 [[constraint]]
   name = "github.com/hashicorp/go-plugin"
-  version = "^v1.0.0"
+  #version = "^v1.0.0"
+  source = "github.com/carolynvs/go-plugin"
+  branch = "accept-stdin"
 
 [prune]
   non-go = true

--- a/pkg/config/datastore.go
+++ b/pkg/config/datastore.go
@@ -1,10 +1,20 @@
 package config
 
+import "errors"
+
 // Data is the data stored in PORTER_HOME/porter.toml|yaml|json
 type Data struct {
 	// Only define fields here that you need to access from code
 	// Values are dynamically applied to flags and don't need to be defined
-	InstanceStoragePlugin string `mapstructure:"instance-storage-plugin"`
+	InstanceStoragePlugin string          `mapstructure:"instance-storage-plugin"`
+	DefaultInstanceStore  string          `mapstructure:"default-instance-store"`
+	InstanceStores        []InstanceStore `mapstructure:"instance-store"`
+}
+
+type InstanceStore struct {
+	Name         string                 `mapstructure:"name"`
+	PluginSubkey string                 `mapstructure:"plugin"`
+	Config       map[string]interface{} `mapstructure:"config"`
 }
 
 func (d *Data) GetInstanceStoragePlugin() string {
@@ -13,6 +23,26 @@ func (d *Data) GetInstanceStoragePlugin() string {
 	}
 
 	return d.InstanceStoragePlugin
+}
+
+func (d *Data) GetDefaultInstanceStore() string {
+	if d == nil {
+		return ""
+	}
+
+	return d.DefaultInstanceStore
+}
+
+func (d *Data) GetInstanceStore(name string) (InstanceStore, error) {
+	if d != nil {
+		for _, is := range d.InstanceStores {
+			if is.Name == name {
+				return is, nil
+			}
+		}
+	}
+
+	return InstanceStore{}, errors.New("instance-store %q not defined")
 }
 
 var _ DataStoreLoaderFunc = NoopDataLoader

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -1,6 +1,10 @@
 package plugins
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/go-plugin"
 )
 
@@ -9,4 +13,39 @@ var HandshakeConfig = plugin.HandshakeConfig{
 	ProtocolVersion:  1,
 	MagicCookieKey:   "PORTER",
 	MagicCookieValue: "bbc2dd71-def4-4311-906e-e98dc27208ce",
+}
+
+type PluginKey struct {
+	Binary         string
+	Interface      string
+	Implementation string
+	IsInternal     bool
+}
+
+func (k PluginKey) String() string {
+	return fmt.Sprintf("%s.%s.%s", k.Interface, k.Binary, k.Implementation)
+}
+
+func ParsePluginKey(value string) (PluginKey, error) {
+	var key PluginKey
+
+	parts := strings.Split(value, ".")
+
+	switch len(parts) {
+	case 1:
+		key.IsInternal = true
+		key.Binary = "porter"
+		key.Implementation = parts[0]
+	case 2:
+		key.Binary = parts[0]
+		key.Implementation = parts[1]
+	case 3:
+		key.Interface = parts[0]
+		key.Binary = parts[1]
+		key.Implementation = parts[2]
+	default:
+		return PluginKey{}, errors.New("invalid plugin key %q, allowed format is [INTERFACE].BINARY.IMPLEMENTATION")
+	}
+
+	return key, nil
 }

--- a/vendor/github.com/hashicorp/go-plugin/client.go
+++ b/vendor/github.com/hashicorp/go-plugin/client.go
@@ -526,7 +526,9 @@ func (c *Client) Start() (addr net.Addr, err error) {
 	cmd := c.config.Cmd
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Env = append(cmd.Env, env...)
-	cmd.Stdin = os.Stdin
+	if cmd.Stdin == nil {
+		cmd.Stdin = os.Stdin
+	}
 
 	cmdStdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -788,7 +790,10 @@ func (c *Client) reattach() (net.Addr, error) {
 	// Verify the process still exists. If not, then it is an error
 	p, err := os.FindProcess(c.config.Reattach.Pid)
 	if err != nil {
-		return nil, err
+		// On Unix systems, FindProcess never returns an error.
+		// On Windows, for non-existent pids it returns:
+		// os.SyscallError - 'OpenProcess: the paremter is incorrect'
+		return nil, ErrProcessNotFound
 	}
 
 	// Attempt to connect to the addr since on Unix systems FindProcess


### PR DESCRIPTION
# What does this change
Reads optional configuration from the porter configuration file and passes it to the plugin on stdin as json. 

It is not sent as part of the plugin interface/contract because each plugin may or may not have config, it may look completely different or be loaded from other places, and I'd like to have the plugin contract mimic the cnab contracts. For example the interface for claims is the CrudStore.

```toml
default-instance-store = "porterci"

[[instance-store]]
  name = "porterci"
  plugin = "azure.blob"

  [instance-store.config]
    env = "PORTERCI_AZURE_STORAGE_CONNECTION_STRING"
```

# What issue does it fix
N/A

# Notes for the reviewer
This relies on a patch: https://github.com/hashicorp/go-plugin/pull/127

This is the first step in getting a general framework in place for plugins. Next steps after this will be to make the pluginProvider generic so it can load a plugin and config for any interface. Right now I'm just feeling out what works.