### PR TITLE
Standardize default and template dockerfiles

### DIFF
--- a/pkg/build/dockerfile-generater.go
+++ b/pkg/build/dockerfile-generater.go
@@ -151,8 +151,9 @@ func (g *DockerfileGenerator) buildPorterSection() []string {
 
 func (g *DockerfileGenerator) buildCNABSection() []string {
 	return []string{
-		`COPY .cnab /cnab`,
+		// Putting RUN before COPY here as a workaround for https://github.com/moby/moby/issues/37965, back to back COPY statements in the same directory (e.g. /cnab) _may_ result in an error from Docker depending on unpredictable factors
 		`RUN rm -fr $BUNDLE_DIR/.cnab`,
+		`COPY .cnab /cnab`,
 	}
 }
 

--- a/pkg/build/dockerfile-generater.go
+++ b/pkg/build/dockerfile-generater.go
@@ -73,12 +73,8 @@ func (g *DockerfileGenerator) buildDockerfile() ([]string, error) {
 		lines = append(pretoken, append(mixinLines, posttoken...)...)
 	}
 
-	// The template dockerfile copies everything by default, but if the user
-	// supplied their own, copy over cnab/ and porter.yaml
-	if g.Manifest.Dockerfile != "" {
-		lines = append(lines, g.buildCNABSection()...)
-		lines = append(lines, g.buildPorterSection()...)
-	}
+	lines = append(lines, g.buildCNABSection()...)
+	lines = append(lines, g.buildPorterSection()...)
 	lines = append(lines, g.buildWORKDIRSection())
 	lines = append(lines, g.buildCMDSection())
 
@@ -155,7 +151,8 @@ func (g *DockerfileGenerator) buildPorterSection() []string {
 
 func (g *DockerfileGenerator) buildCNABSection() []string {
 	return []string{
-		`COPY .cnab/ /cnab/`,
+		`COPY .cnab /cnab`,
+		`RUN rm -fr $BUNDLE_DIR/.cnab`,
 	}
 }
 

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -38,9 +38,10 @@ func TestPorter_buildDockerfile(t *testing.T) {
 		"RUN apt-get update && apt-get install -y ca-certificates",
 		"",
 		"",
-		"COPY .cnab /cnab",
 		"COPY . $BUNDLE_DIR",
+		"COPY .cnab /cnab",
 		"RUN rm -fr $BUNDLE_DIR/.cnab",
+		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 		"WORKDIR $BUNDLE_DIR",
 		"CMD [\"/cnab/app/run\"]",
 	}
@@ -106,7 +107,8 @@ COPY mybin /cnab/app/
 			"ARG BUNDLE_DIR",
 			"COPY mybin /cnab/app/",
 			"",
-			"COPY .cnab/ /cnab/",
+			"COPY .cnab /cnab",
+			"RUN rm -fr $BUNDLE_DIR/.cnab",
 			"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 			"WORKDIR $BUNDLE_DIR",
 			"CMD [\"/cnab/app/run\"]",
@@ -142,9 +144,10 @@ ARG BUNDLE_DIR
 RUN apt-get update && apt-get install -y ca-certificates
 
 
-COPY .cnab /cnab
 COPY . $BUNDLE_DIR
+COPY .cnab /cnab
 RUN rm -fr $BUNDLE_DIR/.cnab
+COPY porter.yaml $BUNDLE_DIR/porter.yaml
 WORKDIR $BUNDLE_DIR
 CMD ["/cnab/app/run"]
 `
@@ -274,7 +277,8 @@ COPY mybin /cnab/app/
 		"",
 		"ARG BUNDLE_DIR",
 		"COPY mybin /cnab/app/",
-		"COPY .cnab/ /cnab/",
+		"COPY .cnab /cnab",
+		"RUN rm -fr $BUNDLE_DIR/.cnab",
 		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 		"WORKDIR $BUNDLE_DIR",
 		"CMD [\"/cnab/app/run\"]",
@@ -314,7 +318,8 @@ COPY mybin /cnab/app/
 		"COPY mybin /cnab/app/",
 		"# exec mixin has no buildtime dependencies",
 		"",
-		"COPY .cnab/ /cnab/",
+		"COPY .cnab /cnab",
+		"RUN rm -fr $BUNDLE_DIR/.cnab",
 		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 		"WORKDIR $BUNDLE_DIR",
 

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -39,8 +39,8 @@ func TestPorter_buildDockerfile(t *testing.T) {
 		"",
 		"",
 		"COPY . $BUNDLE_DIR",
-		"COPY .cnab /cnab",
 		"RUN rm -fr $BUNDLE_DIR/.cnab",
+		"COPY .cnab /cnab",
 		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 		"WORKDIR $BUNDLE_DIR",
 		"CMD [\"/cnab/app/run\"]",
@@ -107,8 +107,8 @@ COPY mybin /cnab/app/
 			"ARG BUNDLE_DIR",
 			"COPY mybin /cnab/app/",
 			"",
-			"COPY .cnab /cnab",
 			"RUN rm -fr $BUNDLE_DIR/.cnab",
+			"COPY .cnab /cnab",
 			"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 			"WORKDIR $BUNDLE_DIR",
 			"CMD [\"/cnab/app/run\"]",
@@ -145,8 +145,8 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 
 COPY . $BUNDLE_DIR
-COPY .cnab /cnab
 RUN rm -fr $BUNDLE_DIR/.cnab
+COPY .cnab /cnab
 COPY porter.yaml $BUNDLE_DIR/porter.yaml
 WORKDIR $BUNDLE_DIR
 CMD ["/cnab/app/run"]
@@ -277,8 +277,8 @@ COPY mybin /cnab/app/
 		"",
 		"ARG BUNDLE_DIR",
 		"COPY mybin /cnab/app/",
-		"COPY .cnab /cnab",
 		"RUN rm -fr $BUNDLE_DIR/.cnab",
+		"COPY .cnab /cnab",
 		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 		"WORKDIR $BUNDLE_DIR",
 		"CMD [\"/cnab/app/run\"]",
@@ -318,8 +318,8 @@ COPY mybin /cnab/app/
 		"COPY mybin /cnab/app/",
 		"# exec mixin has no buildtime dependencies",
 		"",
-		"COPY .cnab /cnab",
 		"RUN rm -fr $BUNDLE_DIR/.cnab",
+		"COPY .cnab /cnab",
 		"COPY porter.yaml $BUNDLE_DIR/porter.yaml",
 		"WORKDIR $BUNDLE_DIR",
 

--- a/pkg/templates/templates/build/Dockerfile
+++ b/pkg/templates/templates/build/Dockerfile
@@ -6,6 +6,4 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 # PORTER_MIXINS
 
-COPY .cnab /cnab
 COPY . $BUNDLE_DIR
-RUN rm -fr $BUNDLE_DIR/.cnab

--- a/pkg/templates/templates/create/Dockerfile.tmpl
+++ b/pkg/templates/templates/create/Dockerfile.tmpl
@@ -1,8 +1,8 @@
-FROM quay.io/deis/lightweight-docker-go:v0.2.0
 FROM debian:stretch
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ARG BUNDLE_DIR
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 # This is a template Dockerfile for the bundle's invocation image
 # You can customize it to use different base images, install tools and copy configuration files.
@@ -18,4 +18,4 @@ ARG BUNDLE_DIR
 # PORTER_MIXINS
 
 # Use the BUNDLE_DIR build argument to copy files into the bundle
-# COPY . $BUNDLE_DIR
+COPY . $BUNDLE_DIR


### PR DESCRIPTION
# What does this change
This standardizes the contents of the default and template Dockerfile generated by Porter. It also has Porter treat both the same, instead of having conditional logic based on if the user has a template or not.

# What issue does it fix
None, I just noticed in another PR, https://github.com/vdice/porter-packer/pull/1/files/c9b3d6ef73a4212ae2fbfb5f267a6e831cbb2885#diff-39844b97085b014640182ce3ec1e1282, that we were still using an old base image that I had thought that I had removed. Turns out the default Dockerfile and the template are using different base images. It's confusing and I wanted to make it easier for us and users to understand what Porter is doing.

# Notes for the reviewer
We don't have to merge this, it's just a suggestion to think about.

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [x] Documentation Not Impacted
