### PR TITLE
Add redirects for our project boards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Closes # _(issue)_
 
 _If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._
 
-[1]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#when-to-open-a-pull-request
+[1]: /CONTRIBUTING.md#when-to-open-a-pull-request
 
 # Notes for the reviewer
 _Put any questions or notes for the reviewer here._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,9 @@ Another great way to contribute is to create a mixin! You can start use the
 
 [skeletor]: https://github.com/deislabs/porter-skeletor
 [mixin-dev-guide]: https://porter.sh/mixin-dev-guide/
-[good-first-issue]: https://github.com/orgs/deislabs/projects/2?card_filter_query=label%3A%22good+first+issue%22
-[help-wanted]: https://github.com/orgs/deislabs/projects/2?card_filter_query=label%3A%22help+wanted%22
-[board]: https://github.com/orgs/deislabs/projects/2
+[good-first-issue]: https://porter.sh/board/good+first+issue
+[help-wanted]: https://porter.sh/board/help+wanted
+[board]: https://porter.sh/board
 
 ## When to open a pull request
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ currently working on and plan to work on over the next few months. We use the
 "on-hold" bucket to communicate items of interest that doesn't have a core
 maintainer who will be working on it.
 
-<p align="center">Check out our <a href="https://github.com/deislabs/porter/projects/4">roadmap</a></p>
+<p align="center">Check out our <a href="https://porter.sh/roadmap">roadmap</a></p>
 
-[board]: https://github.com/orgs/deislabs/projects/2
+[board]: https://porter.sh/board

--- a/docs/content/architecture-buildtime.md
+++ b/docs/content/architecture-buildtime.md
@@ -20,4 +20,4 @@ if you would like to add content for this page.
 * [Mixin Architecture](/mixin-dev-guide/architecture/)
 * [Building the Invocation Image](/build-image/)
 
-[contrib]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#documentation
+[contrib]: /src/CONTRIBUTING.md#documentation

--- a/docs/content/architecture-runtime.md
+++ b/docs/content/architecture-runtime.md
@@ -14,4 +14,4 @@ if you would like to add content for this page.
 * How mixins are executed
 * single invocation image
 
-[contrib]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#documentation
+[contrib]: /src/CONTRIBUTING.md#documentation

--- a/docs/content/contribute.md
+++ b/docs/content/contribute.md
@@ -60,11 +60,11 @@ wanted][help-wanted] issues for our other contributors.
 * `help wanted` are issues suitable for someone who isn't a maintainer and usually 
    also has extra guidance.
 
-[conduct]: https://github.com/deislabs/porter/blob/master/CODE_OF_CONDUCT.md
-[contributing]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md
-[find-an-issue]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#find-an-issue
-[good-first-issue]: https://github.com/orgs/deislabs/projects/2?card_filter_query=label%3A%22good+first+issue%22
-[help-wanted]: https://github.com/orgs/deislabs/projects/2?card_filter_query=label%3A%22help+wanted%22
+[conduct]: /src/CODE_OF_CONDUCT.md
+[contributing]: /src/CONTRIBUTING.md
+[find-an-issue]: /src/CONTRIBUTING.md#find-an-issue
+[good-first-issue]: /board/good+first+issue
+[help-wanted]: /board/help+wanted
 
 ## What can you work on?
 
@@ -88,7 +88,7 @@ reach out to a maintainer on [Slack][slack].
 
 [skeletor]: https://github.com/deislabs/porter-skeletor
 [mixin-dev-guide]: /mixin-dev-guide/
-[roadmap]: https://github.com/deislabs/porter/projects/4
+[roadmap]: /roadmap
 
 ## Who can be a maintainer?
 
@@ -98,5 +98,5 @@ maintainer to admin.
 
 <p align="center">Sound like fun? 🙋🏽‍♀️ Join us!</p>
 
-[ladder]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#contribution-ladder
+[ladder]: /src/CONTRIBUTING.md#contribution-ladder
 [slack]: /community#slack

