### PR TITLE
fix(outputs.go): set displayOutput.Value

### DIFF
--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -83,16 +83,15 @@ func (p *Porter) ShowBundleOutput(opts *OutputShowOptions) error {
 }
 
 type DisplayOutput struct {
-	Name         string
-	Definition   definition.Schema
-	Value        interface{}
-	DisplayValue string
-	Type         string
+	Name       string
+	Definition definition.Schema
+	Value      string
+	Type       string
 }
 
 // ListBundleOutputs lists the outputs for a given bundle,
-// according to the provided options
-func (p *Porter) ListBundleOutputs(c claim.Claim) []DisplayOutput {
+// according to the provided claim and display format
+func (p *Porter) ListBundleOutputs(c claim.Claim, format printer.Format) []DisplayOutput {
 	// Get sorted keys for ordered printing
 	keys := make([]string, 0, len(c.Outputs))
 	for k := range c.Outputs {
@@ -145,7 +144,10 @@ func (p *Porter) ListBundleOutputs(c claim.Claim) []DisplayOutput {
 			do.Type = "file"
 		}
 
-		do.DisplayValue = truncateString(valueStr, 60)
+		// If table output is desired, truncate the value to a reasonable length
+		if format == printer.FormatTable {
+			do.Value = truncateString(valueStr, 60)
+		}
 
 		outputs = append(outputs, do)
 	}
@@ -164,7 +166,7 @@ func (p *Porter) PrintBundleOutputs(opts *OutputListOptions) error {
 		return err
 	}
 
-	outputs := p.ListBundleOutputs(c)
+	outputs := p.ListBundleOutputs(c, opts.Format)
 	if err != nil {
 		return err
 	}
@@ -207,7 +209,7 @@ func (p *Porter) printOutputsTable(outputs []DisplayOutput) error {
 	// Print the outputs table
 	table.SetHeader([]string{"Name", "Type", "Value"})
 	for _, output := range outputs {
-		table.Append([]string{output.Name, output.Type, output.DisplayValue})
+		table.Append([]string{output.Name, output.Type, output.Value})
 	}
 	table.Render()
 

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -108,6 +108,7 @@ func (p *Porter) ListBundleOutputs(c claim.Claim) []DisplayOutput {
 
 		var outputType string
 		valueStr := fmt.Sprintf("%v", c.Outputs[name])
+		do.Value = valueStr
 
 		if c.Bundle == nil {
 			continue

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -2,7 +2,12 @@ package porter
 
 import (
 	"testing"
+	"time"
 
+	"get.porter.sh/porter/pkg/printer"
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/bundle/definition"
+	"github.com/deislabs/cnab-go/claim"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +29,88 @@ func TestPorter_printOutputsTable(t *testing.T) {
 	}
 	err := p.printOutputsTable(outputs)
 	require.NoError(t, err)
+
+	got := p.TestConfig.TestContext.GetOutput()
+	require.Equal(t, want, got)
+}
+
+func TestPorter_printDisplayOutput_JSON(t *testing.T) {
+	p := NewTestPorter(t)
+	p.TestConfig.SetupPorterHome()
+	p.CNAB = NewTestCNABProvider()
+
+	// Create test claim
+	writeOnly := true
+	claim := claim.Claim{
+		Name: "test-bundle",
+		Bundle: &bundle.Bundle{
+			Definitions: definition.Definitions{
+				"foo": &definition.Schema{
+					Type:      "string",
+					WriteOnly: &writeOnly,
+				},
+				"bar": &definition.Schema{
+					Type: "string",
+				},
+			},
+			Outputs: map[string]bundle.Output{
+				"foo": {
+					Definition: "foo",
+					Path:       "/path/to/foo",
+				},
+				"bar": {
+					Definition: "bar",
+				},
+			},
+		},
+		Created:  time.Date(1983, time.April, 18, 1, 2, 3, 4, time.UTC),
+		Modified: time.Date(1983, time.April, 18, 1, 2, 3, 4, time.UTC),
+		Result: claim.Result{
+			Action: "install",
+			Status: "success",
+		},
+		Outputs: map[string]interface{}{
+			"foo": "foo-output",
+			"bar": "bar-output",
+		},
+	}
+
+	err := p.InstanceStorage.Store(claim)
+	require.NoError(t, err, "could not store claim")
+
+	opts := OutputListOptions{
+		sharedOptions: sharedOptions{
+			Name: "test-bundle",
+		},
+		PrintOptions: printer.PrintOptions{
+			Format: printer.FormatJson,
+		},
+	}
+	err = p.PrintBundleOutputs(&opts)
+	require.NoError(t, err, "could not print bundle outputs")
+
+	want := `[
+  {
+    "Name": "bar",
+    "Definition": {
+      "type": "string"
+    },
+    "Value": "bar-output",
+    "DisplayValue": "bar-output",
+    "Type": "string"
+  },
+  {
+    "Name": "foo",
+    "Definition": {
+      "type": "string",
+      "writeOnly": true
+    },
+    "Value": "foo-output",
+    "DisplayValue": "/path/to/foo",
+    "Type": "string"
+  }
+]
+`
 
 	got := p.TestConfig.TestContext.GetOutput()
 	require.Equal(t, want, got)

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -68,7 +68,7 @@ func (p *Porter) ShowInstances(opts ShowOptions) error {
 			fmt.Fprintln(p.Out)
 			fmt.Fprint(p.Out, "Outputs:\n")
 
-			outputs := p.ListBundleOutputs(c)
+			outputs := p.ListBundleOutputs(c, opts.Format)
 			return p.printOutputsTable(outputs)
 		}
 		return nil

--- a/tests/outputs_test.go
+++ b/tests/outputs_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"get.porter.sh/porter/pkg/porter"
+	"get.porter.sh/porter/pkg/printer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,7 @@ func TestExecOutputs(t *testing.T) {
 	// Verify that its bundle level file output was captured
 	c, err := p.InstanceStorage.Read(p.Manifest.Name)
 	require.NoError(t, err, "could not read claim")
-	outputs := p.ListBundleOutputs(c)
+	outputs := p.ListBundleOutputs(c, printer.FormatJSON)
 	var kubeconfigOutput *porter.DisplayOutput
 	for _, o := range outputs {
 		if o.Name == "kubeconfig" {

--- a/tests/outputs_test.go
+++ b/tests/outputs_test.go
@@ -31,7 +31,7 @@ func TestExecOutputs(t *testing.T) {
 	// Verify that its bundle level file output was captured
 	c, err := p.InstanceStorage.Read(p.Manifest.Name)
 	require.NoError(t, err, "could not read claim")
-	outputs := p.ListBundleOutputs(c, printer.FormatJSON)
+	outputs := p.ListBundleOutputs(c, printer.FormatJson)
 	var kubeconfigOutput *porter.DisplayOutput
 	for _, o := range outputs {
 		if o.Name == "kubeconfig" {
@@ -41,7 +41,7 @@ func TestExecOutputs(t *testing.T) {
 	}
 	require.NotNil(t, kubeconfigOutput, "could not find kubeconfig output")
 	assert.Equal(t, "file", kubeconfigOutput.Type)
-	assert.Contains(t, kubeconfigOutput.DisplayValue, "apiVersion")
+	assert.Contains(t, kubeconfigOutput.Value, "apiVersion")
 
 	invokeExecOutputsBundle(p, "status")
 


### PR DESCRIPTION
# What does this change
Sets the `Value` field of the `DisplayOutput` object.

Previously, the displayed output in json or yaml would show:
```
 $ p instance outputs list basic-tf-example -o yaml
- name: a
  definition:
    type: string
  value: null
  displayvalue: |
    a
  type: string
```

Whereas now it will show:
```
 $ p instance outputs list basic-tf-example -o yaml
- name: a
  definition:
    type: string
  value: |
    a
  displayvalue: |
    a
  type: string
```

# What issue does it fix
Closes # _(issue)_

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
