### PR TITLE
Add Kubernetes kustomize support

### DIFF
--- a/examples/kubernetes-kustomize-example/README.md
+++ b/examples/kubernetes-kustomize-example/README.md
@@ -1,0 +1,10 @@
+# Kubernetes + Kustomize Example
+
+Sample for Porter bundle that makes use of Kubernetes Kustomize.
+
+```
+porter build
+porter credentials generate
+porter install -c PORTER_KUBE
+porter uninstall -c PORTER_KUBE
+```

--- a/examples/kubernetes-kustomize-example/kustomize/base/configMap.yaml
+++ b/examples/kubernetes-kustomize-example/kustomize/base/configMap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-map
+data:
+  altGreeting: "Good Morning!"
+  enableRisky: "false"

--- a/examples/kubernetes-kustomize-example/kustomize/base/deployment.yaml
+++ b/examples/kubernetes-kustomize-example/kustomize/base/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: the-deployment
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        deployment: hello
+    spec:
+      containers:
+      - name: the-container
+        image: monopole/hello:1
+        command: ["/hello",
+                  "--port=8080",
+                  "--enableRiskyFeature=$(ENABLE_RISKY)"]
+        ports:
+        - containerPort: 8080
+        env:
+        - name: ALT_GREETING
+          valueFrom:
+            configMapKeyRef:
+              name: the-map
+              key: altGreeting
+        - name: ENABLE_RISKY
+          valueFrom:
+            configMapKeyRef:
+              name: the-map
+              key: enableRisky

--- a/examples/kubernetes-kustomize-example/kustomize/base/kustomization.yaml
+++ b/examples/kubernetes-kustomize-example/kustomize/base/kustomization.yaml
@@ -1,0 +1,12 @@
+# Example configuration for the webserver
+# at https://github.com/monopole/hello
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: my-hello
+
+resources:
+- deployment.yaml
+- service.yaml
+- configMap.yaml

--- a/examples/kubernetes-kustomize-example/kustomize/base/service.yaml
+++ b/examples/kubernetes-kustomize-example/kustomize/base/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: the-service
+spec:
+  selector:
+    deployment: hello
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 8666
+    targetPort: 8080

--- a/examples/kubernetes-kustomize-example/kustomize/overlays/production/deployment.yaml
+++ b/examples/kubernetes-kustomize-example/kustomize/overlays/production/deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: the-deployment
+spec:
+  replicas: 10

--- a/examples/kubernetes-kustomize-example/kustomize/overlays/production/kustomization.yaml
+++ b/examples/kubernetes-kustomize-example/kustomize/overlays/production/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: production-
+commonLabels:
+  variant: production
+  org: acmeCorporation
+commonAnnotations:
+  note: Hello, I am production!
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml

--- a/examples/kubernetes-kustomize-example/kustomize/overlays/staging/kustomization.yaml
+++ b/examples/kubernetes-kustomize-example/kustomize/overlays/staging/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: staging-
+commonLabels:
+  variant: staging
+  org: acmeCorporation
+commonAnnotations:
+  note: Hello, I am staging!
+bases:
+- ../../base
+#resources:
+#- ../../base
+patchesStrategicMerge:
+- map.yaml

--- a/examples/kubernetes-kustomize-example/kustomize/overlays/staging/map.yaml
+++ b/examples/kubernetes-kustomize-example/kustomize/overlays/staging/map.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-map
+data:
+  altGreeting: "Have a pineapple!"
+  enableRisky: "true"