--- a/docs/content/dependencies.md
+++ b/docs/content/dependencies.md
@@ -90,4 +90,4 @@ At this time Porter only supports direct dependencies. Dependencies of dependenc
 transitive dependencies, are ignored. See [Design: Dependency Graph Resolution](https://github.com/deislabs/porter/issues/69) 
 for our backlog item tracking this feature. We do plan to support it!
 
-[example]: https://github.com/deislabs/porter/blob/master/build/testdata/bundles/wordpress/porter.yaml
+[example]: /src/build/testdata/bundles/wordpress/porter.yaml

--- a/docs/content/finding-bundles.md
+++ b/docs/content/finding-bundles.md
@@ -11,4 +11,4 @@ if you would like to add content for this page.
 * CNAB Spec is still working on distributing bundles
 * Once we have it, document how to find bundle registries
 
-[contrib]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#documentation
+[contrib]: /src/CONTRIBUTING.md#documentation

--- a/docs/content/learning.md
+++ b/docs/content/learning.md
@@ -15,7 +15,7 @@ and show it off! ✨
 * [Porter: An Opinionated CNAB Authoring Experience](#porter-an-opinionated-cnab-authoring-experience)
 * [Free Glue Code - Porter](#free-glue-code-porter)
 
-[pr]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md
+[pr]: /src/CONTRIBUTING.md
 
 ### Understanding Cloud Native Application Bundles
 

--- a/docs/content/mixin-dev-guide/distribution.md
+++ b/docs/content/mixin-dev-guide/distribution.md
@@ -74,5 +74,5 @@ can handle installing them as well.
 See the [Search Guide][search-guide] on how to search for available mixins and/or
 add your own to the list.
 
-[mk]: https://github.com/deislabs/porter/blob/master/mixin.mk
+[mk]: /src/mixin.mk
 [search-guide]: /package-search

--- a/docs/content/package-search.md
+++ b/docs/content/package-search.md
@@ -36,8 +36,8 @@ $ porter plugin search -o yaml
 Porter maintains a list each for mixins and plugins available for installation.
 They are represented in JSON:
 
-* [Mixin Directory](https://github.com/deislabs/porter/blob/master/pkg/mixin/directory/index.json)
-* [Plugin Directory](https://github.com/deislabs/porter/blob/master/pkg/plugins/directory/index.json)
+* [Mixin Directory](/src/pkg/mixin/directory/index.json)
+* [Plugin Directory](/src/pkg/plugins/directory/index.json)
 
 To list your mixin or plugin for others to see, create a new JSON entry just
 like the others, with details updated to reflect your offering.

--- a/docs/content/signing-bundles.md
+++ b/docs/content/signing-bundles.md
@@ -10,4 +10,4 @@ if you would like to add content for this page.
 
 * This needs to wait until we wrap duffle commands with porter
 
-[contrib]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#documentation
+[contrib]: /src/CONTRIBUTING.md#documentation

--- a/docs/content/use-mixins.md
+++ b/docs/content/use-mixins.md
@@ -17,4 +17,4 @@ if you would like to add content for this page.
 
 * [Mixin Architecture](/mixin-dev-guide/architecture/)
 
-[contrib]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md#documentation
+[contrib]: /src/CONTRIBUTING.md#documentation

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,2 +1,4 @@
-/project-board      https://github.com/orgs/deislabs/projects/2
+/board              https://github.com/orgs/deislabs/projects/2
+/board/*            https://github.com/orgs/deislabs/projects/2?card_filter_query=label:":splat"
 /roadmap            https://github.com/deislabs/porter/projects/4
+/src/*              https://github.com/deislabs/porter/blob/master/:splat

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,0 +1,2 @@
+/project-board      https://github.com/orgs/deislabs/projects/2
+/roadmap            https://github.com/deislabs/porter/projects/4


### PR DESCRIPTION
# What does this change
The URLs are kind of long and these will help us out if we ever need to change them in the future.

* project board, /board
* label queries on project board, like linking to good first issues and help wanted, e.g. /board/LABEL
* linking back to source code from our website, we can now use `/src/PATH`, e.g. `/src/CONTRIBUTING.md`
* roadmap board

# What issue does it fix
Me typing too much

# Notes for the reviewer
We can test these url's out on the netlify preview

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
