### PR TITLE
Publish Docker images during CI

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,5 +1,8 @@
 These are assets used by the CI build.
 
+* testdata - test data used for the integration tests, such as credentials and test bundles.
+* images - source for any docker images that we publish. 
+
 ## Azure Pipelines
 
 Our pipeline is broken into a few discrete builds so that we can control how and when they are triggered:

--- a/build/images/README.md
+++ b/build/images/README.md
@@ -1,0 +1,11 @@
+# Porter Docker Images
+
+* client - This provides the porter client installed in a container. See the 
+  [Porter Client Docker Image][client] documentation for examples of how to 
+  use it.
+* workshop - This is a container suitable for teaching a workshop on Porter. See
+  the [Porter Workshop Docker Image][workshop] documentation for examples of 
+  how to use it.
+
+[client]: https://porter.sh/docker-images/client/
+[workshop]: https://porter.sh/docker-images/workshop/

--- a/build/images/client/Dockerfile
+++ b/build/images/client/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3
+
+ARG PERMALINK
+
+RUN apk add curl --no-cache
+RUN sh -c 'curl https://cdn.deislabs.io/porter/${PERMALINK}/install-linux.sh | sh' && \
+    ln -s /root/.porter/porter /usr/local/bin/porter
+
+ENTRYPOINT ["/root/.porter/porter"]

--- a/build/images/workshop/Dockerfile
+++ b/build/images/workshop/Dockerfile
@@ -1,0 +1,21 @@
+FROM docker:dind
+
+ARG PERMALINK
+ENV HELM_VER 2.16.1
+
+RUN apk add bash \
+            git \
+            curl \
+            bash-completion \
+            jq \
+            ca-certificates && \
+    curl https://cdn.deislabs.io/porter/${PERMALINK}/install-linux.sh | bash && \
+    ln -s /root/.porter/porter /usr/local/bin/porter && \
+    curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
+    tar -xzf helm.tgz && \
+    mv linux-amd64/helm /usr/local/bin && \
+    rm helm.tgz && \
+    helm init --client-only && \
+    mkdir -p /workshop
+
+WORKDIR /workshop

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -381,8 +381,15 @@ defaultContentLanguage = "en"
     weight = 1010
     parent = "references"
   [[menu.main]]
+    name = "Docker Images"
+    url = "/docker-images/"
+    identifer = "docker-images"
+    weight = 1011
+    parent = "references"
+  [[menu.main]]
     name = "CNAB Spec"
     url = "https://deislabs.io/cnab"
     identifier = "cnab"
     weight = 1020
     parent = "references"
+

--- a/docs/content/docker-images/_index.md
+++ b/docs/content/docker-images/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Docker Images
-description: Listing of available docker images of the Porter client
+description: Listing of available Docker images of the Porter client
 ---
 
-We publish docker images based on our Porter releases that may be helpful to
+We publish Docker images based on our Porter releases that may be helpful to
 you for your CI pipelines and in other situations where you can't install Porter
 locally, such as workshops.

--- a/docs/content/docker-images/_index.md
+++ b/docs/content/docker-images/_index.md
@@ -1,0 +1,8 @@
+---
+title: Docker Images
+description: Listing of available docker images of the Porter client
+---
+
+We publish docker images based on our Porter releases that may be helpful to
+you for your CI pipelines and in other situations where you can't install Porter
+locally, such as workshops.

--- a/docs/content/docker-images/client.md
+++ b/docs/content/docker-images/client.md
@@ -1,9 +1,9 @@
 ---
 title: Porter Client Docker Image
-description: How to use the getporter/porter docker image
+description: How to use the getporter/porter Docker image
 ---
 
-The [getporter/porter][porter] docker image provides the porter client installed in a
+The [getporter/porter][porter] Docker image provides the Porter client installed in a
 container.
 
 It has tags that match what is available from our [install](/install/) page:
@@ -11,17 +11,17 @@ It has tags that match what is available from our [install](/install/) page:
 
 **Notes**
 
