### PR TITLE
ref(mysql/porter.yaml): use latest chart; set mysql-user default

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -17,6 +17,7 @@ parameters:
   env: DATABASE_NAME
 - name: mysql-user
   type: string
+  default: mysql-admin
   env: MYSQL_USER
 - name: namespace
   type: string
@@ -30,7 +31,6 @@ install:
     description: "Install MySQL"
     name: "{{ bundle.parameters.mysql-name }}"
     chart: stable/mysql
-    version: 0.10.2
     namespace: "{{ bundle.parameters.namespace }}"
     replace: true
     set:
@@ -57,7 +57,6 @@ upgrade:
       name: "{{ bundle.parameters.mysql-name }}"
       namespace: "{{ bundle.parameters.namespace }}"
       chart: stable/mysql
-      version: 0.10.2
       outputs:
       - name: mysql-root-password
         secret: "{{ bundle.parameters.mysql-name }}"

--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -31,6 +31,7 @@ install:
     description: "Install MySQL"
     name: "{{ bundle.parameters.mysql-name }}"
     chart: stable/mysql
+    version: 1.6.2
     namespace: "{{ bundle.parameters.namespace }}"
     replace: true
     set:
@@ -57,6 +58,7 @@ upgrade:
       name: "{{ bundle.parameters.mysql-name }}"
       namespace: "{{ bundle.parameters.namespace }}"
       chart: stable/mysql
+      version: 1.6.2
       outputs:
       - name: mysql-root-password
         secret: "{{ bundle.parameters.mysql-name }}"


### PR DESCRIPTION
# What does this change
- Updates the mysql test/sample bundle to install the latest `stable/mysql` chart (by removing a version override)

- Sets a default value for the `mysql-user` parameter

# What issue does it fix
When testing the bundle (prior to this change) on a k8s cluster of v1.17.0, I was greeted with the following error:

```
...
/usr/local/bin/helm helm install --name porter-ci-mysql stable/mysql --version 0.10.2 --replace --set mysqlDatabase=mydb --set mysqlUser=admin
Error: validation failed: unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"
Error: exit status 1
Error: mixin execution failed: exit status 1
```

# Notes for the reviewer
Would also be open to just bumping the version to a semver release that fixes the issue mentioned above, if we are hesitant to default to the latest version.  WDYT?

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
