### PR TITLE
chore(*): update url for cnabio/cnab-spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ DEFINITIONS_SCHEMA := definitions.schema.json
 
 define fetch-schema
 	@curl --fail --silent --show-error -o /tmp/$(1) \
-		https://raw.githubusercontent.com/deislabs/cnab-spec/master/schema/$(1)
+		https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/$(1)
 endef
 
 fetch-schemas: fetch-bundle-schema fetch-definitions-schema

--- a/docs/content/archive-bundles.md
+++ b/docs/content/archive-bundles.md
@@ -25,7 +25,7 @@ porter archive --tag jeremyrickard/porter-do-bundle:v0.5.0 do-porter.tgz
 
 ## Bundle Archive Format
 
-The generated bundle archive is a CNAB [thick bundle](https://github.com/deislabs/cnab-spec/blob/master/104-bundle-formats.md#formatting-and-transmitting-thick-bundles). Once you have a bundle archive, you can use the `tar` command to examine the contents. If we examine the `do-porter.tgz` generated above, we would see:
+The generated bundle archive is a CNAB [thick bundle](https://github.com/cnabio/cnab-spec/blob/master/104-bundle-formats.md#formatting-and-transmitting-thick-bundles). Once you have a bundle archive, you can use the `tar` command to examine the contents. If we examine the `do-porter.tgz` generated above, we would see:
 
 ```
 $ tar tvf do-porter.tgz

--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -22,7 +22,7 @@ We have full [examples](https://github.com/deislabs/porter/tree/master/examples)
 
 ## Bundle Metadata
 
-A lot of the metadata is defined by the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md)
+A lot of the metadata is defined by the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md)
 although Porter does have extra fields that are specific to making Porter bundles.
 
 ```yaml
@@ -79,7 +79,7 @@ See [Using Mixins](/use-mixins) to learn more about how mixins work.
 
 ## Parameters
 
-Parameters are part of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md#parameters) and
+Parameters are part of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#parameters) and
 allow you to pass in configuration values when you execute the bundle.
 
 ```yaml
@@ -104,7 +104,7 @@ parameters:
  
 ## Outputs
 
-Outputs are part of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md#outputs) to
+Outputs are part of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#outputs) to
 allow access to outputs generated during the course of executing a bundle.  These are global/bundle-wide outputs,
 as opposed to step outputs described in [Parameters, Credentials and Outputs](/wiring/).
 
@@ -135,7 +135,7 @@ it must define a `path` where the output file can be located on the filesystem.
 
 ### Parameter and Output Schema
 
-The [CNAB Spec for definitions](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md#definitions)
+The [CNAB Spec for definitions](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#definitions)
 applies to both parameters and outputs.  Parameters and outputs can use [json schema 7](https://json-schema.org) 
 properties to describe acceptable values. Porter uses a slightly [modified schema][json-schema] because CNAB disallows 
 non-integer values.
@@ -166,11 +166,11 @@ parameters:
   minLength: 3
 ```
 
-[json-schema]: https://github.com/deislabs/cnab-spec/blob/master/schema/definitions.schema.json
+[json-schema]: https://github.com/cnabio/cnab-spec/blob/master/schema/definitions.schema.json
 
 ## Credentials
 
-Credentials are part of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/802-credential-sets.md) and allow
+Credentials are part of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/802-credential-sets.md) and allow
 you to pass in sensitive data when you execute the bundle, such as passwords or configuration files.
 
 When the bundle is executed, for example when you run `porter install`, the installer will look on your local system
@@ -254,11 +254,11 @@ customActions:
    and that Porter should not keep track of when this action was last executed.
 * `modifies`: Indicates whether this action modifies resources managed by the bundle.
 
-[well-known-actions]: https://github.com/deislabs/cnab-spec/blob/master/804-well-known-custom-actions.md
+[well-known-actions]: https://github.com/cnabio/cnab-spec/blob/master/804-well-known-custom-actions.md
 
 ## Dependencies
 
-Dependencies are an extension of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/500-CNAB-dependencies.md).
+Dependencies are an extension of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/500-CNAB-dependencies.md).
 See [dependencies](/dependencies/) for more details on how Porter handles dependencies.
 
 ```yaml
@@ -276,7 +276,7 @@ dependencies:
 
 ## Images
 
-The `images` section of the Porter manifest corresponds to the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/103-bundle-runtime.md#image-maps).
+The `images` section of the Porter manifest corresponds to the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/103-bundle-runtime.md#image-maps).
 
 ```yaml
 images:

