### PR TITLE
Always return 0 from doc build check

### DIFF
--- a/build/doc-only-build.sh
+++ b/build/doc-only-build.sh
@@ -6,9 +6,7 @@ DOCS_REGEX='(LICENSE|netlify.toml)|(\.md$)|(^docs/)|(^.github/)|(^.workshop/)'
 if [[ -z "$(git diff --name-only HEAD HEAD~ | grep -vE $DOCS_REGEX)" ]]; then
   echo "This is a doc-only build"
   echo "##vso[task.setvariable variable=DOCS_ONLY;isOutput=true]true"
-  exit 1
 else
   echo "A full build must be run, code has been changed"
   echo "##vso[task.setvariable variable=DOCS_ONLY;isOutput=true]false"
-  exit 0
 fi


### PR DESCRIPTION
I originally wrote the script to return 0/1 depending on if the build should do a full run or not. Then when I switched to setting azure pipeline variables, forgot to take out the exit statements. 🤦‍♀ 