### PR TITLE
Support for CNAB Custom Extensions

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -44,6 +44,7 @@ dockerfile: dockerfile.tmpl
     The `invocationImage` name defaults to `tag`-installer, with the `version` as its image tag. For example if the bundle `tag` is `getporter/porter-hello:v0.1.0` and the `version` is `0.1.0`, then the `invocationImage` will default to `getporter/porter-hello-installer:0.1.0`
 * `dockerfile`: OPTIONAL. The relative path to a Dockerfile to use as a template during `porter build`. 
     See [Custom Dockerfile](/custom-dockerfile/) for details on how to use a custom Dockerfile.
+* `custom`: OPTIONAL. A map of [custom bundle metadata](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions).
 
 ## Mixins
 

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -56,6 +56,11 @@ func (c *ManifestConverter) ToBundle() *bundle.Bundle {
 	b.Outputs = c.generateBundleOutputs(&b.Definitions)
 	b.Credentials = c.generateBundleCredentials()
 	b.Images = c.generateBundleImages()
+
+	for key, value := range c.Manifest.Custom {
+		b.Custom[key] = value
+	}
+
 	b.Custom[config.CustomBundleKey] = c.GenerateStamp()
 
 	b.Custom[extensions.DependenciesKey] = c.generateDependencies()

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -527,7 +527,7 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 
 	bun := a.ToBundle()
 	assert.Len(t, bun.Custom, 3)
-	
+
 	fooCustomData := bun.Custom["foo"]
 	assert.Equal(t, "bar", fooCustomData)
 }

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -515,3 +515,19 @@ func TestManifestConverter_generateDefaultAction(t *testing.T) {
 		})
 	}
 }
+
+func TestManifestConverter_generateCustomMetadata(t *testing.T) {
+	c := config.NewTestConfig(t)
+	c.TestContext.AddTestFile("./testdata/porter-with-custom-metadata.yaml", config.Name)
+
+	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	require.NoError(t, err, "could not load manifest")
+
+	a := NewManifestConverter(c.Context, m, nil, nil)
+
+	bun := a.ToBundle()
+	assert.Len(t, bun.Custom, 3)
+	
+	fooCustomData := bun.Custom["foo"]
+	assert.Equal(t, "bar", fooCustomData)
+}

--- a/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
@@ -22,3 +22,4 @@ uninstall:
     command: bash
     flags:
       c: echo Goodbye World
+

--- a/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
@@ -1,0 +1,24 @@
+name: hello
+description: "An example Porter configuration"
+version: 0.1.0
+tag: getporter/porter-hello:v0.1.0
+
+custom:
+  foo: bar
+  
+mixins:
+- exec
+
+install:
+- exec:
+    description: "Say Hello"
+    command: bash
+    flags:
+      c: echo Hello World
+
+uninstall:
+- exec:
+    description: "Say Goodbye"
+    command: bash
+    flags:
+      c: echo Goodbye World

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -39,6 +39,7 @@ type Manifest struct {
 	Uninstall Steps `yaml:"uninstall"`
 	Upgrade   Steps `yaml:"upgrade"`
 
+	Custom 								  map[string]interface{}  					`yaml:"custom,omitempty"`
 	CustomActions           map[string]Steps                  `yaml:"-"`
 	CustomActionDefinitions map[string]CustomActionDefinition `yaml:"customActions,omitempty"`
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -39,7 +39,7 @@ type Manifest struct {
 	Uninstall Steps `yaml:"uninstall"`
 	Upgrade   Steps `yaml:"upgrade"`
 
-	Custom 								  map[string]interface{}  					`yaml:"custom,omitempty"`
+	Custom                  map[string]interface{}            `yaml:"custom,omitempty"`
 	CustomActions           map[string]Steps                  `yaml:"-"`
 	CustomActionDefinitions map[string]CustomActionDefinition `yaml:"customActions,omitempty"`
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -303,3 +303,19 @@ func TestValidateImageMap(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestLoadManifestWithCustomData(t *testing.T) {
+	cxt := context.NewTestContext(t)
+
+	cxt.AddTestFile("testdata/porter.yaml", config.Name)
+
+	m, err := LoadManifestFrom(cxt.Context, config.Name)
+	require.NoError(t, err, "could not load manifest")
+
+	assert.NotNil(t, m)
+	assert.Equal(t, map[string]interface {}{"foo":"bar"}, m.Custom)
+
+	custom := m.Custom
+	fooCustomField, _ := custom["foo"]
+	assert.Equal(t, "bar", fooCustomField)
+}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -313,7 +313,7 @@ func TestLoadManifestWithCustomData(t *testing.T) {
 	require.NoError(t, err, "could not load manifest")
 
 	assert.NotNil(t, m)
-	assert.Equal(t, map[string]interface {}{"foo":"bar"}, m.Custom)
+	assert.Equal(t, map[string]interface{}{"foo": "bar"}, m.Custom)
 
 	custom := m.Custom
 	fooCustomField, _ := custom["foo"]

--- a/pkg/manifest/testdata/porter.yaml
+++ b/pkg/manifest/testdata/porter.yaml
@@ -23,3 +23,4 @@ uninstall:
 
 custom:
   foo: bar
+

--- a/pkg/manifest/testdata/porter.yaml
+++ b/pkg/manifest/testdata/porter.yaml
@@ -20,3 +20,6 @@ uninstall:
     command: bash
     flags:
       c: echo Goodbye World
+
+custom:
+  foo: bar


### PR DESCRIPTION
# What does this change

* [Added] support for a `custom` top-level porter.yaml key

Effect: `custom` accepts a k/v map of [custom extension](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions) data. Supplied `custom` data is applied first to the bundle and will be overwritten by porter custom extensions.

# What issue does it fix
Closes #888

# Notes for the reviewer

Example:

```yaml
name: hello
description: "An example Porter configuration"
version: 0.1.0
tag: getporter/porter-hello:v0.1.0

custom:
  foo: bar

install:
- exec:
    description: "Say Hello"
    command: bash
    flags:
      c: echo Hello World
```

# Checklist
- [x] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
