### PR TITLE
Generate unique helm test release names

### DIFF
--- a/tests/dependencies_test.go
+++ b/tests/dependencies_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"get.porter.sh/porter/pkg/porter"
 	"github.com/cnabio/cnab-go/claim"
@@ -30,6 +31,7 @@ func TestDependenciesLifecycle(t *testing.T) {
 }
 
 func randomString(len int) string {
+	rand.Seed(time.Now().UnixNano())
 	bytes := make([]byte, len)
 	for i := 0; i < len; i++ {
 		//A=97 and Z = 97+25


### PR DESCRIPTION
# What does this change
We accidentally were seeding with a constant, so the "random" release names we were generating for our tests actually were the same from test run to test run. Oops...

# What issue does it fix
None, I saw this come up with the CI integration tests failed because it collided with a local integration test run.

# Notes for the reviewer
Narp

# Checklist
- [ ] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
