### PR TITLE
Rename resources to learning

### DIFF
--- a/docs/content/learning.md
+++ b/docs/content/learning.md
@@ -1,6 +1,8 @@
 ---
-title: Resources
+title: Learning
 description: External videos, blog posts and tutorials about CNAB and Porter
+aliases:
+- /resources/
 ---
 
 Do you have a blog post, video, tutorial, demo, or some other neat thing 

--- a/docs/themes/porter/layouts/index.html
+++ b/docs/themes/porter/layouts/index.html
@@ -161,7 +161,7 @@
                   <div class="small-12 medium-12 large-5 helm-community-links columns">
                     <ul>
                       <li><i class="fa fa-book"></i> <a href="{{.Site.BaseURL}}docs">Read the Docs</a></li>
-                      <li><i class="fa fa-tv"></i> <a href="{{.Site.BaseURL}}resources">Videos and Tutorials</a></li>
+                      <li><i class="fa fa-tv"></i> <a href="{{.Site.BaseURL}}learning">Learning</a></li>
                       <li><i class="fa fa-comments"></i> <a href="{{.Site.BaseURL}}community">Community</a></li>
                       <li><i class="fa fa-github"></i> <a href="https://github.com/deislabs/porter">Porter on Github</a></li>
                     </ul>

--- a/docs/themes/porter/layouts/partials/nav.html
+++ b/docs/themes/porter/layouts/partials/nav.html
@@ -1,7 +1,7 @@
 <li><a href="{{ .Site.BaseURL }}install" title="Install Porter">Install</a></li>
 <li><a href="{{ .Site.BaseURL }}quickstart" title="Try Porter">QuickStart</a></li>
 <li><a href="{{ .Site.BaseURL }}community" title="Connect with Other Users">Community</a></li>
-<li><a href="{{ .Site.BaseURL }}resources" title="Videos and Tutorials">Resources</a></li>
+<li><a href="{{ .Site.BaseURL }}learning" title="Videos and Tutorials">Learning</a></li>
 <li><a href="{{ .Site.BaseURL }}docs" title="Porter Documentation">Docs</a></li>
 <!--<li><a href="#TODO" target="_blank" title="Find bundles for Porter">Bundles</a></li>-->
 <li><a href="https://github.com/deislabs/porter" target="_blank" class="hide-for-small-only" title="Porter on Github"><img src="{{ .Site.BaseURL }}src/img/github.svg" alt="Github" /></a></li>


### PR DESCRIPTION
# What does this change
When I was talking with @karenhchu yesterday she mentioned having a page called learning, and I thought this was a much better name for what we already had with Resources. We can make this page a collection of where to start learning about Porter.

https://deploy-preview-903--porter.netlify.com/ (top nav and scroll down)
https://deploy-preview-903--porter.netlify.com/learning/

# What issue does it fix
None, Karen is a precog. 🤖

# Notes for the reviewer
I've put in a redirect so that any old links keep working

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
