### PR TITLE
Support generating credentials backed by secrets

### DIFF
--- a/pkg/credentialsgenerator/generator.go
+++ b/pkg/credentialsgenerator/generator.go
@@ -30,6 +30,7 @@ type credentialAnswers struct {
 }
 
 const (
+	questionSecret  = "secret"
 	questionValue   = "specific value"
 	questionEnvVar  = "environment variable"
 	questionPath    = "file path"
@@ -93,7 +94,7 @@ func genCredentialSurvey(name string) (credentials.CredentialStrategy, error) {
 
 	sourceTypePrompt := &survey.Select{
 		Message: fmt.Sprintf("How would you like to set credential %q", name),
-		Options: []string{questionValue, questionEnvVar, questionPath, questionCommand},
+		Options: []string{questionSecret, questionValue, questionEnvVar, questionPath, questionCommand},
 		Default: "environment variable",
 	}
 
@@ -108,6 +109,8 @@ func genCredentialSurvey(name string) (credentials.CredentialStrategy, error) {
 
 	promptMsg := ""
 	switch source {
+	case questionSecret:
+		promptMsg = fmt.Sprintf(sourceValuePromptTemplate, "secret", name)
 	case questionValue:
 		promptMsg = fmt.Sprintf(sourceValuePromptTemplate, "value", name)
 	case questionEnvVar:
@@ -128,6 +131,9 @@ func genCredentialSurvey(name string) (credentials.CredentialStrategy, error) {
 	}
 
 	switch source {
+	case questionSecret:
+		c.Source.Key = "secret"
+		c.Source.Value = value
 	case questionValue:
 		c.Source.Key = host.SourceValue
 		c.Source.Value = value


### PR DESCRIPTION
# What does this change
Updated the credential generator to ask if a credential should come from a secret.

I have created an issue to better handle this long term, see #875 but for now this will allow people to create credentials backed by the azure plugin (keyvault).

```console
$ porter credentials generate

Generating new credential plugins-demo from bundle plugins-demo
==> 1 credentials required for bundle plugins-demo
? How would you like to set credential "db-password" secret
? Enter the secret that will be used to set credential "db-password" password

$ porter credentials list

NAME           MODIFIED
HELLO          0001-01-01
aws            2019-08-02
plugins-demo   10 seconds ago

$ porter credentials show plugins-demo

Name: plugins-demo
Created: 18 seconds ago
Modified: 18 seconds ago

------------------------------------------
  Name         Local Source  Source Type
------------------------------------------
  db-password  password      secret
```
# What issue does it fix
None, it's for Wednesday's demo to the CNAB group of our new credentials/storage/secrets plugin structure.

# Notes for the reviewer
This doesn't seem to be an area that is easily testable right now. Once we add unattended generation, I think that will change.

# Checklist
- [ ] Unit Tests 
- [ ] Documentation
  - [x] Documentation Not Impacted
