### PR TITLE
Improve step troubleshooting

### DIFF
--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -275,22 +275,22 @@ func (m *RuntimeManifest) ResolveStep(step *manifest.Step) error {
 	mustache.AllowMissingVariables = false
 	sourceData, err := m.buildSourceData()
 	if err != nil {
-		return errors.Wrap(err, "unable to resolve step: unable to populate source data")
+		return errors.Wrap(err, "unable to build step template data")
 	}
 
 	payload, err := yaml.Marshal(step)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "invalid step data %v", step)
 	}
 
 	rendered, err := mustache.Render(string(payload), sourceData)
 	if err != nil {
-		return errors.Wrapf(err, "unable to resolve step: unable to render template %s", string(payload))
+		return errors.Wrapf(err, "unable to render step template %s", string(payload))
 	}
 
 	err = yaml.Unmarshal([]byte(rendered), step)
 	if err != nil {
-		return errors.Wrap(err, "unable to resolve step: invalid step yaml")
+		return errors.Wrapf(err, "invalid step yaml\n%s", rendered)
 	}
 
 	return nil

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -172,7 +172,7 @@ func TestResolveMapParamUnknown(t *testing.T) {
 
 	err := rm.ResolveStep(s)
 	require.Error(t, err)
-	assert.Equal(t, "unable to resolve step: unable to render template Parameters:\n  Thing: '{{bundle.parameters.person}}'\ndescription: a test step\n: Missing variable \"person\"", err.Error())
+	assert.Equal(t, "unable to render step template Parameters:\n  Thing: '{{bundle.parameters.person}}'\ndescription: a test step\n: Missing variable \"person\"", err.Error())
 }
 
 func TestPrepare_fileParam(t *testing.T) {
@@ -252,7 +252,7 @@ func TestResolveArrayUnknown(t *testing.T) {
 
 	err := rm.ResolveStep(s)
 	require.Error(t, err)
-	assert.Equal(t, "unable to resolve step: unable to render template Arguments:\n- '{{ bundle.parameters.person }}'\ndescription: a test step\n: Missing variable \"person\"", err.Error())
+	assert.Equal(t, "unable to render step template Arguments:\n- '{{ bundle.parameters.person }}'\ndescription: a test step\n: Missing variable \"person\"", err.Error())
 }
 
 func TestResolveArray(t *testing.T) {
@@ -535,7 +535,7 @@ func TestResolveMissingStepOutputs(t *testing.T) {
 
 	err := rm.ResolveStep(s)
 	require.Error(t, err)
-	assert.Equal(t, "unable to resolve step: unable to render template helm:\n  Arguments:\n  - jdbc://{{bundle.outputs.database_url}}:{{bundle.outputs.database_port}}\n  description: install wordpress\n: Missing variable \"database_url\"", err.Error())
+	assert.Equal(t, "unable to render step template helm:\n  Arguments:\n  - jdbc://{{bundle.outputs.database_url}}:{{bundle.outputs.database_port}}\n  description: install wordpress\n: Missing variable \"database_url\"", err.Error())
 }
 
 func TestResolveDependencyParam(t *testing.T) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -71,7 +71,7 @@ func (r *PorterRuntime) Execute(rm *RuntimeManifest) error {
 		if step != nil {
 			err := r.RuntimeManifest.ResolveStep(step)
 			if err != nil {
-				return errors.Wrap(err, "unable to resolve sourced values")
+				return errors.Wrap(err, "unable to resolve step")
 			}
 
 			description, _ := step.GetDescription()


### PR DESCRIPTION
# What does this change
Improve the error messages when a step fails to render
Print out the yaml that couldn't be marshaled
Dump the step data that couldn't be turned into a step
Use error wrapping properly

Here's the new info dumped when a step can't render:

```
DEBUG: defaulting action to CNAB_ACTION (install)
executing install action from HELLO (bundle instance: HELLO)
Error: unable to resolve step: invalid step yaml
exec:
  command: bash
  description: Install Hello World
  flags:
    c: echo "&#34;{&#34;test&#34;: &#34;test&#34;}&#34;"
: yaml: line 5: mapping values are not allowed in this context
```

# What issue does it fix
When I was troubleshooting #846 I needed more info to troubleshoot the problem.

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [x] Documentation Not Impacted
