### PR TITLE
Detect documenation only builds

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -9,11 +9,17 @@ See all Porter related [pipelines across all repositories](https://dev.azure.com
 
 Our pipeline is broken into a few discrete builds so that we can control how and when they are triggered:
 
-* **azure-pipelines.release.yml**: Validates canary and tag releases. This can be tested in a pull request 
+* **porter-release: azure-pipelines.release.yml**: Validates canary and tag releases. This can be tested in a pull request 
   using `/azp run porter-release` though steps that require credentials will fail. [View Latest Builds](https://dev.azure.com/deislabs/porter/_build?definitionId=23)
-* **azure-pipelines.install.yml**: Validates our install scripts against canary and tag releases. [View Latest Builds](https://dev.azure.com/deislabs/porter/_build?definitionId=16)
-* **azure-pipelines.pr-automatic.yml**: Validates everything we can without a live environment. [View Latest Builds](https://dev.azure.com/deislabs/porter/_build?definitionId=6)
-* **azure-pipelines.pr-manual.yml**: Validates a pull request using a live environment. Requires manual triggering 
+* **porter-check-install: azure-pipelines.install.yml**: Validates our install scripts against canary and tag releases. [View Latest Builds](https://dev.azure.com/deislabs/porter/_build?definitionId=16)
+* **porter: azure-pipelines.pr-automatic.yml**: Validates everything we can without a live environment. [View Latest Builds](https://dev.azure.com/deislabs/porter/_build?definitionId=6)
+* **porter-integration: azure-pipelines.pr-manual.yml**: Validates a pull request using a live environment. Requires manual triggering 
   using `/azp run porter-integration` by a maintainer because this accesses secrets in the environment, 
   e.g. kubeconfig. We don't want this accessible to anyone who submits a PR without a code review first. [View Latest Builds](https://dev.azure.com/deislabs/porter/_build?definitionId=22)
- 
+
+### Documentation Only Builds
+
+The `porter` and `porter-integration` builds [detect if the build is
+documentation only](doc-only-build.sh) and will short circuit the build. They
+look for changes to the website, markdown files, workshop materials and
+repository metadata files that do not affect the build.

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -17,7 +17,15 @@ variables:
   MODULE_PATH: '$(GOPATH)/src/get.porter.sh/porter' # Path to the module's code
 
 jobs:
+- job: setup
+  steps:
+  - script: ./build/doc-only-build.sh
+    name: BUILD
+    displayName: 'Check Doc Only Build'
+
 - job: test
+  dependsOn: setup
+  condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'
@@ -33,6 +41,8 @@ jobs:
     displayName: 'Unit Test'
 
 - job: compile
+  dependsOn: setup
+  condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'
@@ -43,6 +53,8 @@ jobs:
     displayName: 'Cross Compile'
 
 - job: validate_example_bundles
+  dependsOn: setup
+  condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'

--- a/build/azure-pipelines.pr-manual.yml
+++ b/build/azure-pipelines.pr-manual.yml
@@ -17,7 +17,15 @@ variables:
   MODULE_PATH: '$(GOPATH)/src/get.porter.sh/porter' # Path to the module's code
 
 jobs:
+- job: setup
+  steps:
+  - script: ./build/doc-only-build.sh
+    name: BUILD
+    displayName: 'Check Doc Only Build'
+
 - job: integration_test
+  dependsOn: setup
+  condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'
@@ -41,6 +49,8 @@ jobs:
     displayName: 'Integration Test'
 
 - job: cli_test
+  dependsOn: setup
+  condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'

--- a/build/doc-only-build.sh
+++ b/build/doc-only-build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Return non-zero for a doc only build, and 0 for a builds that touch code.
+DOCS_REGEX='(LICENSE|netlify.toml)|(\.md$)|(^docs/)|(^.github/)|(^.workshop/)'
+if [[ -z "$(git diff --name-only HEAD HEAD~ | grep -vE $DOCS_REGEX)" ]]; then
+  echo "This is a doc-only build"
+  echo "##vso[task.setvariable variable=DOCS_ONLY;isOutput=true]true"
+  exit 1
+else
+  echo "A full build must be run, code has been changed"
+  echo "##vso[task.setvariable variable=DOCS_ONLY;isOutput=true]false"
+  exit 0
+fi


### PR DESCRIPTION
# What does this change
When only documentation files have been modified, skip running jobs for code so that the build completes quickly.

# What issue does it fix
Closes #623

# Notes for the reviewer
* The porter and porter-integration pipelines will report back but all the jobs inside will have skipped. So they should come back pretty quickly after checking out the code and detecting that it's a doc only change.
* I originally wrote this to compare master..HEAD but azure pipelines checks out the repo in such a way that it doesn't find master. I spent too much time trying to figure that out so I fell back to comparing HEAD~..HEAD instead since on the CI server it's always going to be a merge commit. If you run the script locally it won't work the same. That is something we could improve later if it becomes a problem.
* Once this is merged we can test it out on the plugin tutorial PR.

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
