### PR TITLE
Render manifest template with raw entities

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -365,6 +365,12 @@ defaultContentLanguage = "en"
   weight = 500
 
 [[menu.main]]
+  name = "Troubleshooting"
+  identifier = "troubleshooting"
+  url = "/troubleshooting"
+  weight = 501
+
+[[menu.main]]
   name = "Best Practices"
   url = "/best-practices/"
   identifier = "best-practices"

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -1,0 +1,81 @@
+---
+title: Troubleshooting
+description: Error messages you may see from Porter and how to handle them
+---
+
+With any porter error, it can really help to re-run the command again with the `--debug` flag.
+
+* [mapping values are not allowed in this context](#mapping-values-are-not-allowed-in-this-context)
+
+## mapping values are not allowed in this context
+
+When you run your bundle you see the following error
+
+```
+executing install action from HELLO (bundle instance: HELLO)
+=== Step Data ===
+map[bundle:map[credentials:map[] dependencies:map[] description:An example Porter configuration images:map[] invocationImage:porter-hello:latest name:HELLO outputs:map[] parameters:map[test:{"test": "test"}] version:0.1.0]]
+=== Step Template ===
+exec:
+  command: bash
+  description: Install Hello World
+  flags:
+    c: echo '{{ bundle.parameters.test }}'
+
+=== Rendered Step ===
+exec:
+  command: bash
+  description: Install Hello World
+  flags:
+    c: echo '{"test": "value"}'
+
+Error: unable to resolve step: invalid step yaml
+exec:
+  command: bash
+  description: Install Hello World
+  flags:
+    c: echo '{"test": "value"}'
+: yaml: line 5: mapping values are not allowed in this context
+```
+
+Right now Porter [doesn't preserve the wrapping quotes around mapping values][851], so if you 
+have lines that contain a colon followed by a space `: ` or a hash `#` preceeded by a space, then
+things will get tricky. If you can remove the space, or wrap the entire line in an extra quote, that
+should workaround the problem.
+
+[851]: https://github.com/deislabs/porter/issues/851
+**before**
+
+```yaml
+parameters:
+- name: test
+  description: test
+  type: string
+  default: '{"test": "value"}'
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      flags:
+        c: "echo {{ bundle.parameters.test}}"
+```
+
+**after**
+
+Remove the extra space after the colon when defining the test parameter's default
+
+```yaml
+parameters:
+- name: test
+  description: test
+  type: string
+  default: '{"test":"value"}'
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      flags:
+        c: "echo {{ bundle.parameters.test}}"
+```

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -278,14 +278,26 @@ func (m *RuntimeManifest) ResolveStep(step *manifest.Step) error {
 		return errors.Wrap(err, "unable to build step template data")
 	}
 
+	if m.Debug {
+		fmt.Fprintf(m.Err, "=== Step Data ===\n%v\n", sourceData)
+	}
+
 	payload, err := yaml.Marshal(step)
 	if err != nil {
 		return errors.Wrapf(err, "invalid step data %v", step)
 	}
 
-	rendered, err := mustache.Render(string(payload), sourceData)
+	if m.Debug {
+		fmt.Fprintf(m.Err, "=== Step Template ===\n%v\n", string(payload))
+	}
+
+	rendered, err := mustache.RenderRaw(string(payload), true, sourceData)
 	if err != nil {
 		return errors.Wrapf(err, "unable to render step template %s", string(payload))
+	}
+
+	if m.Debug {
+		fmt.Fprintf(m.Err, "=== Rendered Step ===\n%s\n", rendered)
 	}
 
 	err = yaml.Unmarshal([]byte(rendered), step)

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -455,7 +455,7 @@ func TestResolveSliceWithAMap(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := RuntimeManifest{Manifest: m}
+	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
 
 	installStep := rm.Install[0]
 
@@ -706,7 +706,7 @@ func TestManifest_ApplyStepOutputs(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := RuntimeManifest{Manifest: m}
+	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
 
 	depStep := rm.Install[0]
 	err = rm.ApplyStepOutputs(depStep, map[string]string{"foo": "bar"})
@@ -727,7 +727,7 @@ func TestManifest_ResolveImageMap(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := RuntimeManifest{Manifest: m}
+	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
 	expectedImage, ok := m.ImageMap["something"]
 	require.True(t, ok, "couldn't get expected image")
 	expectedRef := fmt.Sprintf("%s@%s", expectedImage.Repository, expectedImage.Digest)


### PR DESCRIPTION
# What does this change
Do not encode HTML entities such as quotes when rendering the manifest. I've added some additional debug output and am using the force raw rendering option to ensure that whatever template string the user has defined in the manifest is preserved when we render it.

I've added a troubleshooting page that explains a bug that I keep running into until we fix #851. See https://deploy-preview-852--porter.netlify.com/troubleshooting/

# What issue does it fix
Closes #846 

# Notes for the reviewer
I've made a follow-up issue, #851, to address how we lose wrapping quotes when we read in the porter manifest. So if they had wrapped their line with `>-` or single quotes or double quotes, we lose it when we read it in and then write it back out.

# Checklist
- [x] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
