### PR TITLE
Stop invoke when claim not found

### DIFF
--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -6,6 +6,7 @@
 trigger: none
 pr: 
   - master
+  - release-*
 
 pool:
   vmImage: 'Ubuntu 16.04'

--- a/build/azure-pipelines.pr-manual.yml
+++ b/build/azure-pipelines.pr-manual.yml
@@ -6,6 +6,7 @@
 trigger: none
 pr: 
   - master
+  - release-*
 
 pool:
   vmImage: 'Ubuntu 16.04'

--- a/pkg/cnab/provider/invoke.go
+++ b/pkg/cnab/provider/invoke.go
@@ -27,7 +27,7 @@ func (d *Runtime) getClaim(bun *bundle.Bundle, actionName, claimName string) (*c
 				}
 			}
 		}
-		return nil, false, errors.Wrapf(err, "could not load claim %s", claimName)
+		return nil, false, errors.Wrapf(err, "could not load bundle instance %s", claimName)
 	}
 	return &c, false, nil
 }
@@ -53,6 +53,9 @@ func (d *Runtime) Invoke(action string, args ActionArguments) error {
 	}
 
 	c, isTemp, err := d.getClaim(bun, action, args.Claim)
+	if err != nil {
+		return err
+	}
 
 	// Here we need to check this again
 	// If provided, we should set the bundle on the claim accordingly

--- a/pkg/cnab/provider/invoke_test.go
+++ b/pkg/cnab/provider/invoke_test.go
@@ -189,21 +189,32 @@ func Test_ClaimLoading(t *testing.T) {
 			want: result{
 				claim: eClaim,
 				temp:  false,
-				err:   errors.Wrap(claim.ErrClaimNotFound, "could not load claim nonexist"),
+				err:   errors.Wrap(claim.ErrClaimNotFound, "could not load bundle instance nonexist"),
 			},
 		},
 	}
 
 	for _, tc := range tests {
-		in := tc.in
-		want := tc.want
-		_, temp, err := d.getClaim(in.bun, in.action, in.claim)
-		assert.Equalf(t, want.temp, temp, "%s: expected temp=want.temp", tc.name)
-		if want.err == nil {
-			assert.NoErrorf(t, err, "%s: expected no error", tc.name)
-		} else {
-			assert.Errorf(t, err, "%s: expected error", tc.name)
-			assert.EqualErrorf(t, want.err, err.Error(), "%s: expected error %s, got %s", tc.name, want.err, err)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			in := tc.in
+			want := tc.want
+			_, temp, err := d.getClaim(in.bun, in.action, in.claim)
+			assert.Equalf(t, want.temp, temp, "getClaim returned an unexpected temporary flag")
+			if want.err == nil {
+				assert.NoErrorf(t, err, "getClaim failed")
+			} else {
+				assert.EqualErrorf(t, err, want.err.Error(), "getClaim returned an unexpected error")
+			}
+		})
 	}
+}
+
+func TestInvoke_NoClaimBubblesUpError(t *testing.T) {
+	r := NewTestRuntime(t)
+
+	args := ActionArguments{
+		Claim: "mybuns",
+	}
+	err := r.Invoke("custom-action", args)
+	require.EqualError(t, err, "could not load bundle instance mybuns: Claim does not exist")
 }


### PR DESCRIPTION
# What does this change
* During invoke, when we cannot find the requested claim, and it is required for the action, stop immediately and report the error to the user.
* I updated the error message so that it matches what is returned by upgrade when the claim doesn't exist.
* Run CI against release candidate PRs

Because we have changes in master that aren't ready to go in a release, I am making this a patch against the last release. Note that the branch this PR is open against is`release-0.24.1-beta.1` which is the desired next version (I branched off of `v0.24.0-beta.1`).

To facilitate this PR, I updated our azure pipelines to run against PRs targeting `release-*` branches.
 
# What issue does it fix
Closes #948 

# Notes for the reviewer
What the user was really doing was this

```
porter uninstall mybuns
porter invoke --action uninstallCleanup
```

Where the uninstallCleanup would do extra work. However since our current implementation deletes the claim, that is why when they called invoke, the claim was missing and they hit this bug. We are waiting on #935 for the long term fix for this problem.

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
