### PR TITLE
feat(*): add logic to resolve/interpolate output values in a Porter manifest

### DIFF
--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -3,10 +3,12 @@ package cnabprovider
 import (
 	"encoding/json"
 
+	"get.porter.sh/porter/pkg/config"
 	"github.com/cnabio/cnab-go/action"
 	"github.com/cnabio/cnab-go/driver"
 	"github.com/docker/cnab-to-oci/relocation"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 // Shared arguments for all CNAB actions
@@ -57,6 +59,18 @@ func (d *Runtime) AddFiles(args ActionArguments) action.OperationConfigFunc {
 		for k, v := range args.Files {
 			op.Files[k] = v
 		}
+
+		// Add claim.json to file list as well, if exists
+		claimName := args.Claim
+		claim, err := d.instanceStorage.Read(claimName)
+		if err == nil {
+			claimBytes, err := yaml.Marshal(claim)
+			if err != nil {
+				return errors.Wrapf(err, "could not marshal claim %s", claimName)
+			}
+			op.Files[config.ClaimFilepath] = string(claimBytes)
+		}
+
 		return nil
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,9 @@ const (
 	// BundleOutputsDir is the directory where outputs are expected to be placed
 	// during the execution of a bundle action.
 	BundleOutputsDir = "/cnab/app/outputs"
+
+	// ClaimFilepath is the filepath to the claim.json inside of an invocation image
+	ClaimFilepath = "/cnab/claim.json"
 )
 
 // These are functions that afero doesn't support, so this lets us stub them out for tests to set the

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -10,6 +10,7 @@ import (
 	"get.porter.sh/porter/pkg/manifest"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/docker/cnab-to-oci/relocation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -367,8 +368,9 @@ func TestResolveCredential(t *testing.T) {
 	assert.Equal(t, []string{"deliciou$dubonnet"}, rm.GetSensitiveValues())
 }
 
-func TestResolveStepOutputs(t *testing.T) {
+func TestResolveStepOutputs_Install_NoPreexistingClaiml(t *testing.T) {
 	cxt := context.NewTestContext(t)
+
 	m := &manifest.Manifest{
 		Dependencies: map[string]manifest.Dependency{
 			"dep": {
@@ -376,7 +378,77 @@ func TestResolveStepOutputs(t *testing.T) {
 			},
 		},
 	}
+
 	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm.bundles = map[string]bundle.Bundle{
+		"dep": {
+			Outputs: map[string]bundle.Output{
+				"dep_output": {
+					Definition: "dep_output",
+				},
+			},
+			Definitions: map[string]*definition.Schema{
+				"dep_output": {WriteOnly: makeBoolPtr(true)},
+			},
+		},
+	}
+
+	cxt.FileSystem.WriteFile("/cnab/app/dependencies/dep/outputs/dep_output", []byte("dep_output_value"), 0644)
+
+	s := &manifest.Step{
+		Data: map[string]interface{}{
+			"description": "a test step",
+			"Arguments": []string{
+				"{{ bundle.dependencies.dep.outputs.dep_output }}",
+			},
+		},
+	}
+
+	// Prior to resolving step values, this method should return an empty string array
+	assert.Equal(t, rm.GetSensitiveValues(), []string{})
+
+	err := rm.ResolveStep(s)
+	require.NoError(t, err)
+	args, ok := s.Data["Arguments"].([]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "dep_output_value", args[0].(string))
+
+	// There should now be a sensitive value tracked under the manifest
+	assert.Equal(t, []string{"dep_output_value"}, rm.GetSensitiveValues())
+}
+
+func TestResolveStepOutputs_fromPreexistingClaim(t *testing.T) {
+	cxt := context.NewTestContext(t)
+
+	// Create a claim and store it in the expected location of the execution environment
+	// It holds the output value for 'output', from the previous action
+	claim, err := claim.New("test")
+	require.NoError(t, err)
+
+	claim.Outputs = map[string]interface{}{
+		"output": "output_value",
+	}
+
+	bytes, err := yaml.Marshal(claim)
+	require.NoError(t, err)
+	cxt.FileSystem.WriteFile("/cnab/claim.json", bytes, 0644)
+
+	m := &manifest.Manifest{
+		Outputs: []manifest.OutputDefinition{
+			{
+				Name:      "output",
+				Sensitive: true,
+			},
+		},
+		Dependencies: map[string]manifest.Dependency{
+			"dep": {
+				Tag: "deislabs/porter-hello",
+			},
+		},
+	}
+
+	rm := NewRuntimeManifest(cxt.Context, manifest.ActionUpgrade, m)
 	rm.bundles = map[string]bundle.Bundle{
 		"dep": {
 			Outputs: map[string]bundle.Output{
@@ -408,7 +480,7 @@ func TestResolveStepOutputs(t *testing.T) {
 	// Prior to resolving step values, this method should return an empty string array
 	assert.Equal(t, rm.GetSensitiveValues(), []string{})
 
-	err := rm.ResolveStep(s)
+	err = rm.ResolveStep(s)
 	require.NoError(t, err)
 	args, ok := s.Data["Arguments"].([]interface{})
 	assert.True(t, ok)
@@ -473,10 +545,25 @@ func TestResolveSliceWithAMap(t *testing.T) {
 	assert.NotNil(t, flags)
 }
 
-func TestResolveMultipleStepOutputs(t *testing.T) {
+func TestResolveMultipleStepOutputsFromPreexistingClaim(t *testing.T) {
+	cxt := context.NewTestContext(t)
 
 	databaseURL := "localhost"
 	databasePort := "3303"
+
+	// Create a claim and store it in the expected location of the execution environment
+	// It holds the output value for 'output', from the previous action
+	claim, err := claim.New("test")
+	require.NoError(t, err)
+
+	claim.Outputs = map[string]interface{}{
+		"database_url":  databaseURL,
+		"database_port": databasePort,
+	}
+
+	bytes, err := yaml.Marshal(claim)
+	require.NoError(t, err)
+	cxt.FileSystem.WriteFile("/cnab/claim.json", bytes, 0644)
 
 	s := &manifest.Step{
 		Data: map[string]interface{}{
@@ -489,20 +576,23 @@ func TestResolveMultipleStepOutputs(t *testing.T) {
 		},
 	}
 
-	cxt := context.NewTestContext(t)
 	m := &manifest.Manifest{
+		Outputs: []manifest.OutputDefinition{
+			{
+				Name: "database_url",
+			},
+			{
+				Name: "database_port",
+			},
+		},
 		Mixins: []manifest.MixinDeclaration{{Name: "helm"}},
 		Install: manifest.Steps{
 			s,
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
-	rm.outputs = map[string]string{
-		"database_url":  databaseURL,
-		"database_port": databasePort,
-	}
+	rm := NewRuntimeManifest(cxt.Context, manifest.ActionUpgrade, m)
 
-	err := rm.ResolveStep(s)
+	err = rm.ResolveStep(s)
 	require.NoError(t, err)
 	helm, ok := s.Data["helm"].(map[interface{}]interface{})
 	assert.True(t, ok)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -171,7 +171,7 @@ func (r *PorterRuntime) applyUnboundBundleOutputs() error {
 	outputs := r.RuntimeManifest.GetOutputs()
 	for _, outputDef := range r.RuntimeManifest.Outputs {
 		// Ignore outputs that have already been set
-		if _, hasOutput := outputs[outputDef.Name]; hasOutput {
+		if output := outputs[outputDef.Name]; output != "" {
 			continue
 		}
 

--- a/tests/outputs_test.go
+++ b/tests/outputs_test.go
@@ -92,3 +92,41 @@ func invokeExecOutputsBundle(p *porter.TestPorter, action string) {
 	err = p.InvokeBundle(statusOpts)
 	require.NoError(p.T(), err, "invoke %s should have succeeded", action)
 }
+
+func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+	p.Debug = false
+
+	// TODO: add output that is both step and bundle level
+	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundles/porter-outputs/porter.yaml"), "porter.yaml")
+	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundles/porter-outputs/dump-config.sh"), "dump-config.sh")
+	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundles/porter-outputs/Dockerfile"), "Dockerfile")
+
+	// Install the bundle
+	// A step-level output will be used during this action
+	installOpts := porter.InstallOptions{}
+	err := installOpts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+	err = p.InstallBundle(installOpts)
+	require.NoError(t, err, "install should have succeeded")
+
+	// Upgrade the bundle
+	// A bundle-level output will be produced during this action
+	upgradeOpts := porter.UpgradeOptions{}
+	upgradeOpts.Insecure = true
+	err = upgradeOpts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+	err = p.UpgradeBundle(upgradeOpts)
+	require.NoError(t, err, "upgrade should have succeeded")
+
+	// Uninstall the bundle
+	// A bundle-level output will be used during this action
+	uninstallOpts := porter.UninstallOptions{}
+	uninstallOpts.Insecure = true
+	err = uninstallOpts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+	err = p.UninstallBundle(uninstallOpts)
+	require.NoError(t, err, "uninstall should have succeeded")
+}

--- a/tests/outputs_test.go
+++ b/tests/outputs_test.go
@@ -99,7 +99,6 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 	defer p.CleanupIntegrationTest()
 	p.Debug = false
 
-	// TODO: add output that is both step and bundle level
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundles/porter-outputs/porter.yaml"), "porter.yaml")
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundles/porter-outputs/dump-config.sh"), "dump-config.sh")
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundles/porter-outputs/Dockerfile"), "Dockerfile")

--- a/tests/testdata/bundles/porter-outputs/Dockerfile
+++ b/tests/testdata/bundles/porter-outputs/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:stretch
+
+ARG BUNDLE_DIR
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+# exec mixin has no buildtime dependencies
+
+
+COPY . $BUNDLE_DIR
+RUN rm -fr $BUNDLE_DIR/.cnab
+COPY .cnab /cnab
+COPY porter.yaml $BUNDLE_DIR/porter.yaml
+WORKDIR $BUNDLE_DIR
+CMD ["/cnab/app/run"]

--- a/tests/testdata/bundles/porter-outputs/dump-config.sh
+++ b/tests/testdata/bundles/porter-outputs/dump-config.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo '{"user": "sally"}'

--- a/tests/testdata/bundles/porter-outputs/porter.yaml
+++ b/tests/testdata/bundles/porter-outputs/porter.yaml
@@ -1,0 +1,55 @@
+name: mybun
+version: 0.1.0
+description: "An example Porter configuration"
+tag: deislabs/porter-outputs:latest
+
+mixins:
+  - exec
+
+outputs:
+  - name: user-output
+    type: string
+    sensitive: true
+    applyTo:
+      - upgrade
+
+install:
+  - exec:
+      description: "Produce step-level output"
+      command: bash
+      arguments:
+        - dump-config.sh
+      outputs:
+        - name: user
+          sensitive: false
+          jsonPath: '$.user'
+  # This step tests successful interpolation of a step-level output
+  - exec:
+      description: "Echo step-level output"
+      command: bash
+      flags:
+        c: echo "{{ bundle.outputs.user }}"
+
+upgrade:
+  - exec:
+      description: "Produce bundle-level output"
+      command: bash
+      arguments:
+        - dump-config.sh
+      outputs:
+        - name: user-output
+          jsonPath: '$.user'
+  # This step tests successful interpolation of a bundle-level output in the same action
+  - exec:
+      description: "Echo bundle-level output in same action as it was produced"
+      command: bash
+      flags:
+        c: echo "{{ bundle.outputs.user-output }}"
+
+uninstall:
+  # This step tests successful interpolation of a bundle-level output across actions  
+  - exec:
+      description: "Echo bundle-level output"
+      command: bash
+      flags:
+        c: echo "{{ bundle.outputs.user-output }}"


### PR DESCRIPTION
# What does this change
Note: ~~**Do not merge yet**~~ - ~~Blocked by~~/Depends on https://github.com/cnabio/cnab-spec/pull/300

- Adds logic to enable using bundle output values in a Porter manifest via the supported templating language
- As an example, `{{ bundle.outputs.foo }}` can now be used in a step for action `next`, which will pull `foo`'s value from the claim, assuming the action that produced the current claim (say, `install`) produced an output of `foo`.

One caveat here is that currently, until work is done to address https://github.com/deislabs/porter/issues/836, interpolation of these values will only be possible if the previous action supplied the output needed.  Otherwise, outputs don't yet span more than one action _if the actions spanned don't also produce the same output_.

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/834 

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
