### PR TITLE
Fix adding duplicate files

### DIFF
--- a/pkg/mixin/feed/generate.go
+++ b/pkg/mixin/feed/generate.go
@@ -94,9 +94,10 @@ func (feed *MixinFeed) Generate(opts GenerateOptions) error {
 			}
 
 			for i := range feed.Index[mixin][version].Files {
-				if feed.Index[mixin][version].Files[i].File == filename {
-					if feed.Index[mixin][version].Files[i].Updated.Before(updated) {
-						feed.Index[mixin][version].Files[i].Updated = updated
+				mixinFile := feed.Index[mixin][version].Files[i]
+				if mixinFile.File == filename {
+					if mixinFile.Updated.Before(updated) {
+						mixinFile.Updated = updated
 					}
 
 					return nil

--- a/pkg/mixin/feed/generate.go
+++ b/pkg/mixin/feed/generate.go
@@ -94,15 +94,15 @@ func (feed *MixinFeed) Generate(opts GenerateOptions) error {
 			}
 
 			for file := range feed.Index[mixin][version].Files {
-				if feed.Index[mixin][version].Files[file].Updated.Before(updated) {
-					feed.Index[mixin][version].Files[file].Updated = updated
-				}
-				
 				if feed.Index[mixin][version].Files[file].File == filename {
+					if feed.Index[mixin][version].Files[file].Updated.Before(updated) {
+						feed.Index[mixin][version].Files[file].Updated = updated
+					}
+					
 					return nil
 				}
 			}
-
+			
 			feed.Index[mixin][version].Files = append(feed.Index[mixin][version].Files, &MixinFile{File: filename, Updated: updated})
 		}
 

--- a/pkg/mixin/feed/generate.go
+++ b/pkg/mixin/feed/generate.go
@@ -89,20 +89,20 @@ func (feed *MixinFeed) Generate(opts GenerateOptions) error {
 					Mixin:   mixin,
 					Version: version,
 				}
-				
+
 				feed.Index[mixin][version] = &fileset
 			}
 
-			for file := range feed.Index[mixin][version].Files {
-				if feed.Index[mixin][version].Files[file].File == filename {
-					if feed.Index[mixin][version].Files[file].Updated.Before(updated) {
-						feed.Index[mixin][version].Files[file].Updated = updated
+			for i := range feed.Index[mixin][version].Files {
+				if feed.Index[mixin][version].Files[i].File == filename {
+					if feed.Index[mixin][version].Files[i].Updated.Before(updated) {
+						feed.Index[mixin][version].Files[i].Updated = updated
 					}
-					
+
 					return nil
 				}
 			}
-			
+
 			feed.Index[mixin][version].Files = append(feed.Index[mixin][version].Files, &MixinFile{File: filename, Updated: updated})
 		}
 

--- a/pkg/mixin/feed/generate_test.go
+++ b/pkg/mixin/feed/generate_test.go
@@ -120,33 +120,57 @@ func TestGenerate_ExistingFeed(t *testing.T) {
 	assert.Equal(t, wantXml, gotXml)
 }
 
-func TestGenerate_DuplicatesNotIncluded(t *testing.T) {
+func TestGenerate_RegenerateDoesNotCreateDuplicates(t *testing.T) {
 	tc := context.NewTestContext(t)
 	tc.AddTestFile("testdata/atom-template.xml", "template.xml")
+	tc.AddTestFile("testdata/atom-existing.xml", "atom.xml")
 
-	tc.FileSystem.Create("bin/a/canary/mixin-darwin-amd64")
-	older, _ := time.Parse("2006-Jan-02", "2000-Jan-01")
-	tc.FileSystem.Chtimes("bin/a/canary/mixin-darwin-amd64", older, older)
+	tc.FileSystem.Create("bin/v1.2.4/helm-darwin-amd64")
+	tc.FileSystem.Create("bin/v1.2.4/helm-linux-amd64")
+	tc.FileSystem.Create("bin/v1.2.4/helm-windows-amd64.exe")
 
-	tc.FileSystem.Create("bin/b/canary/mixin-darwin-amd64")
-	newer, _ := time.Parse("2006-Jan-02", "2000-Feb-01")
-	tc.FileSystem.Chtimes("bin/b/canary/mixin-darwin-amd64", newer, newer)
+	up4, _ := time.Parse("2006-Jan-02", "2013-Feb-04")
+	tc.FileSystem.Chtimes("bin/v1.2.4/helm-darwin-amd64", up4, up4)
+	tc.FileSystem.Chtimes("bin/v1.2.4/helm-linux-amd64", up4, up4)
+	tc.FileSystem.Chtimes("bin/v1.2.4/helm-windows-amd64.exe", up4, up4)
+
+	tc.FileSystem.Create("bin/canary/exec-darwin-amd64")
+	tc.FileSystem.Create("bin/canary/exec-linux-amd64")
+	tc.FileSystem.Create("bin/canary/exec-windows-amd64.exe")
+
+	up10, _ := time.Parse("2006-Jan-02", "2013-Feb-10")
+	tc.FileSystem.Chtimes("bin/canary/exec-darwin-amd64", up10, up10)
+	tc.FileSystem.Chtimes("bin/canary/exec-linux-amd64", up10, up10)
+	tc.FileSystem.Chtimes("bin/canary/exec-windows-amd64.exe", up10, up10)
 
 	opts := GenerateOptions{
 		AtomFile:        "atom.xml",
 		SearchDirectory: "bin",
 		TemplateFile:    "template.xml",
 	}
-
 	f := NewMixinFeed(tc.Context)
 
 	err := f.Generate(opts)
 	require.NoError(t, err)
+	err = f.Save(opts)
+	require.NoError(t, err)
 
-	fileCount := len(f.Index["mixin"]["canary"].Files)
-	expectedCount := 1
-	
-	assert.Equal(t, fileCount, expectedCount)
+	// Run the generation again, against the same versions, and make sure they don't insert duplicate files
+	// This mimics what the CI does when we repeat a build, or have multiple canary builds on master
+	err = f.Generate(opts)
+	require.NoError(t, err)
+	err = f.Save(opts)
+	require.NoError(t, err)
+
+	b, err := tc.FileSystem.ReadFile("atom.xml")
+	require.NoError(t, err)
+	gotXml := string(b)
+
+	b, err = ioutil.ReadFile("testdata/atom.xml")
+	require.NoError(t, err)
+	wantXml := string(b)
+
+	assert.Equal(t, wantXml, gotXml)
 }
 
 func TestMixinEntries_Sort(t *testing.T) {


### PR DESCRIPTION
# What does this change do?
The heart of this change is that we should always be skipping files that already exist in the feed. Duplications can occur if the first file in the feed, of the same version, were created before the next duplicated file in the `for each`. We can split up the conditional to guarantee duplication are always skipped.

Additionally, changed `.After()` to `.Before()`, as we really only want to update the time if the current file in the feed was modified _before_ the file we're currently looking at in the `for each`.

I also took some liberties with how we were adding `Fileset`s to the collection to (hopefully) make it more readable. We were mixing up value/pointer semantics, and it took a bit to digest.

Let me know if anything needs changing!

# What issue does it fix
Closes #749 

# Checklist
- [x] Unit Tests
- [x] Documentation
  - [x] Documentation Not Impacted
