### PR TITLE
List which registries are compatible

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -269,6 +269,12 @@ defaultContentLanguage = "en"
     url = "/archive-bundles"
     weight = 313
     parent = "distribute-bundles"
+  [[menu.main]]
+    name = "Compatible Registries"
+    identifier = "compatible-registries"
+    url = "/compatible-registries/"
+    weight = 314
+    parent = "distribute-bundles"
 
 [[menu.main]]
   name = "Examine Bundles"

--- a/docs/content/compatible-registries.md
+++ b/docs/content/compatible-registries.md
@@ -9,7 +9,7 @@ tested a bunch of registries for compatibility with CNAB and so far here is what
 we have found.
 
 There is an explicit verification using Porter because we use specific libraries,
-such as cnab-to-oci, and this helps us communicate confidently that we've tested
+such as [cnab-to-oci], and this helps us communicate confidently that we've tested
 out a particular registry and know that it will work for you.
 
 | Registry | CNAB Compatible | Porter Verified |
@@ -25,4 +25,6 @@ out a particular registry and know that it will work for you.
  
  _If you are a registry or user and know that this page is out of date, [please
  let us know!](https://github.com/deislabs/porter/issues/new)_
+ 
+ [cnab-to-oci]: https://github.com/docker/cnab-to-oci
  

--- a/docs/content/compatible-registries.md
+++ b/docs/content/compatible-registries.md
@@ -1,0 +1,28 @@
+---
+title: Compatible Registries
+description: Understanding which OCI registries work with CNAB 
+---
+
+Cloud Native Application Bundles are very new, and support for storing anything
+other than container images in a registry is inconsistent. The community has
+tested a bunch of registries for compatibility with CNAB and so far here is what
+we have found.
+
+There is an explicit verification using Porter because we use specific libraries,
+such as cnab-to-oci, and this helps us communicate confidently that we've tested
+out a particular registry and know that it will work for you.
+
+| Registry | CNAB Compatible | Porter Verified |
+| -------- | --------------- | ------------- |
+| ACR | Yes | Yes |
+| Artifactory | No |  |
+| Docker Hub | Yes | Yes |
+| Digital Ocean |  | |
+| ECR | No |  |
+| GCR | Yes |  |
+| Nexus | No |  |
+| Quay | No | No
+ 
+ _If you are a registry or user and know that this page is out of date, [please
+ let us know!](https://github.com/deislabs/porter/issues/new)_
+ 


### PR DESCRIPTION
# What does this change
Document which registries are compatible with CNAB and which ones have been explicitly tested with porter.

Preview at https://deploy-preview-811--porter.netlify.com/compatible-registries/

# What issue does it fix
Part of #809 

# Notes for the reviewer
This is a bit of an ongoing issue that we will need to keep working on. I've documented what we know so far, but we should test porter with the others and figure out why it doesn't work with some, like quay, and make sure it's not something we can change on our end.

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
