### PR TITLE
Preserve name casing in credentials show

### DIFF
--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -3,7 +3,6 @@ package porter
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"get.porter.sh/porter/pkg/context"
@@ -143,7 +142,7 @@ func (o *CredentialShowOptions) Validate(args []string) error {
 	case 0:
 		return errors.Errorf("no credential name was specified")
 	case 1:
-		o.Name = strings.ToLower(args[0])
+		o.Name = args[0]
 	default:
 		return errors.Errorf("only one positional argument may be specified, the credential name, but multiple were received: %s", args)
 	}

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -361,6 +361,15 @@ Modified: 2019-06-24
 	}
 }
 
+func TestShowCredential_PreserveCase(t *testing.T) {
+	opts := CredentialShowOptions{}
+	opts.RawFormat = string(printer.FormatTable)
+
+	err := opts.Validate([]string{"HELLO"})
+	require.NoError(t, err, "Validate failed")
+	assert.Equal(t, "HELLO", opts.Name, "Validate should preserve the credential set name case")
+}
+
 type SourceTest struct {
 	name      string
 	source    credentials.Source


### PR DESCRIPTION
# What does this change
porter credentials show HELLO should query the backend credentials store for a credential set named "HELLO" and not force it to lower-case. The CNAB spec allows for credential sets that use upper-case, and when you generate credential sets for bundles with upper-case letters, it
defaults to the name of the bundle. So we end up with credential sets that depending on the backing store, cannot be read due to forcing to lower-case.

I checked and the other only place we do this is for mixins. I'm going to leave that as-is for now, since perhaps limiting mixins to all lower case is useful? I'll make a follow-up issue to consider if we need to change that too.


# What issue does it fix
https://github.com/deislabs/porter/pull/889/files#r377707582

# Notes for the reviewer
I've created #897 to look into the mixin question

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
