### PR TITLE
fix(archive.go): update mode on archive file

### DIFF
--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -59,7 +59,7 @@ func (p *Porter) Archive(opts ArchiveOptions) error {
 		return err
 	}
 
-	dest, err := p.Config.FileSystem.OpenFile(opts.ArchiveFile, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	dest, err := p.Config.FileSystem.OpenFile(opts.ArchiveFile, os.O_RDWR|os.O_CREATE, 0644)
 
 	exp := &exporter{
 		out:                   p.Config.Out,
@@ -93,7 +93,7 @@ func (ex *exporter) export() error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(archiveDir, 0755); err != nil {
+	if err := os.MkdirAll(archiveDir, 0644); err != nil {
 		return err
 	}
 	defer os.RemoveAll(archiveDir)

--- a/tests/archive_test.go
+++ b/tests/archive_test.go
@@ -3,6 +3,7 @@
 package tests
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -37,6 +38,10 @@ func TestArchive(t *testing.T) {
 
 	err = p.Archive(archiveOpts)
 	require.NoError(p.T(), err, "archival of bundle failed")
+
+	info, err := p.FileSystem.Stat("mybuns.tgz")
+	require.NoError(p.T(), err)
+	require.Equal(p.T(), os.FileMode(0644), info.Mode())
 
 	// Publish bundle from archive, with new tag
 


### PR DESCRIPTION
# What does this change
Sets file mode appropriately for archive file and parent directory.  (Neither should be executable.)

# What issue does it fix
Closes #838 

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
