### PR TITLE
Temporarily disable parameter defaults for deps

### DIFF
--- a/docs/content/dependencies.md
+++ b/docs/content/dependencies.md
@@ -41,6 +41,9 @@ dependencies:
       mysql_user: wordpress
 ```
 
+There is a bug with defaulting parameters from the manifest right now so it's turned off but we plan on adding that back soon.
+Watch [#800](https://github.com/deislabs/porter/issues/800) for when it's available again.
+
 ## Specifying parameters
 
 You can specifying parameters for a dependent bundle on the command-line using the following syntax

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -17,7 +17,8 @@ import (
 
 type dependencyExecutioner struct {
 	*context.Context
-	Manifest        *manifest.Manifest
+	// See https://github.com/deislabs/porter/issues/799
+	// Manifest        *manifest.Manifest
 	Resolver        BundleResolver
 	CNAB            CNABProvider
 	InstanceStorage instancestorage.StorageProvider
@@ -34,8 +35,9 @@ func newDependencyExecutioner(p *Porter) *dependencyExecutioner {
 		Registry: p.Registry,
 	}
 	return &dependencyExecutioner{
-		Context:         p.Context,
-		Manifest:        p.Manifest,
+		Context: p.Context,
+		// See https://github.com/deislabs/porter/issues/799
+		// Manifest:        p.Manifest,
 		Resolver:        resolver,
 		CNAB:            p.CNAB,
 		InstanceStorage: p.InstanceStorage,
@@ -190,6 +192,8 @@ func (e *dependencyExecutioner) prepareDependency(dep *queuedDependency) error {
 	//   DEP:
 	//     parameters:
 	//       PARAM: VALUE
+	/* Disabling this until we have access to the manifest when working with a bundle from a tag
+	   See https://github.com/deislabs/porter/issues/799
 	for paramName, value := range e.Manifest.Dependencies[dep.Alias].Parameters {
 		// Make sure the parameter is defined in the bundle
 		if _, ok := depParams[paramName]; !ok {
@@ -201,6 +205,7 @@ func (e *dependencyExecutioner) prepareDependency(dep *queuedDependency) error {
 		}
 		dep.Parameters[paramName] = value
 	}
+	*/
 
 	// Handle any parameter overrides for the dependency defined on the command line
 	// --param DEP#PARAM=VALUE

--- a/tests/dependencies_test.go
+++ b/tests/dependencies_test.go
@@ -65,6 +65,8 @@ func installWordpressBundle(p *porter.TestPorter) (namespace string) {
 		"namespace=" + namespace,
 		"wordpress-name=porter-ci-wordpress-" + namespace,
 		"mysql#mysql-name=porter-ci-mysql-" + namespace,
+		// TODO: Remove this once we put back in dependency parameter defaults in #800
+		"mysql#mysql-user=wordpress",
 	}
 	err := installOpts.Validate([]string{}, p.Context)
 	require.NoError(p.T(), err, "validation of install opts for root bundle failed")
@@ -113,6 +115,8 @@ func upgradeWordpressBundle(p *porter.TestPorter, namespace string) {
 		"namespace=" + namespace,
 		"wordpress-name=porter-ci-wordpress-" + namespace,
 		"mysql#mysql-name=porter-ci-mysql-" + namespace,
+		// TODO: Remove this once we put back in dependency parameter defaults in #800
+		"mysql#mysql-user=wordpress",
 	}
 	err := upgradeOpts.Validate([]string{}, p.Context)
 	require.NoError(p.T(), err, "validation of upgrade opts for root bundle failed")
@@ -141,6 +145,8 @@ func invokeWordpressBundle(p *porter.TestPorter, namespace string) {
 		"namespace=" + namespace,
 		"wordpress-name=porter-ci-wordpress-" + namespace,
 		"mysql#mysql-name=porter-ci-mysql-" + namespace,
+		// TODO: Remove this once we put back in dependency parameter defaults in #800
+		"mysql#mysql-user=wordpress",
 	}
 	err := invokeOpts.Validate([]string{}, p.Context)
 	require.NoError(p.T(), err, "validation of invoke opts for root bundle failed")
@@ -169,6 +175,8 @@ func uninstallWordpressBundle(p *porter.TestPorter, namespace string) {
 		"namespace=" + namespace,
 		"wordpress-name=porter-ci-wordpress-" + namespace,
 		"mysql#mysql-name=porter-ci-mysql-" + namespace,
+		// TODO: Remove this once we put back in dependency parameter defaults in #800
+		"mysql#mysql-user=wordpress",
 	}
 	err := uninstallOptions.Validate([]string{}, p.Context)
 	require.NoError(p.T(), err, "validation of uninstall opts for root bundle failed")


### PR DESCRIPTION
# What does this change
Until we have access to the manifest consistently across both file based installs and tag based, stop accessing the manifest when installing dependencies since it's not available for tag based installs from the porter client.

# What issue does it fix
Closes #799

# Notes for the reviewer
This is a temporary fix to avoid the panic. I want the defaulting functionality so will come back and figure out a way to get access to the data in the manifest and put this back in place.

See #800 to turn the feature back on and #801 to figure out how.

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
