### PR TITLE
Install azure by default

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -86,24 +86,33 @@ iwr "https://cdn.porter.sh/$VERSION/install-windows.ps1" -UseBasicParsing | iex
 
 # Mixins
 
-We have a number of [mixins](/mixins) to help you get started. The stable ones
-are installed by default:
-
-* exec
-* kubernetes
-* helm
-* azure
-* terraform
+We have a number of [mixins](/mixins) to help you get started, and stable mixins
+are installed by default.
 
 You can update an existing mixin, or install a new mixin using the `porter mixin
 install` command:
 
 ```console
 $ porter mixin install terraform
-installed terraform mixin
-v0.3.0-beta.1 (0d24b85)
+installed terraform mixin v0.3.0-beta.1 (0d24b85)
 ```
 
-All of the Porter mixins are published to `https://cdn.porter.sh/mixins/atom.xml`.
+All of the Porter authored mixins are published to `https://cdn.porter.sh/mixins/atom.xml`.
+
+# Plugins
+
+We are working on building out [plugins](/plugins) to extend Porter and the stable
+plugins are installed by default.
+
+You can update an existing plugin, or install a new plugin using the `porter plugin
+plugin` command:
+
+```console
+$ porter plugin install azure --version canary
+installed azure plugin v0.1.1-10-g7071451 (7071451)
+```
+
+All of the Porter authored plugins are published to `https://cdn.porter.sh/plugins/atom.xml`.
+
 
 [releases]: https://github.com/deislabs/porter/releases

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -97,7 +97,7 @@ $ porter mixin install terraform
 installed terraform mixin v0.3.0-beta.1 (0d24b85)
 ```
 
-All of the Porter authored mixins are published to `https://cdn.porter.sh/mixins/atom.xml`.
+All of the Porter-authored mixins are published to `https://cdn.porter.sh/mixins/atom.xml`.
 
 # Plugins
 
@@ -105,14 +105,14 @@ We are working on building out [plugins](/plugins) to extend Porter and the stab
 plugins are installed by default.
 
 You can update an existing plugin, or install a new plugin using the `porter plugin
-plugin` command:
+install` command:
 
 ```console
 $ porter plugin install azure --version canary
 installed azure plugin v0.1.1-10-g7071451 (7071451)
 ```
 
-All of the Porter authored plugins are published to `https://cdn.porter.sh/plugins/atom.xml`.
+All of the Porter-authored plugins are published to `https://cdn.porter.sh/plugins/atom.xml`.
 
 
 [releases]: https://github.com/deislabs/porter/releases

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -76,7 +76,7 @@ func (p *Porter) InstallMixin(opts mixin.InstallOptions) error {
 	}
 
 	v := mixin.GetVersionInfo()
-	fmt.Fprintf(p.Out, "installed %s mixin %s (%s)", opts.Name, v.Version, v.Commit)
+	fmt.Fprintf(p.Out, "installed %s mixin %s (%s)\n", opts.Name, v.Version, v.Commit)
 
 	return nil
 }

--- a/pkg/porter/mixins_test.go
+++ b/pkg/porter/mixins_test.go
@@ -39,7 +39,7 @@ func TestPorter_InstallMixin(t *testing.T) {
 
 	require.NoError(t, err)
 
-	wantOutput := "installed exec mixin v1.0 (abc123)"
+	wantOutput := "installed exec mixin v1.0 (abc123)\n"
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	assert.Contains(t, wantOutput, gotOutput)
 }

--- a/pkg/porter/plugins.go
+++ b/pkg/porter/plugins.go
@@ -167,7 +167,7 @@ func (p *Porter) InstallPlugin(opts plugins.InstallOptions) error {
 	}
 
 	v := plugin.GetVersionInfo()
-	fmt.Fprintf(p.Out, "installed %s plugin %s (%s)", opts.Name, v.Version, v.Commit)
+	fmt.Fprintf(p.Out, "installed %s plugin %s (%s)\n", opts.Name, v.Version, v.Commit)
 
 	return nil
 }

--- a/pkg/porter/plugins_test.go
+++ b/pkg/porter/plugins_test.go
@@ -248,7 +248,7 @@ func TestPorter_InstallPlugin(t *testing.T) {
 	err = p.InstallPlugin(opts)
 	require.NoError(t, err, "InstallPlugin failed")
 
-	wantOutput := "installed plugin1 plugin v1.0 (abc123)"
+	wantOutput := "installed plugin1 plugin v1.0 (abc123)\n"
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	assert.Contains(t, wantOutput, gotOutput)
 }

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -17,7 +17,7 @@ echo Installed `$PORTER_HOME/porter version`
 $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install azure --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 PORTER_HOME=~/.porter
 PORTER_URL=https://cdn.porter.sh
 PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
