### PR TITLE
chore(*): update cdn url and mixin author name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 INT_MIXINS = exec kubernetes
 EXT_MIXINS = helm azure terraform
 MIXIN_TAG ?= canary
-MIXINS_URL = https://cdn.deislabs.io/porter/mixins
+MIXINS_URL = https://cdn.porter.sh/mixins
 
 .PHONY: build
 build: build-porter docs-gen build-mixins clean-packr get-mixins

--- a/build/atom-template.xml
+++ b/build/atom-template.xml
@@ -1,24 +1,24 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <id>https://cdn.deislabs.io/porter</id>
-    <title>DeisLabs Mixins</title>
+    <id>https://porter.sh/mixins</id>
+    <title>Porter Mixins</title>
     <updated>{{Updated}}</updated>
-    <link rel="self" href="https://cdn.deislabs.io/porter/atom.xml"/>
+    <link rel="self" href="https://cdn.porter.sh/mixins/atom.xml"/>
     <author>
-        <name>DeisLabs</name>
-        <uri>https://deislabs.io</uri>
+        <name>Porter Authors</name>
+        <uri>https://porter.sh/mixins</uri>
     </author>
     {{#Mixins}}
     <category term="{{.}}"/>
     {{/Mixins}}
     {{#Entries}}
     <entry>
-        <id>https://cdn.deislabs.io/porter/mixins/{{Mixin}}/{{Version}}</id>
+        <id>https://cdn.porter.sh/mixins/{{Mixin}}/{{Version}}</id>
         <title>{{Mixin}} @ {{Version}}</title>
         <updated>{{Updated}}</updated>
         <category term="{{Mixin}}"/>
         <content>{{Version}}</content>
         {{#Files}}
-        <link rel="download" href="https://cdn.deislabs.io/porter/mixins/{{Mixin}}/{{Version}}/{{File}}" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/{{Mixin}}/{{Version}}/{{File}}" />
         {{/Files}}
     </entry>
     {{/Entries}}

--- a/build/images/client/Dockerfile
+++ b/build/images/client/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3
 ARG PERMALINK
 
 RUN apk add curl --no-cache
-RUN sh -c 'curl https://cdn.deislabs.io/porter/${PERMALINK}/install-linux.sh | sh' && \
+RUN sh -c 'curl https://cdn.porter.sh/${PERMALINK}/install-linux.sh | sh' && \
     ln -s /root/.porter/porter /usr/local/bin/porter
 
 ENTRYPOINT ["/root/.porter/porter"]

--- a/build/images/workshop/Dockerfile
+++ b/build/images/workshop/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add bash \
             bash-completion \
             jq \
             ca-certificates && \
-    curl https://cdn.deislabs.io/porter/${PERMALINK}/install-linux.sh | bash && \
+    curl https://cdn.porter.sh/${PERMALINK}/install-linux.sh | bash && \
     ln -s /root/.porter/porter /usr/local/bin/porter && \
     curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
     tar -xzf helm.tgz && \

--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -52,10 +52,10 @@ func BuildMixinInstallCommand(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install NAME",
 		Short: "Install a mixin",
-		Example: `  porter mixin install helm --url https://cdn.deislabs.io/porter/mixins/helm
-  porter mixin install helm --feed-url https://cdn.deislabs.io/porter/atom.xml
-  porter mixin install azure --version v0.4.0-ralpha.1+dubonnet --url https://cdn.deislabs.io/porter/mixins/azure
-  porter mixin install kubernetes --version canary --url https://cdn.deislabs.io/porter/mixins/kubernetes`,
+		Example: `  porter mixin install helm --url https://cdn.porter.sh/mixins/helm
+  porter mixin install helm --feed-url https://cdn.porter.sh/atom.xml
+  porter mixin install azure --version v0.4.0-ralpha.1+dubonnet --url https://cdn.porter.sh/mixins/azure
+  porter mixin install kubernetes --version canary --url https://cdn.porter.sh/mixins/kubernetes`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args)
 		},

--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -53,7 +53,7 @@ func BuildMixinInstallCommand(p *porter.Porter) *cobra.Command {
 		Use:   "install NAME",
 		Short: "Install a mixin",
 		Example: `  porter mixin install helm --url https://cdn.porter.sh/mixins/helm
-  porter mixin install helm --feed-url https://cdn.porter.sh/atom.xml
+  porter mixin install helm --feed-url https://cdn.porter.sh/mixins/atom.xml
   porter mixin install azure --version v0.4.0-ralpha.1+dubonnet --url https://cdn.porter.sh/mixins/azure
   porter mixin install kubernetes --version canary --url https://cdn.porter.sh/mixins/kubernetes`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/content/cli/mixins_install.md
+++ b/docs/content/cli/mixins_install.md
@@ -19,7 +19,7 @@ porter mixins install NAME [flags]
 
 ```
   porter mixin install helm --url https://cdn.porter.sh/mixins/helm
-  porter mixin install helm --feed-url https://cdn.porter.sh/atom.xml
+  porter mixin install helm --feed-url https://cdn.porter.sh/mixins/atom.xml
   porter mixin install azure --version v0.4.0-ralpha.1+dubonnet --url https://cdn.porter.sh/mixins/azure
   porter mixin install kubernetes --version canary --url https://cdn.porter.sh/mixins/kubernetes
 ```
@@ -27,7 +27,7 @@ porter mixins install NAME [flags]
 ### Options
 
 ```
-      --feed-url string   URL of an atom feed where the mixin can be downloaded (default https://cdn.porter.sh/atom.xml)
+      --feed-url string   URL of an atom feed where the mixin can be downloaded (default https://cdn.porter.sh/mixins/atom.xml)
   -h, --help              help for install
       --url string        URL from where the mixin can be downloaded, for example https://github.com/org/proj/releases/downloads
   -v, --version string    The mixin version. This can either be a version number, or a tagged release like 'latest' or 'canary' (default "latest")

--- a/docs/content/cli/mixins_install.md
+++ b/docs/content/cli/mixins_install.md
@@ -18,16 +18,16 @@ porter mixins install NAME [flags]
 ### Examples
 
 ```
-  porter mixin install helm --url https://cdn.deislabs.io/porter/mixins/helm
-  porter mixin install helm --feed-url https://cdn.deislabs.io/porter/atom.xml
-  porter mixin install azure --version v0.4.0-ralpha.1+dubonnet --url https://cdn.deislabs.io/porter/mixins/azure
-  porter mixin install kubernetes --version canary --url https://cdn.deislabs.io/porter/mixins/kubernetes
+  porter mixin install helm --url https://cdn.porter.sh/mixins/helm
+  porter mixin install helm --feed-url https://cdn.porter.sh/atom.xml
+  porter mixin install azure --version v0.4.0-ralpha.1+dubonnet --url https://cdn.porter.sh/mixins/azure
+  porter mixin install kubernetes --version canary --url https://cdn.porter.sh/mixins/kubernetes
 ```
 
 ### Options
 
 ```
-      --feed-url string   URL of an atom feed where the mixin can be downloaded (default https://cdn.deislabs.io/porter/atom.xml)
+      --feed-url string   URL of an atom feed where the mixin can be downloaded (default https://cdn.porter.sh/atom.xml)
   -h, --help              help for install
       --url string        URL from where the mixin can be downloaded, for example https://github.com/org/proj/releases/downloads
   -v, --version string    The mixin version. This can either be a version number, or a tagged release like 'latest' or 'canary' (default "latest")

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -21,17 +21,17 @@ Install the most recent stable release of porter and its default [mixins](#mixin
 
 ## Latest MacOS
 ```
-curl https://cdn.deislabs.io/porter/latest/install-mac.sh | bash
+curl https://cdn.porter.sh/latest/install-mac.sh | bash
 ```
 
 ## Latest Linux
 ```
-curl https://cdn.deislabs.io/porter/latest/install-linux.sh | bash
+curl https://cdn.porter.sh/latest/install-linux.sh | bash
 ```
 
 ## Latest Windows
 ```
-iwr "https://cdn.deislabs.io/porter/latest/install-windows.ps1" -UseBasicParsing | iex
+iwr "https://cdn.porter.sh/latest/install-windows.ps1" -UseBasicParsing | iex
 ```
 
 # Canary
@@ -44,17 +44,17 @@ that we are developing.
 
 ## Canary MacOS
 ```
-curl https://cdn.deislabs.io/porter/canary/install-mac.sh | bash
+curl https://cdn.porter.sh/canary/install-mac.sh | bash
 ```
 
 ## Canary Linux
 ```
-curl https://cdn.deislabs.io/porter/canary/install-linux.sh | bash
+curl https://cdn.porter.sh/canary/install-linux.sh | bash
 ```
 
 ## Canary Windows
 ```
-iwr "https://cdn.deislabs.io/porter/canary/install-windows.ps1" -UseBasicParsing | iex
+iwr "https://cdn.porter.sh/canary/install-windows.ps1" -UseBasicParsing | iex
 ```
 
 # Older Version
@@ -69,19 +69,19 @@ Set `VERSION` to the version of Porter that you want to install.
 ## Older Version MacOS
 ```
 VERSION="v0.18.1-beta.2"
-curl https://cdn.deislabs.io/porter/$VERSION/install-mac.sh | bash
+curl https://cdn.porter.sh/$VERSION/install-mac.sh | bash
 ```
 
 ## Older Version Linux
 ```
 VERSION="v0.18.1-beta.2"
-curl https://cdn.deislabs.io/porter/$VERSION/install-linux.sh | bash
+curl https://cdn.porter.sh/$VERSION/install-linux.sh | bash
 ```
 
 ## Older Version Windows
 ```
 $VERSION="v0.18.1-beta.2"
-iwr "https://cdn.deislabs.io/porter/$VERSION/install-windows.ps1" -UseBasicParsing | iex
+iwr "https://cdn.porter.sh/$VERSION/install-windows.ps1" -UseBasicParsing | iex
 ```
 
 # Mixins
@@ -104,6 +104,6 @@ installed terraform mixin
 v0.3.0-beta.1 (0d24b85)
 ```
 
-All of the DeisLabs mixins are published to `https://cdn.deislabs.io/porter/atom.xml`.
+All of the Porter mixins are published to `https://cdn.porter.sh/mixins/atom.xml`.
 
 [releases]: https://github.com/deislabs/porter/releases

--- a/docs/content/mixin-dev-guide/commands.md
+++ b/docs/content/mixin-dev-guide/commands.md
@@ -260,6 +260,6 @@ $ ~/.porter/mixins/exec/exec version --output json
   "name": "exec",
   "version": "v0.13.1-beta.1",
   "commit": "37f3637",
-  "author": "DeisLabs"
+  "author": "Porter Authors"
 }
 ```

--- a/docs/content/mixin-dev-guide/distribution.md
+++ b/docs/content/mixin-dev-guide/distribution.md
@@ -21,7 +21,7 @@ systems:
 * GOARCH: amd64
 
 If you are creating your mixin in Go, you may find the [Makefile][mk] that we use
-for our DeisLabs mixins helpful as a starting point.
+for our Porter mixins helpful as a starting point.
 
 ## Publish
 
@@ -64,7 +64,7 @@ When `--version` is not specified, it is defaulted to `latest` which should
 represent the most recent version of the mixin.
 
 You may also choose to publish `canary` versions of the mixin, which are
-unpublished builds from the master branch. Porter and the official DeisLabs
+unpublished builds from the master branch. Porter and the official Porter Authors
 mixins follow this pattern. If you have other published tagged builds of your
 mixin, porter can handle installing them as well.
 

--- a/docs/content/mixin-dev-guide/distribution.md
+++ b/docs/content/mixin-dev-guide/distribution.md
@@ -64,8 +64,8 @@ When `--version` is not specified, it is defaulted to `latest` which should
 represent the most recent version of the mixin.
 
 You may also choose to publish `canary` versions of the mixin, which are
-unpublished builds from the master branch. Porter and the official Porter Authors
-mixins follow this pattern. If you have other published tagged builds of your
-mixin, porter can handle installing them as well.
+unpublished builds from the master branch. The official Porter mixins follow
+this pattern. If you have other published tagged builds of your mixin, porter
+can handle installing them as well.
 
 [mk]: https://github.com/deislabs/porter/blob/master/mixin.mk

--- a/pkg/exec/version.go
+++ b/pkg/exec/version.go
@@ -12,7 +12,7 @@ func (m *Mixin) PrintVersion(opts version.Options) error {
 		VersionInfo: mixin.VersionInfo{
 			Version: pkg.Version,
 			Commit:  pkg.Commit,
-			Author:  "DeisLabs",
+			Author:  "Porter Authors",
 		},
 	}
 	return version.PrintVersion(m.Context, opts, metadata)

--- a/pkg/exec/version_test.go
+++ b/pkg/exec/version_test.go
@@ -24,7 +24,7 @@ func TestPrintVersion(t *testing.T) {
 	m.PrintVersion(opts)
 
 	gotOutput := m.TestContext.GetOutput()
-	wantOutput := "exec v1.2.3 (abc123) by DeisLabs"
+	wantOutput := "exec v1.2.3 (abc123) by Porter Authors"
 	if !strings.Contains(gotOutput, wantOutput) {
 		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
 	}
@@ -47,7 +47,7 @@ func TestPrintJsonVersion(t *testing.T) {
   "name": "exec",
   "version": "v1.2.3",
   "commit": "abc123",
-  "author": "DeisLabs"
+  "author": "Porter Authors"
 }
 `
 	if !strings.Contains(gotOutput, wantOutput) {

--- a/pkg/kubernetes/version.go
+++ b/pkg/kubernetes/version.go
@@ -12,7 +12,7 @@ func (m *Mixin) PrintVersion(opts version.Options) error {
 		VersionInfo: mixin.VersionInfo{
 			Version: pkg.Version,
 			Commit:  pkg.Commit,
-			Author:  "DeisLabs",
+			Author:  "Porter Authors",
 		},
 	}
 	return version.PrintVersion(m.Context, opts, metadata)

--- a/pkg/kubernetes/version_test.go
+++ b/pkg/kubernetes/version_test.go
@@ -24,7 +24,7 @@ func TestPrintVersion(t *testing.T) {
 	m.PrintVersion(opts)
 
 	gotOutput := m.TestContext.GetOutput()
-	wantOutput := "kubernetes v1.2.3 (abc123) by DeisLabs"
+	wantOutput := "kubernetes v1.2.3 (abc123) by Porter Authors"
 	if !strings.Contains(gotOutput, wantOutput) {
 		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
 	}
@@ -47,7 +47,7 @@ func TestPrintJsonVersion(t *testing.T) {
   "name": "kubernetes",
   "version": "v1.2.3",
   "commit": "abc123",
-  "author": "DeisLabs"
+  "author": "Porter Authors"
 }
 `
 	if !strings.Contains(gotOutput, wantOutput) {

--- a/pkg/mixin/feed/testdata/atom-existing.xml
+++ b/pkg/mixin/feed/testdata/atom-existing.xml
@@ -1,32 +1,32 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://porter.sh/mixins</id>
-    <title>DeisLabs Mixins</title>
+    <title>Porter Mixins</title>
     <updated>2013-02-03T00:00:00Z</updated>
-    <link rel="self" href="https://porter.sh/mixins/atom.xml"/>
+    <link rel="self" href="https://cdn.porter.sh/mixins/atom.xml"/>
     <author>
-        <name>DeisLabs</name>
-        <uri>https://deislabs.io</uri>
+        <name>Porter Authors</name>
+        <uri>https://porter.sh/mixins</uri>
     </author>
     <category term="exec"/>
     <category term="helm"/>
     <entry>
-        <id>https://porter.sh/mixins/v1.2.3/helm</id>
+        <id>https://cdn.porter.sh/mixins/v1.2.3/helm</id>
         <title>helm @ v1.2.3</title>
         <updated>2013-02-03T00:00:00Z</updated>
         <category term="helm"/>
         <content>v1.2.3</content>
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-linux-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
     </entry>
     <entry>
-        <id>https://porter.sh/mixins/v1.2.3/exec</id>
+        <id>https://cdn.porter.sh/mixins/v1.2.3/exec</id>
         <title>exec @ v1.2.3</title>
         <updated>2013-02-02T00:00:00Z</updated>
         <category term="exec"/>
         <content>v1.2.3</content>
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-darwin-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-linux-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-windows-amd64.exe" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/exec-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/exec-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/exec-windows-amd64.exe" />
     </entry>
 </feed>

--- a/pkg/mixin/feed/testdata/atom-template.xml
+++ b/pkg/mixin/feed/testdata/atom-template.xml
@@ -1,24 +1,24 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://porter.sh/mixins</id>
-    <title>DeisLabs Mixins</title>
+    <title>Porter Mixins</title>
     <updated>{{Updated}}</updated>
-    <link rel="self" href="https://porter.sh/mixins/atom.xml"/>
+    <link rel="self" href="https://cdn.porter.sh/mixins/atom.xml"/>
     <author>
-        <name>DeisLabs</name>
-        <uri>https://deislabs.io</uri>
+        <name>Porter Authors</name>
+        <uri>https://porter.sh/mixins</uri>
     </author>
     {{#Mixins}}
     <category term="{{.}}"/>
     {{/Mixins}}
     {{#Entries}}
     <entry>
-        <id>https://porter.sh/mixins/{{Version}}/{{Mixin}}</id>
+        <id>https://cdn.porter.sh/mixins/{{Version}}/{{Mixin}}</id>
         <title>{{Mixin}} @ {{Version}}</title>
         <updated>{{Updated}}</updated>
         <category term="{{Mixin}}"/>
         <content>{{Version}}</content>
         {{#Files}}
-        <link rel="download" href="https://porter.sh/mixins/{{Version}}/{{File}}" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/{{Version}}/{{File}}" />
         {{/Files}}
     </entry>
     {{/Entries}}

--- a/pkg/mixin/feed/testdata/atom.xml
+++ b/pkg/mixin/feed/testdata/atom.xml
@@ -1,52 +1,52 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://porter.sh/mixins</id>
-    <title>DeisLabs Mixins</title>
+    <title>Porter Mixins</title>
     <updated>2013-02-10T00:00:00Z</updated>
-    <link rel="self" href="https://porter.sh/mixins/atom.xml"/>
+    <link rel="self" href="https://cdn.porter.sh/mixins/atom.xml"/>
     <author>
-        <name>DeisLabs</name>
-        <uri>https://deislabs.io</uri>
+        <name>Porter Authors</name>
+        <uri>https://porter.sh/mixins</uri>
     </author>
     <category term="exec"/>
     <category term="helm"/>
     <entry>
-        <id>https://porter.sh/mixins/canary/exec</id>
+        <id>https://cdn.porter.sh/mixins/canary/exec</id>
         <title>exec @ canary</title>
         <updated>2013-02-10T00:00:00Z</updated>
         <category term="exec"/>
         <content>canary</content>
-        <link rel="download" href="https://porter.sh/mixins/canary/exec-darwin-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/canary/exec-linux-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/canary/exec-windows-amd64.exe" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/canary/exec-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/canary/exec-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/canary/exec-windows-amd64.exe" />
     </entry>
     <entry>
-        <id>https://porter.sh/mixins/v1.2.4/helm</id>
+        <id>https://cdn.porter.sh/mixins/v1.2.4/helm</id>
         <title>helm @ v1.2.4</title>
         <updated>2013-02-04T00:00:00Z</updated>
         <category term="helm"/>
         <content>v1.2.4</content>
-        <link rel="download" href="https://porter.sh/mixins/v1.2.4/helm-darwin-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.4/helm-linux-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.4/helm-windows-amd64.exe" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.4/helm-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.4/helm-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.4/helm-windows-amd64.exe" />
     </entry>
     <entry>
-        <id>https://porter.sh/mixins/v1.2.3/helm</id>
+        <id>https://cdn.porter.sh/mixins/v1.2.3/helm</id>
         <title>helm @ v1.2.3</title>
         <updated>2013-02-03T00:00:00Z</updated>
         <category term="helm"/>
         <content>v1.2.3</content>
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-linux-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
     </entry>
     <entry>
-        <id>https://porter.sh/mixins/v1.2.3/exec</id>
+        <id>https://cdn.porter.sh/mixins/v1.2.3/exec</id>
         <title>exec @ v1.2.3</title>
         <updated>2013-02-02T00:00:00Z</updated>
         <category term="exec"/>
         <content>v1.2.3</content>
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-darwin-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-linux-amd64" />
-        <link rel="download" href="https://porter.sh/mixins/v1.2.3/exec-windows-amd64.exe" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/exec-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/exec-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/exec-windows-amd64.exe" />
     </entry>
 </feed>

--- a/pkg/mixin/install.go
+++ b/pkg/mixin/install.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DefaultFeedUrl = "https://cdn.porter.sh/atom.xml"
+	DefaultFeedUrl = "https://cdn.porter.sh/mixins/atom.xml"
 )
 
 type InstallOptions struct {

--- a/pkg/mixin/install.go
+++ b/pkg/mixin/install.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DefaultFeedUrl = "https://cdn.deislabs.io/porter/atom.xml"
+	DefaultFeedUrl = "https://cdn.porter.sh/atom.xml"
 )
 
 type InstallOptions struct {

--- a/pkg/mixin/provider/install_test.go
+++ b/pkg/mixin/provider/install_test.go
@@ -56,7 +56,7 @@ func TestFileSystem_InstallFromFeedUrl(t *testing.T) {
 		if strings.HasSuffix(r.RequestURI, "atom.xml") {
 			// swap out the urls in the test atom feed to match the test http server here so that porter downloads
 			// the mixin binaries from the fake server
-			testAtom := strings.Replace(string(feed), "https://porter.sh", testURL, -1)
+			testAtom := strings.Replace(string(feed), "https://cdn.porter.sh", testURL, -1)
 			fmt.Fprintln(w, testAtom)
 		} else {
 			fmt.Fprintf(w, "#!/usr/bin/env bash\necho i am the helm mixin\n")
@@ -172,7 +172,7 @@ func TestFileSystem_Install_MixinInfoSavedWhenNoFileExists(t *testing.T) {
 	c.SetupPorterHome()
 	p := NewFileSystem(c.Config)
 
-	mixinURL := "https://cdn.deislabs.io/porter/mixins/helm"
+	mixinURL := "https://cdn.porter.sh/mixins/helm"
 	opts := mixin.InstallOptions{
 		Version: "v1.2.4",
 		URL:     mixinURL,

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 PORTER_HOME=~/.porter
-PORTER_URL=https://deislabs.blob.core.windows.net/porter
+PORTER_URL=https://cdn.porter.sh
 PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
 MIXIN_PERMALINK=${MIXIN_PERMALINK:-latest}
 echo "Installing porter to $PORTER_HOME"

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 PORTER_HOME=~/.porter
-PORTER_URL=https://deislabs.blob.core.windows.net/porter
+PORTER_URL=https://cdn.porter.sh
 PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
 MIXIN_PERMALINK=${MIXIN_PERMALINK:-latest}
 echo "Installing porter to $PORTER_HOME"

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -1,7 +1,7 @@
 param([String]$PORTER_PERMALINK='latest', [String]$MIXIN_PERMALINK='latest')
 
 $PORTER_HOME="$env:USERPROFILE\.porter"
-$PORTER_URL="https://cdn.deislabs.io/porter"
+$PORTER_URL="https://cdn.porter.sh"
 
 echo "Installing porter to $PORTER_HOME"
 


### PR DESCRIPTION
# What does this change
- Updates the cdn url to `https://cdn.porter.sh`
- Updates the mixin author to `Porter Authors`

# What issue does it fix
Ref https://github.com/deislabs/porter/issues/824

# Notes for the reviewer
Similar to other PRs contributing towards #824, I avoided changes to the `docs/content/slides` and `workshop/` directories.

PRs in the associated mixin repos forthcoming, though this shouldn't necessarily need to block on them.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
