### PR TITLE
fix: fix spacing to assuage my compulsiveness

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -275,8 +275,8 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 		Long:  "Publishes a bundle by pushing the invocation image and bundle to a registry.",
 		Example: `  porter bundle publish
   porter bundle publish --file myapp/porter.yaml
-	porter bundle publish --insecure
-	porter bundle publish --archive /tmp/mybuns.tgz --tag myrepo/my-buns:0.1.0
+  porter bundle publish --insecure
+  porter bundle publish --archive /tmp/mybuns.tgz --tag myrepo/my-buns:0.1.0
 		`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(p.Context)

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -20,8 +20,8 @@ porter publish [flags]
 ```
   porter publish
   porter publish --file myapp/porter.yaml
-	porter publish --insecure
-	porter publish --archive /tmp/mybuns.tgz --tag myrepo/my-buns:0.1.0
+  porter publish --insecure
+  porter publish --archive /tmp/mybuns.tgz --tag myrepo/my-buns:0.1.0
 		
 ```
 


### PR DESCRIPTION
This just replaces a few tabs with spaces to make the formatting align.

# What does this change
Fix help text spacing for `porter publish -h`

# Checklist
- [X] Documentation


Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>