-MIXIN_PERMALINK=${MIXIN_PERMALINK:-latest}
+PKG_PERMALINK=${PKG_PERMALINK:-latest}
 echo "Installing porter to $PORTER_HOME"
 
 mkdir -p $PORTER_HOME
@@ -14,14 +14,16 @@ chmod +x $PORTER_HOME/porter
 cp $PORTER_HOME/porter $PORTER_HOME/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
-$PORTER_HOME/porter mixin install exec --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install kubernetes --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install helm --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install azure --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install terraform --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install az --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install aws --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install gcloud --version $MIXIN_PERMALINK
+$PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install azure --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
+
+$PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
 
 echo "Installation complete."
 echo "Add porter to your path by running:"

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -18,7 +18,7 @@ echo Installed `$PORTER_HOME/porter version`
 $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install azure --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 PORTER_HOME=~/.porter
 PORTER_URL=https://cdn.porter.sh
 PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
-MIXIN_PERMALINK=${MIXIN_PERMALINK:-latest}
+PKG_PERMALINK=${PKG_PERMALINK:-latest}
 echo "Installing porter to $PORTER_HOME"
 
 mkdir -p $PORTER_HOME
@@ -15,14 +15,16 @@ chmod +x $PORTER_HOME/porter
 chmod +x $PORTER_HOME/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
-$PORTER_HOME/porter mixin install exec --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install kubernetes --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install helm --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install azure --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install terraform --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install az --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install aws --version $MIXIN_PERMALINK
-$PORTER_HOME/porter mixin install gcloud --version $MIXIN_PERMALINK
+$PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install azure --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
+
+$PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
 
 echo "Installation complete."
 echo "Add porter to your path by running:"

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -1,4 +1,4 @@
-param([String]$PORTER_PERMALINK='latest', [String]$MIXIN_PERMALINK='latest')
+param([String]$PORTER_PERMALINK='latest', [String]$PKG_PERMALINK='latest')
 
 $PORTER_HOME="$env:USERPROFILE\.porter"
 $PORTER_URL="https://cdn.porter.sh"
