### PR TITLE
Split mixin command args by whitespace

### DIFF
--- a/pkg/exec/builder/execute.go
+++ b/pkg/exec/builder/execute.go
@@ -2,7 +2,6 @@ package builder
 
 import (
 	"bytes"
-	"encoding/csv"
 	"fmt"
 	"io"
 	"strings"
@@ -81,7 +80,7 @@ func ExecuteStep(cxt *context.Context, step ExecutableStep) (string, error) {
 	// Split up any arguments or flags that have spaces so that we pass them as separate array elements
 	// It doesn't show up any differently in the printed command, but it matters to how the command
 	// it executed against the system.
-	args = expandOnWhitespace(args)
+	args = splitCommand(args)
 
 	cmd := cxt.NewCommand(step.GetCommand(), args...)
 	output := &bytes.Buffer{}
@@ -106,26 +105,106 @@ func ExecuteStep(cxt *context.Context, step ExecutableStep) (string, error) {
 	return output.String(), nil
 }
 
+var whitespace = string([]rune{space, newline, tab})
+
+const (
+	space       = rune(' ')
+	newline     = rune('\n')
+	tab         = rune('\t')
+	backslash   = rune('\\')
+	doubleQuote = rune('"')
+	singleQuote = rune('\'')
+)
+
 // expandOnWhitespace finds elements with multiple words that are not "glued" together with quotes
 // and splits them into separate elements in the slice
-func expandOnWhitespace(slice []string) []string {
+func splitCommand(slice []string) []string {
 	expandedSlice := make([]string, 0, len(slice))
 	for _, chunk := range slice {
-		r := csv.NewReader(strings.NewReader(chunk))
-		r.Comma = ' '
-		r.LazyQuotes = true
-		group, err := r.Read()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			expandedSlice = append(expandedSlice, chunk)
-		} else {
-			for _, chunkette := range group {
-				expandedSlice = append(expandedSlice, chunkette)
-			}
-		}
+		chunkettes := findWords(chunk)
+		expandedSlice = append(expandedSlice, chunkettes...)
 	}
 
 	return expandedSlice
+}
+
+func findWords(input string) []string {
+	words := make([]string, 0, 1)
+	next := input
+	for len(next) > 0 {
+		word, remainder, err := findNextWord(next)
+		if err != nil {
+			return []string{input}
+		}
+		next = remainder
+		words = append(words, word)
+	}
+
+	return words
+}
+
+func findNextWord(input string) (string, string, error) {
+	var buf bytes.Buffer
+
+	// Remove leading whitespace before starting
+	input = strings.TrimLeft(input, whitespace)
+
+	var escaped bool
+	var wordStart, wordStop int
+	var closingQuote rune
+
+	for i, r := range input {
+		// Prevent escaped characters from matching below
+		if escaped {
+			r = -1
+			escaped = false
+		}
+
+		switch r {
+		case backslash:
+			// Escape the next character
+			escaped = true
+			continue
+		case closingQuote:
+			wordStop = i
+			closingQuote = 0 // Reset looking for a closing quote
+		case singleQuote, doubleQuote:
+			// Seek to the closing quote only
+			if closingQuote != 0 {
+				continue
+			}
+
+			wordStart = 1    // Skip opening quote
+			closingQuote = r // Seek to the same closing quote
+		case space, tab, newline:
+			// Seek to the closing quote only
+			if closingQuote != 0 {
+				continue
+			}
+
+			wordStart = 0
+			wordStop = i
+		}
+
+		// Found the end of a word
+		if wordStop > 0 {
+			_, err := buf.WriteString(input[wordStart:wordStop])
+			if err != nil {
+				return "", input, errors.New("error writing to buffer")
+			}
+			return buf.String(), input[wordStop+1:], nil
+		}
+	}
+
+	if closingQuote != 0 {
+		return "", "", errors.New("unmatched quote found")
+	}
+
+	// Hit the end of input, flush the remainder
+	_, err := buf.WriteString(input)
+	if err != nil {
+		return "", input, errors.New("error writing to buffer")
+	}
+
+	return buf.String(), "", nil
 }

--- a/pkg/exec/builder/execute_test.go
+++ b/pkg/exec/builder/execute_test.go
@@ -59,3 +59,25 @@ func TestExecuteSingleStepAction(t *testing.T) {
 	exists, _ = c.FileSystem.Exists("/cnab/app/porter/outputs/jsonpath")
 	assert.True(t, exists, "jsonpath output was not evaluated")
 }
+
+func Test_expandOnWhitespace(t *testing.T) {
+	t.Run("split whitespace", func(t *testing.T) {
+		result := expandOnWhitespace([]string{"cmd", "--myarg", "val1 val2"})
+		assert.Equal(t, []string{"cmd", "--myarg", "val1", "val2"}, result)
+	})
+
+	t.Run("keep double quoted whitespace", func(t *testing.T) {
+		result := expandOnWhitespace([]string{"cmd", "--myarg", "\"val1 val2\" val3"})
+		assert.Equal(t, []string{"cmd", "--myarg", "val1 val2", "val3"}, result)
+	})
+
+	t.Run("embedded single quote", func(t *testing.T) {
+		result := expandOnWhitespace([]string{"cmd", "--myarg", `"Patty O'Brien" true`})
+		assert.Equal(t, []string{"cmd", "--myarg", "Patty O'Brien", "true"}, result)
+	})
+
+	t.Run("embedded double quote", func(t *testing.T) {
+		result := expandOnWhitespace([]string{"cmd", "--myarg", `"Patty O"Brien" true`})
+		assert.Equal(t, []string{"cmd", "--myarg", "Patty O\"Brien", "true"}, result)
+	})
+}

--- a/pkg/exec/builder/execute_test.go
+++ b/pkg/exec/builder/execute_test.go
@@ -63,21 +63,27 @@ func TestExecuteSingleStepAction(t *testing.T) {
 func Test_expandOnWhitespace(t *testing.T) {
 	t.Run("split whitespace", func(t *testing.T) {
 		result := expandOnWhitespace([]string{"cmd", "--myarg", "val1 val2"})
-		assert.Equal(t, []string{"cmd", "--myarg", "val1", "val2"}, result)
+		assert.Equal(t, []string{"cmd", "--myarg", "val1", "val2"}, result, "strings not enclosed should be split apart")
 	})
 
 	t.Run("keep double quoted whitespace", func(t *testing.T) {
-		result := expandOnWhitespace([]string{"cmd", "--myarg", "\"val1 val2\" val3"})
-		assert.Equal(t, []string{"cmd", "--myarg", "val1 val2", "val3"}, result)
+		result := expandOnWhitespace([]string{"cmd", "--myarg", `"val1 val2" val3`})
+		assert.Equal(t, []string{"cmd", "--myarg", "val1 val2", "val3"}, result, "strings in the enclosing quotes should be grouped together")
 	})
 
 	t.Run("embedded single quote", func(t *testing.T) {
 		result := expandOnWhitespace([]string{"cmd", "--myarg", `"Patty O'Brien" true`})
-		assert.Equal(t, []string{"cmd", "--myarg", "Patty O'Brien", "true"}, result)
+		assert.Equal(t, []string{"cmd", "--myarg", "Patty O'Brien", "true"}, result, "single quotes should be included in the enclosing quotes")
 	})
 
+	// This test case could go either way, depending on what works better.
 	t.Run("embedded double quote", func(t *testing.T) {
 		result := expandOnWhitespace([]string{"cmd", "--myarg", `"Patty O"Brien" true`})
-		assert.Equal(t, []string{"cmd", "--myarg", "Patty O\"Brien", "true"}, result)
+		assert.Equal(t, []string{"cmd", "--myarg", "Patty O\"Brien", "true"}, result, "unmatched single quotes should be included in the enclosing quotes")
+	})
+
+	t.Run("escaped quotes", func(t *testing.T) {
+		result := expandOnWhitespace([]string{"c", `"echo { \"test\": \"myvalue\" }"`})
+		assert.Equal(t, []string{"c", `echo { \"test\": \"myvalue\" }`}, result, "escaped quotes should be included in the enclosing quotes")
 	})
 }

--- a/pkg/exec/builder/execute_test.go
+++ b/pkg/exec/builder/execute_test.go
@@ -60,30 +60,49 @@ func TestExecuteSingleStepAction(t *testing.T) {
 	assert.True(t, exists, "jsonpath output was not evaluated")
 }
 
-func Test_expandOnWhitespace(t *testing.T) {
-	t.Run("split whitespace", func(t *testing.T) {
-		result := expandOnWhitespace([]string{"cmd", "--myarg", "val1 val2"})
+func Test_splitCommand(t *testing.T) {
+	t.Run("split space", func(t *testing.T) {
+		result := splitCommand([]string{"cmd", "--myarg", "val1 val2"})
+		assert.Equal(t, []string{"cmd", "--myarg", "val1", "val2"}, result, "strings not enclosed should be split apart")
+	})
+
+	t.Run("split tab", func(t *testing.T) {
+		result := splitCommand([]string{"cmd", "--myarg", "val1\tval2"})
+		assert.Equal(t, []string{"cmd", "--myarg", "val1", "val2"}, result, "strings not enclosed should be split apart")
+	})
+
+	t.Run("split newline", func(t *testing.T) {
+		result := splitCommand([]string{"cmd", "--myarg", "val1\nval2"})
 		assert.Equal(t, []string{"cmd", "--myarg", "val1", "val2"}, result, "strings not enclosed should be split apart")
 	})
 
 	t.Run("keep double quoted whitespace", func(t *testing.T) {
-		result := expandOnWhitespace([]string{"cmd", "--myarg", `"val1 val2" val3`})
+		result := splitCommand([]string{"cmd", "--myarg", `"val1 val2" val3`})
 		assert.Equal(t, []string{"cmd", "--myarg", "val1 val2", "val3"}, result, "strings in the enclosing quotes should be grouped together")
 	})
 
 	t.Run("embedded single quote", func(t *testing.T) {
-		result := expandOnWhitespace([]string{"cmd", "--myarg", `"Patty O'Brien" true`})
+		result := splitCommand([]string{"cmd", "--myarg", `"Patty O'Brien" true`})
 		assert.Equal(t, []string{"cmd", "--myarg", "Patty O'Brien", "true"}, result, "single quotes should be included in the enclosing quotes")
 	})
 
-	// This test case could go either way, depending on what works better.
-	t.Run("embedded double quote", func(t *testing.T) {
-		result := expandOnWhitespace([]string{"cmd", "--myarg", `"Patty O"Brien" true`})
-		assert.Equal(t, []string{"cmd", "--myarg", "Patty O\"Brien", "true"}, result, "unmatched single quotes should be included in the enclosing quotes")
+	t.Run("escaped double quotes", func(t *testing.T) {
+		result := splitCommand([]string{"c", `"echo { \"test\": \"myvalue\" }"`})
+		assert.Equal(t, []string{"c", `echo { \"test\": \"myvalue\" }`}, result, "escaped double quotes should be included in the enclosing quotes")
 	})
 
-	t.Run("escaped quotes", func(t *testing.T) {
-		result := expandOnWhitespace([]string{"c", `"echo { \"test\": \"myvalue\" }"`})
-		assert.Equal(t, []string{"c", `echo { \"test\": \"myvalue\" }`}, result, "escaped quotes should be included in the enclosing quotes")
+	t.Run("escaped single quotes", func(t *testing.T) {
+		result := splitCommand([]string{"c", `"echo $'I\'m a linux admin.'"`})
+		assert.Equal(t, []string{"c", `echo $'I\'m a linux admin.'`}, result, "escaped single quotes should be included in the enclosing quotes")
+	})
+
+	t.Run("unmatched double quote", func(t *testing.T) {
+		result := splitCommand([]string{"cmd", "--myarg", `"Patty O"Brien" true`})
+		assert.Equal(t, []string{"cmd", "--myarg", `"Patty O"Brien" true`}, result, "unmatched double quotes should cause the grouping to fail")
+	})
+
+	t.Run("unmatched single quote", func(t *testing.T) {
+		result := splitCommand([]string{"cmd", "--myarg", `'Patty O'Brien' true`})
+		assert.Equal(t, []string{"cmd", "--myarg", `'Patty O'Brien' true`}, result, "unmatched single quotes should cause the grouping to fail")
 	})
 }

--- a/pkg/pkgmgmt/client/runner_integration_test.go
+++ b/pkg/pkgmgmt/client/runner_integration_test.go
@@ -70,6 +70,7 @@ func TestRunner_RunWithMaskedOutput(t *testing.T) {
 		Command: "install",
 		File:    "testdata/exec_input_with_whitespace.yaml",
 	}
+
 	err = r.Run(cmd)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hello ******* 	

--- a/pkg/pkgmgmt/client/testdata/exec_input.yaml
+++ b/pkg/pkgmgmt/client/testdata/exec_input.yaml
@@ -3,4 +3,4 @@ install:
     description: "Say Hello"
     command: bash
     flags:
-        c: echo Hello World
+        c: '"echo Hello World"'

--- a/pkg/pkgmgmt/client/testdata/exec_input_with_whitespace.yaml
+++ b/pkg/pkgmgmt/client/testdata/exec_input_with_whitespace.yaml
@@ -3,4 +3,6 @@ install:
     description: "Say Hello"
     command: bash
     flags:
-        c: "\"printf \"Hello World \t\n\"\""
+        c: |+
+          'printf "Hello World \t
+          "'

--- a/pkg/pkgmgmt/client/testdata/exec_input_with_whitespace.yaml
+++ b/pkg/pkgmgmt/client/testdata/exec_input_with_whitespace.yaml
@@ -3,4 +3,4 @@ install:
     description: "Say Hello"
     command: bash
     flags:
-        c: "printf \"Hello World \t\n\""
+        c: "\"printf \"Hello World \t\n\"\""


### PR DESCRIPTION
# What does this change
Some mixin commands have whitespace and right now we are passing them in as packed into a single array element when executing the command

`exec.Cmd("aws", []string{"ec2", "run-instances", "--security-group-ids group1 group2"})`

When the debug command is printed, we can't tell that this has happened, and why the command failed. What needs to happen is that when there is a space, and it's not enclosed in double quotes, it should be split into its own array element

`exec.Cmd("aws", []string{"ec2", "run-instances", "--security-group-ids", "group1", "group2"})`

# What issue does it fix
I think this will help with https://github.com/deislabs/porter-aws/issues/15

Here is how it would work
```yaml
install:
  - aws:
      description: "Provision VM"
      service: ec2
      operation: run-instances
      flags:
        image-id: ami-xxxxxxxxxxxxxxxxx
        instance-type: t2.micro
        region: eu-west-1
        subnet-id: subnet-xxxxxx
        security-group-ids: sg-1 sg2
```

If you really needed the flag to get both arguments passed together then you would use this:

```yaml
install:
  - aws:
      description: "Provision VM"
      service: ec2
      operation: run-instances
      flags:
        image-id: ami-xxxxxxxxxxxxxxxxx
        instance-type: t2.micro
        region: eu-west-1
        subnet-id: subnet-xxxxxx
        security-group-ids: '"sg-1 sg2"'
```

# Notes for the reviewer
Since the command looks the same when printed, I wasn't sure how to test this out other than just testing the function I added. 

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