--- a/examples/kubernetes-kustomize-example/porter.yaml
+++ b/examples/kubernetes-kustomize-example/porter.yaml
@@ -1,0 +1,56 @@
+mixins:
+  - exec
+  - kubernetes
+
+credentials:
+  - name: kubeconfig
+    path: /root/.kube/config
+
+name: PORTER_KUSTOMIZE 
+version: 0.1.0
+description: "An example Porter bundle with Kubernetes Kustomize"
+invocationImage: deislabs/porter-kustomize:latest
+tag: deislabs/porter-kustomize-bundle:v0.1.0
+#dockerfile: Dockerfile.tmpl
+
+install:
+  - kubernetes:
+      description: "Create production and staging apps"
+      kustomizes:
+        - kustomize/overlays/production
+        - kustomize/overlays/staging
+      wait: true
+      outputs:
+        - name: PROD_IP_ADDRESS
+          resourceType: service
+          resourceName: production-the-service 
+          jsonPath: "{.spec.clusterIP}"
+        - name: STAGE_IP_ADDRESS
+          resourceType: service
+          resourceName: staging-the-service 
+          jsonPath: "{.spec.clusterIP}"
+  - exec:
+      description: "Echo the PROD IP Address"
+      command: bash
+      flags:
+        c: "echo 'You will find the production service at: {{bundle.outputs.PROD_IP_ADDRESS}}'"
+
+  - exec:
+      description: "Echo the STAGE IP Address"
+      command: bash
+      flags:
+        c: "echo 'You will find the staging service at: {{bundle.outputs.STAGE_IP_ADDRESS}}'"
+
+uninstall:
+  - kubernetes:
+      description: "Uninstall production and staging apps"
+      kustomizes:
+        - kustomize/overlays/production
+        - kustomize/overlays/staging
+      wait: true
+
+#outputs:
+#  - name: PROD_IP_ADDRESS
+#    type: string
+#  - name: STAGE_IP_ADDRESS
+#    type: string

--- a/pkg/kubernetes/execute.go
+++ b/pkg/kubernetes/execute.go
@@ -80,7 +80,16 @@ func (m *Mixin) Execute() error {
 	var commands []*exec.Cmd
 
 	for _, manifestPath := range step.Manifests {
-		commandPayload, err := m.buildExecuteCommand(step.ExecuteInstruction, manifestPath)
+		commandPayload, err := m.buildExecuteCommand(step.ExecuteInstruction, manifestPath, false)
+		if err != nil {
+			return err
+		}
+		cmd := m.NewCommand("kubectl", commandPayload...)
+		commands = append(commands, cmd)
+	}
+
+	for _, kustomize := range step.Kustomizes {
+		commandPayload, err := m.buildExecuteCommand(step.ExecuteInstruction, kustomize, true)
 		if err != nil {
 			return err
 		}
@@ -108,8 +117,8 @@ func (m *Mixin) Execute() error {
 	return err
 }
 
-func (m *Mixin) buildExecuteCommand(args ExecuteInstruction, manifestPath string) ([]string, error) {
-	command, err := m.buildInstallCommand(args.InstallArguments, manifestPath)
+func (m *Mixin) buildExecuteCommand(args ExecuteInstruction, path string, isKustomize bool) ([]string, error) {
+	command, err := m.buildInstallCommand(args.InstallArguments, path, isKustomize)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create upgrade command")
 	}

--- a/pkg/kubernetes/schema/kubernetes.json
+++ b/pkg/kubernetes/schema/kubernetes.json
@@ -21,6 +21,13 @@
                 "minItems": 1
               }
             },
+            "kustomizes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
             "record": {
               "type": "boolean"
             },
@@ -40,8 +47,16 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
+          "allOf": [
+            {
+              "required": [ "description" ]
+            },
+            {
+              "anyOf": [
+                { "required": [ "manifests" ] },
+                { "required": [ "kustomizes" ] }
+              ]
+            }
           ]
         }
       },
@@ -70,6 +85,13 @@
                 "minItems": 1
               }
             },
+            "kustomizes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
             "force": {
               "type": ["boolean","null"]
             },
@@ -106,8 +128,16 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
+          "allOf": [
+            {
+              "required": [ "description" ]
+            },
+            {
+              "anyOf": [
+                { "required": [ "manifests" ] },
+                { "required": [ "kustomizes" ] }
+              ]
+            }
           ]
         }
       },
@@ -136,6 +166,13 @@
                 "minItems": 1
               }
             },
+            "kustomizes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
             "force": {
               "type": ["boolean","null"]
             },
@@ -172,8 +209,16 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
+          "allOf": [
+            {
+              "required": [ "description" ]
+            },
+            {
+              "anyOf": [
+                { "required": [ "manifests" ] },
+                { "required": [ "kustomizes" ] }
+              ]
+            }
           ]
         }
       },
@@ -202,6 +247,13 @@
                 "minItems": 1
               }
             },
+            "kustomizes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
             "force": {
               "type": ["boolean","null"]
             },
@@ -220,8 +272,16 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
+          "allOf": [
+            {
+              "required": [ "description" ]
+            },
+            {
+              "anyOf": [
+                { "required": [ "manifests" ] },
+                { "required": [ "kustomizes" ] }
+              ]
+            }
           ]
         }
       },

