### PR TITLE
Do docker login before push docker images on release

### DIFF
--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -101,6 +101,13 @@ stages:
       workingDirectory: '$(MODULE_PATH)'
       displayName: 'Cross Compile'
 
+    - task: Docker@1
+      displayName: Docker Login
+      inputs:
+        containerRegistryType: Container Registry
+        dockerRegistryEndpoint: deislabs-registry
+        command: login
+
     - script: |
         export AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING)
         make publish


### PR DESCRIPTION
When I added `publish-images` to the `publish` target, I forgot to ensure that we were logged into docker on the CI server so the master release build has been failing for a bit.