@@ -11,14 +11,16 @@ mkdir -f $PORTER_HOME
 (new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64", "$PORTER_HOME\porter-runtime")
 echo "Installed $(& $PORTER_HOME\porter.exe version)"
 
-& $PORTER_HOME/porter mixin install exec --version $MIXIN_PERMALINK
-& $PORTER_HOME/porter mixin install kubernetes --version $MIXIN_PERMALINK
-& $PORTER_HOME/porter mixin install helm --version $MIXIN_PERMALINK
-& $PORTER_HOME/porter mixin install azure --version $MIXIN_PERMALINK
-& $PORTER_HOME/porter mixin install terraform --version $MIXIN_PERMALINK
-& $PORTER_HOME/porter mixin install az --version $MIXIN_PERMALINK
-& $PORTER_HOME/porter mixin install aws --version $MIXIN_PERMALINK
-& $PORTER_HOME/porter mixin install gcloud --version $MIXIN_PERMALINK
+& $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
+& $PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
+& $PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
+& $PORTER_HOME/porter mixin install azure --version $PKG_PERMALINK
+& $PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
+& $PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
+& $PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
+& $PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
+
+& $PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
 
 echo "Installation complete."
 echo "Add porter to your path by running:"

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -14,7 +14,7 @@ echo "Installed $(& $PORTER_HOME\porter.exe version)"
 & $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
 & $PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
 & $PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
-& $PORTER_HOME/porter mixin install azure --version $PKG_PERMALINK
+& $PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
 & $PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
 & $PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
 & $PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK

--- a/scripts/prep-install-scripts.sh
+++ b/scripts/prep-install-scripts.sh
@@ -10,6 +10,6 @@ else
   PORTER_PERMALINK=$VERSION
 fi
 
-sed -e "s|PORTER_PERMALINK:-latest|PORTER_PERMALINK:-$PORTER_PERMALINK|g" -e "s|MIXIN_PERMALINK:-latest|MIXIN_PERMALINK:-$PERMALINK|" scripts/install/install-mac.sh > bin/$VERSION/install-mac.sh
-sed -e "s|PORTER_PERMALINK:-latest|PORTER_PERMALINK:-$PORTER_PERMALINK|g" -e "s|MIXIN_PERMALINK:-latest|MIXIN_PERMALINK:-$PERMALINK|" scripts/install/install-linux.sh > bin/$VERSION/install-linux.sh
-sed -e "s|PORTER_PERMALINK='latest'|PORTER_PERMALINK='$PORTER_PERMALINK'|g" -e "s|MIXIN_PERMALINK='latest'|MIXIN_PERMALINK='$PERMALINK'|g" scripts/install/install-windows.ps1 > bin/$VERSION/install-windows.ps1
+sed -e "s|PORTER_PERMALINK:-latest|PORTER_PERMALINK:-$PORTER_PERMALINK|g" -e "s|PKG_PERMALINK:-latest|PKG_PERMALINK:-$PERMALINK|" scripts/install/install-mac.sh > bin/$VERSION/install-mac.sh
+sed -e "s|PORTER_PERMALINK:-latest|PORTER_PERMALINK:-$PORTER_PERMALINK|g" -e "s|PKG_PERMALINK:-latest|PKG_PERMALINK:-$PERMALINK|" scripts/install/install-linux.sh > bin/$VERSION/install-linux.sh
+sed -e "s|PORTER_PERMALINK='latest'|PORTER_PERMALINK='$PORTER_PERMALINK'|g" -e "s|PKG_PERMALINK='latest'|PKG_PERMALINK='$PERMALINK'|g" scripts/install/install-windows.ps1 > bin/$VERSION/install-windows.ps1

--- a/scripts/test/test-linux-install.sh
+++ b/scripts/test/test-linux-install.sh
@@ -6,7 +6,7 @@ export PATH=$PATH:~/.porter
 
 PORTER_PERMALINK=canary ./scripts/install/install-linux.sh
 
-PORTER_PERMALINK=v0.16.0-beta.1 ./scripts/install/install-linux.sh
-porter version | grep v0.16.0-beta.1
+PORTER_PERMALINK=v0.23.0-beta.1 ./scripts/install/install-linux.sh
+porter version | grep v0.23.0-beta.1
 
 PORTER_PERMALINK=latest ./scripts/install/install-linux.sh

--- a/scripts/test/test-mac-install.sh
+++ b/scripts/test/test-mac-install.sh
@@ -6,7 +6,7 @@ export PATH=$PATH:~/.porter
 
 PORTER_PERMALINK=canary ./scripts/install/install-mac.sh
 
-PORTER_PERMALINK=v0.16.0-beta.1 ./scripts/install/install-mac.sh
-porter version | grep v0.16.0-beta.1
+PORTER_PERMALINK=v0.23.0-beta.1 ./scripts/install/install-mac.sh
+porter version | grep v0.23.0-beta.1
 
 PORTER_PERMALINK=latest ./scripts/install/install-mac.sh

--- a/scripts/test/test-windows-install.ps1
+++ b/scripts/test/test-windows-install.ps1
@@ -4,8 +4,8 @@ $env:PATH+=";$env:USERPROFILE\.porter"
 
 & $PSScriptRoot\..\install\install-windows.ps1 -PORTER_PERMALINK canary
 
-& $PSScriptRoot\..\install\install-windows.ps1 -PORTER_PERMALINK v0.16.0-beta.1
-if (-Not (porter version | Select-String -Pattern 'v0.16.0-beta.1' -SimpleMatch))
+& $PSScriptRoot\..\install\install-windows.ps1 -PORTER_PERMALINK v0.23.0-beta.1
+if (-Not (porter version | Select-String -Pattern 'v0.23.0-beta.1' -SimpleMatch))
 {
     echo "Failed to install a specific version of porter"
     Exit 1


### PR DESCRIPTION
# What does this change
* Install the azure plugin by default
*  Fix missing newline when installing packages
    We lost the \n when printing the success message after installing a mixin or plugin. It wasn't obvious until I went to update the install script and saw the messages printing all on the same line.
*  Update install page
    * Include information about plugins
    * Do not list each mixin/plugin included in the install script, link to the index page instead.




# What issue does it fix
Closes #772

# Notes for the reviewer
I need to do a stable release of the azure plugin before this will pass, otherwise `porter plugins install azure` will fail because it doesn't have a `latest` stable release to install.

# Checklist
- [x] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