-* The docker socket must be mounted to the container in order to execute a
+* The Docker socket must be mounted to the container in order to execute a
   bundle, using `-v /var/run/docker.sock:/var/run/docker.sock`.
 * The `ENTRYPOINT` is set to `porter`, to change that you can use 
   `--entrypoint`, for example `docker run --rm -it --entrypoint /bin/sh porter`. 
-* Don't mount the entire porter home directory, because that's where the porter
+* Don't mount the entire Porter home directory, because that's where the porter
   binary is located, instead mount individual directories such as claims or
   credentials underneath it. Otherwise you will get an error like 
   `exec user process caused "exec format error"`.
 
 ## Examples
-Here are some examples of how to use the porter client docker image.
+Here are some examples of how to use the Porter client Docker image.
 
 ### Create
 ```
@@ -34,10 +34,10 @@ docker run -it --rm \
 
 Breaking down the command, here's what it just did:
 
-* Mount the docker socket
-* Mount a location from our local machine so that we can persist our bundle's files
-* Set the working directory to the bundle directory
-* Run the `porter create` command
+* Mount the Docker socket.
+* Mount a location from our local machine so that we can persist our bundle's files.
+* Set the working directory to the bundle directory.
+* Run the `porter create` command.
 
 After this executes, you should be able to see the bundles files:
 
@@ -74,7 +74,7 @@ execution completed successfully!
 ```
 
 ### List
