### PR TITLE
Fix help text for porter credentials

### DIFF
--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -62,9 +62,9 @@ When you wish to install, upgrade or delete a bundle, Porter will use the
 credential set to determine where to read the necessary information from and
 will then provide it to the bundle in the correct location. `,
 		Example: `  porter credential generate
-  porter bundle credential generate kubecred --file myapp/porter.yaml
-  porter bundle credential generate kubecred --tag getporter/porter-hello:v0.1.0
-  porter bundle credential generate kubecred --cnab-file myapp/bundle.json --dry-run
+  porter credential generate kubecred --file myapp/porter.yaml
+  porter credential generate kubecred --tag getporter/porter-hello:v0.1.0
+  porter credential generate kubecred --cnab-file myapp/bundle.json --dry-run
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -35,9 +35,9 @@ porter credentials generate [NAME] [flags]
 
 ```
   porter credential generate
-  porter bundle credential generate kubecred --file myapp/porter.yaml
-  porter bundle credential generate kubecred --tag getporter/porter-hello:v0.1.0
-  porter bundle credential generate kubecred --cnab-file myapp/bundle.json --dry-run
+  porter credential generate kubecred --file myapp/porter.yaml
+  porter credential generate kubecred --tag getporter/porter-hello:v0.1.0
+  porter credential generate kubecred --cnab-file myapp/bundle.json --dry-run
 
 ```
 


### PR DESCRIPTION
Was reading through the docs on the site today and got caught up on "porter bundle credentials generate" then realized its supposed to be "porter credentials generate"