### PR TITLE
Fix whitespace in the copy help text

### DIFF
--- a/cmd/porter/copy.go
+++ b/cmd/porter/copy.go
@@ -13,13 +13,11 @@ func buildBundleCopyCommand(p *porter.Porter) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "copy",
 		Short: "Copy a bundle",
-		Long: `Copy a published bundle from one registry to another.
-		
-		Source bundle can be either a tagged reference or a digest reference.
-
-		Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
-		If the source bundle is a digest reference, destination must be a tagged reference.
-		`,
+		Long: `Copy a published bundle from one registry to another.		
+Source bundle can be either a tagged reference or a digest reference.
+Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
+If the source bundle is a digest reference, destination must be a tagged reference.
+`,
 		Example: `  porter bundle copy
   porter bundle copy --source deislabs/porter-bundle:v0.1.0 --destination portersh
   porter bundle copy --source deislabs/porter-bundle:v0.1.0 --destination portersh --insecure-registry

--- a/docs/content/cli/bundles_copy.md
+++ b/docs/content/cli/bundles_copy.md
@@ -9,13 +9,11 @@ Copy a bundle
 
 ### Synopsis
 
-Copy a published bundle from one registry to another.
-		
-		Source bundle can be either a tagged reference or a digest reference.
+Copy a published bundle from one registry to another.		
+Source bundle can be either a tagged reference or a digest reference.
+Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
+If the source bundle is a digest reference, destination must be a tagged reference.
 
-		Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
-		If the source bundle is a digest reference, destination must be a tagged reference.
-		
 
 ```
 porter bundles copy [flags]

--- a/docs/content/cli/copy.md
+++ b/docs/content/cli/copy.md
@@ -9,13 +9,11 @@ Copy a bundle
 
 ### Synopsis
 
-Copy a published bundle from one registry to another.
-		
-		Source bundle can be either a tagged reference or a digest reference.
+Copy a published bundle from one registry to another.		
+Source bundle can be either a tagged reference or a digest reference.
+Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
+If the source bundle is a digest reference, destination must be a tagged reference.
 
-		Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
-		If the source bundle is a digest reference, destination must be a tagged reference.
-		
 
 ```
 porter copy [flags]


### PR DESCRIPTION
Signed-off-by: Jeremy Rickard <jeremy.rickard@microsoft.com>

# What does this change

Fixes the whitespace in the long desc for the copy command. It was indented too much and looked bad during a demo last week. 