--- a/docs/content/dependencies.md
+++ b/docs/content/dependencies.md
@@ -7,7 +7,7 @@ In the Porter manifest you can [define a dependency](#define-a-dependency) on an
 bundle. The dependent bundle is executed _before_ the bundle is installed, updated, or a custom action is invoked.
 The dependent bundle is uninstalled _after_ the root bundle is uninstalled.
 
-Dependencies are an extension of the [CNAB Spec](https://github.com/deislabs/cnab-spec/blob/master/500-CNAB-dependencies.md).
+Dependencies are an extension of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/500-CNAB-dependencies.md).
 The Dependency specification is still evolving and we are using Porter to act as an initial implementation. So other CNAB 
 tools may not support dependencies initially.
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -42,7 +42,7 @@ credentials for a Kubernetes cluster.
 ## Does Porter fully implement the CNAB specification?
 
 Porter currently implements much of the CNAB spec, however, as the [CNAB
-specification](https://github.com/deislabs/cnab-spec) moves toward 1.0, some
+specification](https://github.com/cnabio/cnab-spec) moves toward 1.0, some
 gaps have emerged. Currently, if you build a bundle with Porter, you'll be able
 to install it with Porter. There are some gaps with the spec that limit
 compatibility with other CNAB tooling. See the [CNAB 1.0

--- a/docs/content/mixin-dev-guide/architecture.md
+++ b/docs/content/mixin-dev-guide/architecture.md
@@ -52,7 +52,7 @@ In this case, the `helm` mixin will first run apt-get update and then install `c
 
 ### Run Time
 
-The [CNAB specification](https://github.com/deislabs/cnab-spec/blob/master/103-bundle-runtime.md) specifies three actions that an invocation image should support:
+The [CNAB specification](https://github.com/cnabio/cnab-spec/blob/master/103-bundle-runtime.md) specifies three actions that an invocation image should support:
 
 * install
 * upgrade

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -17,7 +17,7 @@ parameters:
 
 This is the minimum required to create a parameter in Porter. Porter will specify an environment variable destination that defaults to the upper-cased name of the parameter.
 
-You can also provide any other attributes, as specified by the CNAB [parameters](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md#parameters) specification. To specify a default value, for example, you could provide the following parameter definition:
+You can also provide any other attributes, as specified by the CNAB [parameters](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#parameters) specification. To specify a default value, for example, you could provide the following parameter definition:
 
 ```yaml
 - name: database_name

--- a/docs/themes/porter/layouts/index.html
+++ b/docs/themes/porter/layouts/index.html
@@ -170,7 +170,7 @@
                   <div class="hide-for-medium-down medium-7 helm-community-blocks columns">
                     <section>
                       <h4>Project Status</h4>
-                      <p>The <a href="https://github.com/deislabs/cnab-spec">CNAB Core specification</a> has been frozen and we support version 1.0.0-WD.</p>
+                      <p>The <a href="https://github.com/cnabio/cnab-spec">CNAB Core specification</a> has been frozen and we support version 1.0.0-WD.</p>
                       <p align=center>Check out our <a href="https://github.com/deislabs/porter#roadmap">roadmap</a>.</p>
                     </section>
 

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -92,7 +92,7 @@ func (c *ManifestConverter) generateCustomActionDefinitions() map[string]bundle.
 }
 
 func (c *ManifestConverter) generateDefaultAction(action string) bundle.Action {
-	// See https://github.com/deislabs/cnab-spec/blob/master/804-well-known-custom-actions.md
+	// See https://github.com/cnabio/cnab-spec/blob/master/804-well-known-custom-actions.md
 	switch action {
 	case "dry-run", "io.cnab.dry-run":
 		return bundle.Action{

--- a/pkg/cnab/extensions/dependencies.go
+++ b/pkg/cnab/extensions/dependencies.go
@@ -13,7 +13,7 @@ const (
 )
 
 // Dependencies describes the set of custom extension metadata associated with the dependencies spec
-// https://github.com/deislabs/cnab-spec/blob/master/500-CNAB-dependencies.md
+// https://github.com/cnabio/cnab-spec/blob/master/500-CNAB-dependencies.md
 type Dependencies struct {
 	// Requires is a list of bundles required by this bundle
 	Requires map[string]Dependency `json:"requires,omitempty" mapstructure:"requires"`

--- a/workshop/scratch/azure/README.md
+++ b/workshop/scratch/azure/README.md
@@ -17,7 +17,7 @@ export REGISTRY=<yourusername>
 
 Start with the `cnab\app\terraform` directory. This directory contains a set of Terraform configurations that will utilize the Azure provider to create an Azure MySQL instance and store the TF state file in an Azure storage account. The files in here aren't special for use with CNAB or Porter.
 
-Next, review the `cnab\app\run` script. This script serves as the CNAB [run tool](https://github.com/deislabs/cnab-spec/blob/master/103-bundle-runtime.md#the-run-tool-main-entry-point). In this bash script, you'll see some special things like:
+Next, review the `cnab\app\run` script. This script serves as the CNAB [run tool](https://github.com/cnabio/cnab-spec/blob/master/103-bundle-runtime.md#the-run-tool-main-entry-point). In this bash script, you'll see some special things like:
 
 ```
 action=$CNAB_ACTION
@@ -193,7 +193,7 @@ Finally, you're ready to complete the CNAB! To do this, open up the `bundle.json
 	}
 ```
 
-JSON Schema is used to define the data type for each parameter. A `bundle.json` will normally have 1 or more `definitions`. Each of these `definitions` is referenced in the `parameters` section. Parameters and credentials have some similarities, but CNAB uses them in different ways. Check out the [cnab-spec](https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md#definitions) for more information on definitions, parameters and credentials.
+JSON Schema is used to define the data type for each parameter. A `bundle.json` will normally have 1 or more `definitions`. Each of these `definitions` is referenced in the `parameters` section. Parameters and credentials have some similarities, but CNAB uses them in different ways. Check out the [cnab-spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#definitions) for more information on definitions, parameters and credentials.
 
 In order to produce a valid `bundle.json` using your new invocation image, you'll need to change the following inside the `bundle.json`:
 


### PR DESCRIPTION
# What does this change
Updates the URL for the [CNAB Spec](https://github.com/cnabio/cnab-spec) repository.

Not immediately urgent, as GitHub still handles redirects, but should be updated nonetheless.

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
