### PR TITLE
fix(pkg/cnab): be sure output path uses unix conventions

### DIFF
--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -2,7 +2,7 @@ package configadapter
 
 import (
 	"fmt"
-	"path/filepath"
+	unix_path "path"
 	"strings"
 
 	"get.porter.sh/porter/pkg/cnab/extensions"
@@ -182,7 +182,7 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 				Definition:  output.Name,
 				Description: output.Description,
 				ApplyTo:     output.ApplyTo,
-				Path:        filepath.Join(config.BundleOutputsDir, output.Name),
+				Path:        unix_path.Join(config.BundleOutputsDir, output.Name),
 			}
 
 			if output.Sensitive {

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -2,7 +2,7 @@ package configadapter
 
 import (
 	"fmt"
-	unix_path "path"
+	"path"
 	"strings"
 
 	"get.porter.sh/porter/pkg/cnab/extensions"
@@ -182,7 +182,9 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 				Definition:  output.Name,
 				Description: output.Description,
 				ApplyTo:     output.ApplyTo,
-				Path:        unix_path.Join(config.BundleOutputsDir, output.Name),
+				// must be a standard Unix path as this will be inside of the container
+				// (only linux containers supported currently)
+				Path: path.Join(config.BundleOutputsDir, output.Name),
 			}
 
 			if output.Sensitive {


### PR DESCRIPTION
# What does this change
Set the output path using Unix path conventions.

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/761

# Notes for the reviewer
I'm still trying to get a Windows VM set up for testing.  If a Windows user is able to test, this would be very helpful!

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