--- a/pkg/kubernetes/schema_test.go
+++ b/pkg/kubernetes/schema_test.go
@@ -36,12 +36,17 @@ func TestMixin_ValidatePayload(t *testing.T) {
 		error string
 	}{
 		{"install", "testdata/install-input.yaml", true, ""},
+		{"install", "testdata/install-input-manifests-and-kustomizes.yaml", true, ""},
+		{"install", "testdata/install-input-only-kustomizes.yaml", true, ""},
 		{"upgrade", "testdata/upgrade-input.yaml", true, ""},
 		{"invoke", "testdata/invoke-input.yaml", true, ""},
 		{"uninstall", "testdata/uninstall-input.yaml", true, ""},
+		{"uninstall", "testdata/uninstall-input-only-kustomizes.yaml", true, ""},
+		{"uninstall", "testdata/uninstall-input-manifests-and-kustomizes.yaml", true, ""},
 		{"install-bad-wait-flag", "testdata/install-input-bad-wait-flag.yaml", false, "install.0.kubernetes.wait: Invalid type. Expected: boolean, given: string"},
 		{"install-no-manifests", "testdata/install-input-no-manifests.yaml", false, "install.0.kubernetes: manifests is required"},
 		{"install-bad-outputs", "testdata/install-input-bad-outputs.yaml", false, "install.0.kubernetes.outputs.0: resourceType is required\n\t* install.0.kubernetes.outputs.0: resourceName is required\n\t* install.0.kubernetes.outputs.0: jsonPath is required"},
+		{"install-input-no-description", "testdata/install-input-no-description.yaml", false, "install.0.kubernetes: description is required"},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/kubernetes/testdata/install-input-manifests-and-kustomizes.yaml
+++ b/pkg/kubernetes/testdata/install-input-manifests-and-kustomizes.yaml
@@ -1,0 +1,10 @@
+install:
+  - kubernetes:
+      description: "Install foo and bar App"
+      manifests:
+        - /cnab/app/manifests/foo
+        - /cnab/app/manifests/bar
+      kustomizes:
+        - /cnab/app/kustomizes/foo1
+        - /cnab/app/kustomizes/bar1
+      wait: true

--- a/pkg/kubernetes/testdata/install-input-no-description.yaml
+++ b/pkg/kubernetes/testdata/install-input-no-description.yaml
@@ -1,0 +1,5 @@
+install:
+  - kubernetes:
+      manifests:
+        - /cnab/app/manifests/hello
+      wait: true

--- a/pkg/kubernetes/testdata/install-input-only-kustomizes.yaml
+++ b/pkg/kubernetes/testdata/install-input-only-kustomizes.yaml
@@ -1,0 +1,7 @@
+install:
+  - kubernetes:
+      description: "Install foo and bar App"
+      kustomizes:
+        - /cnab/app/kustomizes/foo
+        - /cnab/app/kustomizes/bar
+      wait: true

--- a/pkg/kubernetes/testdata/uninstall-input-manifests-and-kustomizes.yaml
+++ b/pkg/kubernetes/testdata/uninstall-input-manifests-and-kustomizes.yaml
@@ -1,0 +1,10 @@
+uninstall:
+  - kubernetes:
+      description: "Install foo and bar App"
+      manifests:
+        - /cnab/app/manifests/foo
+        - /cnab/app/manifests/bar
+      kustomizes:
+        - /cnab/app/kustomizes/foo1
+        - /cnab/app/kustomizes/bar1
+      wait: true

--- a/pkg/kubernetes/testdata/uninstall-input-only-kustomizes.yaml
+++ b/pkg/kubernetes/testdata/uninstall-input-only-kustomizes.yaml
@@ -1,0 +1,7 @@
+uninstall:
+  - kubernetes:
+      description: "Unnstall foo and bar App"
+      kustomizes:
+        - /cnab/app/kustomizes/foo
+        - /cnab/app/kustomizes/bar
+      wait: true


### PR DESCRIPTION
## What does this change
Kubernetes mixin add kustomize support，so we can use porter in CI/CD or other various scenes.

## What issue does it fix
N/A

## Notes for the reviewer
The command line of kubectl add -k flag, and the mixin definition can use k8s manifest and kustomize both for deploy complex environment

## Checklist
