### PR TITLE
Cleaning up the spelling in documentation

### DIFF
--- a/docs/content/design/kubernetes-mixin.md
+++ b/docs/content/design/kubernetes-mixin.md
@@ -1,5 +1,5 @@
 ---
-title: Kuberentes Mixin 
+title: Kubernetes Mixin 
 description: The Porter Kubernetes Mixin 
 ---
 
@@ -84,7 +84,7 @@ The mixin allows bundle authors to specify the following parameters on delete:
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `namespace` | string | The namespace in which to create resources. | `default` |
-| `manifests` | string | The path to the manifests. Can be a file or directory. | `/cnab/app/kuberentes` |
+| `manifests` | string | The path to the manifests. Can be a file or directory. | `/cnab/app/kubernetes` |
 | `force` | boolean | If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation. Sets grace period to `0`. | `false` |
 | `gracePeriod` | integer | Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. | `-1` |
 | `timeout` | integer | The length of time (in seconds) to wait before giving up on a delete, zero means determine a timeout from the size of the object. | 0 |

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -31,7 +31,7 @@ have everything you need inside of it:
 
 The installer would take care of:
 
-1. Requesting credentials for an existing Kuberentes cluster.
+1. Requesting credentials for an existing Kubernetes cluster.
 1. Provisioning an Azure MySQL database.
 1. Collecting the database credentials.
 1. Installing the Wordpress chart and passing in the database credentials.

--- a/examples/exec-outputs/create-cluster.sh
+++ b/examples/exec-outputs/create-cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This pretends to create a kuberentes cluster
+# This pretends to create a kubernetes cluster
 # by generating a dummy kubeconfig file
 mkdir -p /root/.kube
 cat <<EOF >> /root/.kube/config

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -2,7 +2,7 @@
 
 This is a sample Porter bundle that makes use of both the Kubernetes and Exec mixins. The Kubernetes mixin is used to apply Kubernetes manifests to an existing Kubernetes cluster, creating an NGINX deployment and a service. The Kubernetes mixin is also used to produce an output with the value of the service's ClusterIP.  After the kubernetes mixin finishes, the `exec` mixin is ued to echo the cluster IP of the service that was created. 
 
-To use this bundle, you will need an existing Kuberentes cluster and a kubeconfig file for use as a credential.
+To use this bundle, you will need an existing Kubernetes cluster and a kubeconfig file for use as a credential.
 
 ```
 porter build


### PR DESCRIPTION
This fixes Issue #886. I originally found this when reading the FAQ.
I was a little confused, and then went searching for other areas
that it might be spelled the same way in the repository, and then
in other projects.

It seems like this is super common. Rather than leave any confusion for 
new project contributors, I'm creating this PR to repair. I couldn't see an 
example spelling PR inthe closed PRs either, so this might be a reasonable
example for future PRs when correcting spelling to add to the contributing doc 
(or as areas where it could be improved.)



# What does this change
Cleans up spelling in documentation and examples

# What issue does it fix
Closes #886

# Notes for the reviewer


# Checklist
- [ ] Unit Tests
- [X] Documentation
  - [ ] Documentation Not Impacted
