### PR TITLE
Link to project board

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,15 @@ slack, interactions on social media, project meetings, conferences and meetups.
 ## Find an issue
 
 We have [good first issues][good-first-issue] for new contributors and [help
-wanted][help-wanted] issues for our other contributors.
+wanted][help-wanted] issues for our other contributors. When you have been
+contributing for a while, take a look at the "Backlog" column on our [project
+board][board] for high priority issues.
 
 * `good first issue` has extra information to help you make your first contribution.
 * `help wanted` are issues suitable for someone who isn't a core maintainer.
+* `hmm 🛑🤔` issues should be avoided. They are not ready to be worked on yet
+  because they are not finished being designed or we aren't sure if we want the
+  feature, etc.
 
 Maintainers will do our best regularly make new issues for you to solve and then
 help out as you work on them. 💖
@@ -61,6 +66,9 @@ Another great way to contribute is to create a mixin! You can start use the
 
 [skeletor]: https://github.com/deislabs/porter-skeletor
 [mixin-dev-guide]: https://porter.sh/mixin-dev-guide/
+[good-first-issue]: https://github.com/orgs/deislabs/projects/2?card_filter_query=label%3A%22good+first+issue%22
+[help-wanted]: https://github.com/orgs/deislabs/projects/2?card_filter_query=label%3A%22help+wanted%22
+[board]: https://github.com/orgs/deislabs/projects/2
 
 ## When to open a pull request
 
@@ -327,9 +335,6 @@ We use [Hugo](gohugo.io) to build our documentation site, and it is hosted on
 If anyone is interested in contributing changes to our makefile to improve the
 authoring experience, such as doing this with Docker so that you don't need Hugo
 installed, it would be a welcome contribution! ❤️
-
-[good-first-issue]: https://github.com/deislabs/porter/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
-[help-wanted]: https://github.com/deislabs/porter/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
 
 ## Command Documentation
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Porter is an open-source project and things get done as quickly as we have
 motivated contributors working on features that interest them. 😉
 
 We use a single [project board][board] across all of our repositories to track
-open issues and pull requests. See Find an Issue
+open issues and pull requests.
 
 The roadmap represents what the core maintainers have said that they are
 currently working on and plan to work on over the next few months. We use the

--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ into becoming reviewers and maintainers.
 Porter is an open-source project and things get done as quickly as we have
 motivated contributors working on features that interest them. 😉
 
+We use a single [project board][board] across all of our repositories to track
+open issues and pull requests. See Find an Issue
+
 The roadmap represents what the core maintainers have said that they are
 currently working on and plan to work on over the next few months. We use the
 "on-hold" bucket to communicate items of interest that doesn't have a core
 maintainer who will be working on it.
 
 <p align="center">Check out our <a href="https://github.com/deislabs/porter/projects/4">roadmap</a></p>
+
+[board]: https://github.com/orgs/deislabs/projects/2

--- a/docs/content/contribute.md
+++ b/docs/content/contribute.md
@@ -52,7 +52,8 @@ contributing to our repositories. The guide also covers the project's code
 structure, makefile commands, how to preview documentation and other useful
 things to know.
 
-There are [good first issues][good-first-issue] for new contributors and [help
+The contributing guide explains how to [find an issue][find-an-issue]. We do use
+two labels: [good first issues][good-first-issue] for new contributors and [help
 wanted][help-wanted] issues for our other contributors.
 
 * `good first issue` has extra information to help you make your first contribution.
@@ -61,8 +62,9 @@ wanted][help-wanted] issues for our other contributors.
 
 [conduct]: https://github.com/deislabs/porter/blob/master/CODE_OF_CONDUCT.md
 [contributing]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md
-[good-first-issue]: https://github.com/deislabs/porter/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
-[help-wanted]: https://github.com/deislabs/porter/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+[find-an-issue]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#find-an-issue
+[good-first-issue]: https://github.com/orgs/deislabs/projects/2?card_filter_query=label%3A%22good+first+issue%22
+[help-wanted]: https://github.com/orgs/deislabs/projects/2?card_filter_query=label%3A%22help+wanted%22
 
 ## What can you work on?
 


### PR DESCRIPTION
# What does this change
Prominently link to our project board from the:
* readme
* contributing guide
* [new contributor guide](https://deploy-preview-893--porter.netlify.com/contribute/#where-should-you-start)

I also threw in what label to _avoid_ in case someone is just looking around the project board for something to do.

# What issue does it fix
None this came up in the dev call today

# Notes for the reviewer
🐳

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
