### PR TITLE
Show value instead of paths for sensitve outputs

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -17,6 +17,7 @@ parameters:
   env: DATABASE_NAME
 - name: mysql-user
   type: string
+  default: mysql-admin
   env: MYSQL_USER
 - name: namespace
   type: string
@@ -30,7 +31,7 @@ install:
     description: "Install MySQL"
     name: "{{ bundle.parameters.mysql-name }}"
     chart: stable/mysql
-    version: 0.10.2
+    version: 1.6.2
     namespace: "{{ bundle.parameters.namespace }}"
     replace: true
     set:
@@ -57,7 +58,7 @@ upgrade:
       name: "{{ bundle.parameters.mysql-name }}"
       namespace: "{{ bundle.parameters.namespace }}"
       chart: stable/mysql
-      version: 0.10.2
+      version: 1.6.2
       outputs:
       - name: mysql-root-password
         secret: "{{ bundle.parameters.mysql-name }}"

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -1071,7 +1071,7 @@ $ porter bundle show
 
 Outputs:
 -------------------------------------------------------------------------------------------
-  Name                 Type    Value (Path if sensitive)
+  Name                 Type    Value
 -------------------------------------------------------------------------------------------
   STORAGE_ACCOUNT_KEY  string  JKb9C+J+nFtGrDyBW4Y0zaIK5hzIvi2gW3SfnmnkcunyXSYV3HucQGNIo...
 ```

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -124,9 +124,9 @@ func (p *Porter) ListBundleOutputs(c claim.Claim, format printer.Format) []Displ
 		}
 		do.Definition = *def
 
-		if def.WriteOnly != nil && *def.WriteOnly {
-			valueStr = output.Path
-		}
+		// if def.WriteOnly != nil && *def.WriteOnly {
+		// 	valueStr = output.Path
+		// }
 
 		outputType, _, err := def.GetType()
 		if err != nil {

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -124,10 +124,6 @@ func (p *Porter) ListBundleOutputs(c claim.Claim, format printer.Format) []Displ
 		}
 		do.Definition = *def
 
-		// if def.WriteOnly != nil && *def.WriteOnly {
-		// 	valueStr = output.Path
-		// }
-
 		outputType, _, err := def.GetType()
 		if err != nil {
 			// Do not have the entire listing fail because of one output type error

--- a/pkg/porter/show_test.go
+++ b/pkg/porter/show_test.go
@@ -75,13 +75,12 @@ Last Action: install
 Last Status: success
 
 Outputs:
-------------------------------
-  Name  Type    Value         
-------------------------------
-  bar   string  bar-output    
-  foo   string  /path/to/foo  
+----------------------------
+  Name  Type    Value       
+----------------------------
+  bar   string  bar-output  
+  foo   string  foo-output  
 `
-
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	require.Equal(t, wantOutput, gotOutput)
 }

--- a/workshop/porter-tf-aci/azure/README.md
+++ b/workshop/porter-tf-aci/azure/README.md
@@ -1,6 +1,6 @@
 # Advanced Azure + Terraform Cloud Native Application Bundle Using Porter
 
-This exercise extends the [porter-tf](https://github.com/deislabs/porter/tree/master/workshop/porter-tf)  example in order provide a more complete example of buiding a CNAB that combines both infrastructure and deployment of an application. As in the `porter-tf` example, we will use the `azure` and `terraform` mixins to provision a MySQL database on Azure. We will then use the `azure` mixin with a custom [ARM](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates) template to deploy a notional web service as an Azure Container Instance. This part of the bundle could easily be replaced with deployment to Kubernetes or any other container runtime system, but this exercise will use Azure. 
+This exercise extends the [porter-tf](https://github.com/deislabs/porter/tree/master/workshop/porter-tf) example in order provide a more complete example of buiding a CNAB that combines both infrastructure and deployment of an application. As in the `porter-tf` example, we will use the `azure` and `terraform` mixins to provision a MySQL database on Azure. We will then use the `azure` mixin with a custom [ARM](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates) template to deploy a notional web service as an Azure Container Instance. This part of the bundle could easily be replaced with deployment to Kubernetes or any other container runtime system, but this exercise will use Azure.
 
 ## Prerequisites
 
@@ -72,9 +72,9 @@ Copy these values and move on to setting up your environment variables.
 
 You'll need the following Service Principal information, along with an Azure Subscription ID:
 
-* Client ID (also called AppId)
-* Client Secret (also called Password)
-* Tenant Id (also called Tenant)
+- Client ID (also called AppId)
+- Client Secret (also called Password)
+- Tenant Id (also called Tenant)
 
 These will need to be in a set of environment variables for use in generating a CNAB credential set. Set them like this:
 
@@ -120,7 +120,7 @@ Last Status: success
 
 Outputs:
 -----------------------------------------------
-  Name        Type    Value (Path if sensitive)
+  Name        Type    Value
 -----------------------------------------------
   IP_ADDRESS  string  20.42.26.66
 ```

--- a/workshop/porter-tf-aci/azure/README.md
+++ b/workshop/porter-tf-aci/azure/README.md
@@ -123,7 +123,7 @@ Outputs:
   Name        Type    Value
 -----------------------------------------------
   IP_ADDRESS           string  40.88.49.175
-  STORAGE_ACCOUNT_KEY  string  /cnab/app/outputs/STORAGE_ACCOUNT_KEY
+  STORAGE_ACCOUNT_KEY  string  <your storage account key>
 ```
 
 Note that sensitive outputs (`STORAGE_ACCOUNT_KEY` in this example) are replaced by their runtime path


### PR DESCRIPTION
# What does this change
Now that outputs aren't stored in porter home anymore, displaying the path inside the bundled runtime to the output doesn't seem helpful for sensitive outputs.

Here is what someone sees when they list outputs in table format:
```
-----------------------------------------------
  Name                 Type    Value (Path if sensitive)
-----------------------------------------------
  IP_ADDRESS           string  40.88.49.175
  STORAGE_ACCOUNT_KEY  string  /cnab/app/outputs/STORAGE_ACCOUNT_KEY
```
Back when the path was a local path to porter home, e.g. ~/.porter/outputs/BUNDLE/STORAGE_ACCOUNT_KEY, it made more sense. They could choose to go look and see if they had permission to view that file. But now that we display a path that is inaccessible, /cnab/app/... isn't available after a bundle has been run.

After discussion in #863 , the following is solution was accepted,

show the value, regardless of sensitive or not (just like you would see if it's json/yaml). 

# What issue does it fix
Closes #863 

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