-We can also ist our installed bundles with their status:
+We can also list our installed bundles with their status:
 
 ```
 $ docker run -it --rm \

--- a/docs/content/docker-images/client.md
+++ b/docs/content/docker-images/client.md
@@ -1,0 +1,89 @@
+---
+title: Porter Client Docker Image
+description: How to use the getporter/porter docker image
+---
+
+The [getporter/porter][porter] docker image provides the porter client installed in a
+container.
+
+It has tags that match what is available from our [install](/install/) page:
+`latest`, `canary` and specific versions such as `v0.20.0-beta.1`.
+
+**Notes**
+
+* The docker socket must be mounted to the container in order to execute a
+  bundle, using `-v /var/run/docker.sock:/var/run/docker.sock`.
+* The `ENTRYPOINT` is set to `porter`, to change that you can use 
+  `--entrypoint`, for example `docker run --rm -it --entrypoint /bin/sh porter`. 
+* Don't mount the entire porter home directory, because that's where the porter
+  binary is located, instead mount individual directories such as claims or
+  credentials underneath it. Otherwise you will get an error like 
+  `exec user process caused "exec format error"`.
+
+## Examples
+Here are some examples of how to use the porter client docker image.
+
+### Create
+```
+docker run -it --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v `pwd`/hello:/tmp/hello \
+    -w /tmp/hello \
+    getporter/porter create
+```
+
+Breaking down the command, here's what it just did:
+
+* Mount the docker socket
+* Mount a location from our local machine so that we can persist our bundle's files
+* Set the working directory to the bundle directory
+* Run the `porter create` command
+
+After this executes, you should be able to see the bundles files:
+
+```
+$ ls hello/
+Dockerfile  Dockerfile.tmpl  README.md	porter.yaml
+```
+
+### Publish
+Now let's publish the bundle to an OCI registry:
+
+```
+docker run -it --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v `pwd`/hello:/tmp/hello \
+    -w /tmp/hello \
+    getporter/porter publish
+```
+
+### Install
+Finally let's install a bundle:
+
+```
+$ docker run -it --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $HOME/.porter/claims:/root/.porter/claims \
+    getporter/porter install -t getporter/hello:0.1.0
+
+installing hello...
+executing install action from hello (bundle instance: hello)
+Install Hello World
+Hello World
+execution completed successfully!
+```
+
+### List
+We can also ist our installed bundles with their status:
+
+```
+$ docker run -it --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $HOME/.porter/claims:/root/.porter/claims \
+    getporter/porter list
+
+NAME      CREATED         MODIFIED        LAST ACTION   LAST STATUS
+hello     2 minutes ago   2 minutes ago   install       success
+```
+
+[porter]: https://hub.docker.com/r/getporter/porter/tags

--- a/docs/content/docker-images/workshop.md
+++ b/docs/content/docker-images/workshop.md
@@ -1,0 +1,31 @@
+---
+title: Porter Workshop Docker Image
+description: How to use the getporter/workshop docker image
+---
+
+The [getporter/workshop][workshop] docker image provides the porter client installed in a
+container that has Docker in Docker. It is suitable for workshops because
+participants don't need to figure out their various docker setups since they will
+use the docker host inside the container.
+
+It has tags that match what is available from our [install](/install/) page:
+`latest`, `canary` and specific versions such as `v0.20.0-beta.1`.
+
+## Start the workshop container
+```
+docker run -d --privileged --name workshop getporter/workshop
+```
+
+## Log into the workshop container
+```
+docker exec -it workshop sh
+```
+
+For the rest of the workshop, participants will execute commands from inside
+the workshop container. 
+
+**Notes**
+
+You cannot mount volumes into the workshop container from your local computer.
+
+[workshop]: https://hub.docker.com/r/getporter/workshop/tags

--- a/docs/content/docker-images/workshop.md
+++ b/docs/content/docker-images/workshop.md
@@ -1,12 +1,12 @@
 ---
 title: Porter Workshop Docker Image
-description: How to use the getporter/workshop docker image
+description: How to use the getporter/workshop Docker image
 ---
 
-The [getporter/workshop][workshop] docker image provides the porter client installed in a
-container that has Docker in Docker. It is suitable for workshops because
-participants don't need to figure out their various docker setups since they will
-use the docker host inside the container.
+The [getporter/workshop][workshop] Docker image provides the Porter client installed in a
+container that has Docker-in-Docker. It is suitable for workshops because
+participants don't need to figure out their various Docker setups since they will
+use the Docker host inside the container.
 
 It has tags that match what is available from our [install](/install/) page:
 `latest`, `canary` and specific versions such as `v0.20.0-beta.1`.
@@ -26,6 +26,8 @@ the workshop container.
 
 **Notes**
 
-You cannot mount volumes into the workshop container from your local computer.
+You cannot mount volumes to arbitrary points into the workshop container from
+your local computer because the image is based on the [docker:dind] image, see
+[Where to Store Data](https://hub.docker.com/_/docker) for more information.
 
 [workshop]: https://hub.docker.com/r/getporter/workshop/tags

--- a/scripts/publish-images.sh
+++ b/scripts/publish-images.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PERMALINK and VERSION must be set before calling this script
+# It is intended to only be executed by make publish
+
+if [[ "$PERMALINK" == "latest" ]]; then
+  docker build --build-arg PERMALINK=$VERSION -t getporter/porter:$VERSION build/images/client
+  docker build --build-arg PERMALINK=$VERSION -t getporter/workshop:$VERSION build/images/workshop
+
+  docker tag getporter/porter:$VERSION getporter/porter:$PERMALINK
+  docker tag getporter/workshop:$VERSION getporter/workshop:$PERMALINK
+
+  docker push getporter/porter:$VERSION
+  docker push getporter/workshop:$VERSION
+  docker push getporter/porter:$PERMALINK
+  docker push getporter/workshop:$PERMALINK
+else
+  docker build --build-arg PERMALINK=$PERMALINK -t getporter/porter:$PERMALINK build/images/client
+  docker build --build-arg PERMALINK=$PERMALINK -t getporter/workshop:$PERMALINK build/images/workshop
+
+  docker push getporter/porter:$PERMALINK
+  docker push getporter/workshop:$PERMALINK
+fi


### PR DESCRIPTION
# What does this change
When we cut releases of porter, publish docker images of the porter client and also of our workshop docker image for people to use as well.

Preview at https://deploy-preview-812--porter.netlify.com/docker-images/

The makefile changes are only executed on releases but I did a manual publish so that you can run through the docs to see what the images look like. We publish `latest`, `canary` and `VERSION`.

# What issue does it fix
None, just something that came up in slack.

# Notes for the reviewer
🦃

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
