### PR TITLE
Simplify porter command navigation

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -39,154 +39,40 @@ defaultContentLanguage = "en"
   identifier = "cli"
   weight = 102
   [[menu.main]]
-    name = "porter create"
-    url = "/cli/porter_create"
-    identifier = "cli-create"
+    name = "Overview"
+    url = "/cli/porter/#see-also"
+    identifier = "cli-overview"
+    weight = 103
+    parent = "cli"
+  [[menu.main]]
+    name = "Bundles"
+    url = "/cli/porter_bundles"
+    identifier = "cli-bundles"
     weight = 123
     parent = "cli"
   [[menu.main]]
-    name = "porter build"
-    url = "/cli/porter_build"
-    identifier = "cli-build"
+    name = "Credentials"
+    url = "/cli/porter_credentials"
+    identifier = "cli-credentials"
     weight = 124
     parent = "cli"
   [[menu.main]]
-    name = "porter install"
-    url = "/cli/porter_install"
-    identifier = "cli-install"
+    name = "Instances"
+    url = "/cli/porter_instances"
+    identifier = "cli-instances"
     weight = 125
     parent = "cli"
   [[menu.main]]
-    name = "porter invoke"
-    url = "/cli/porter_invoke"
-    identifier = "cli-invoke"
+    name = "Mixins"
+    url = "/cli/porter_mixins"
+    identifier = "cli-mixins"
     weight = 126
     parent = "cli"
   [[menu.main]]
-    name = "porter upgrade"
-    url = "/cli/porter_upgrade"
-    identifier = "cli-upgrade"
+    name = "Plugins"
+    url = "/cli/porter_plugins"
+    identifier = "cli-plugins"
     weight = 127
-    parent = "cli"
-  [[menu.main]]
-    name = "porter uninstall"
-    url = "/cli/porter_uninstall"
-    identifier = "cli-uninstall"
-    weight = 128
-    parent = "cli"
-  [[menu.main]]
-    name = "porter list"
-    url = "/cli/porter_list"
-    identifier = "cli-list"
-    weight = 129
-    parent = "cli"
-  [[menu.main]]
-    name = "porter show"
-    url = "/cli/porter_show"
-    identifier = "cli-show"
-    weight = 129
-    parent = "cli"
-  [[menu.main]]
-    name = "porter instances output list"
-    url = "/cli/porter_instances_output_list"
-    identifier = "cli-instances-output-list"
-    weight = 130
-    parent = "cli"
-  [[menu.main]]
-    name = "porter instances output show"
-    url = "/cli/porter_instances_output_show"
-    identifier = "cli-instances-output-show"
-    weight = 131
-    parent = "cli"
-  [[menu.main]]
-    name = "porter mixins list"
-    url = "/cli/porter_mixins_list/"
-    identifier = "cli-mixins-list"
-    weight = 140
-    parent = "cli"
-  [[menu.main]]
-    name = "porter mixins search"
-    url = "/cli/porter_mixins_search/"
-    identifier = "cli-mixins-search"
-    weight = 141
-    parent = "cli"
-  [[menu.main]]
-    name = "porter mixins install"
-    url = "/cli/porter_mixins_install/"
-    identifier = "cli-mixins-install"
-    weight = 142
-    parent = "cli"
-  [[menu.main]]
-    name = "porter mixins uninstall"
-    url = "/cli/porter_mixins_uninstall/"
-    identifier = "cli-mixins-uninstall"
-    weight = 143
-    parent = "cli"
-  [[menu.main]]
-    name = "porter mixins feed template"
-    url = "/cli/porter_mixins_feed_template"
-    identifier = "cli-mixins-feed-template"
-    weight = 150
-    parent = "cli"
-  [[menu.main]]
-    name = "porter mixins feed generate"
-    url = "/cli/porter_mixins_feed_generate"
-    identifier = "cli-mixins-feed-generate"
-    weight = 151
-    parent = "cli"
-  [[menu.main]]
-    name = "porter copy"
-    url = "/cli/porter_copy"
-    identifier = "cli-copy"
-    weight = 160
-    parent = "cli"
-  [[menu.main]]
-    name = "porter archive"
-    url = "/cli/porter_archive"
-    identifier = "cli-archive"
-    weight = 161
-    parent = "cli"
-  [[menu.main]]
-    name = "porter plugins install"
-    url = "/cli/porter_plugins_install"
-    identifider = "cli-porter-plugins-install"
-    weight = 170
-    parent = "cli"
-  [[menu.main]]
-    name = "porter plugins show"
-    url = "/cli/porter_plugins_show"
-    identifider = "cli-porter-plugins-show"
-    weight = 171
-    parent = "cli"
-  [[menu.main]]
-    name = "porter plugins uninstall"
-    url = "/cli/porter_plugins_uninstall"
-    identifider = "cli-porter-plugins-uninstall"
-    weight = 172
-    parent = "cli"
-  [[menu.main]]
-    name = "porter plugins list"
-    url = "/cli/porter_plugins_list/"
-    identifier = "cli-plugins-list"
-    weight = 173
-    parent = "cli"
-  [[menu.main]]
-    name = "porter plugins search"
-    url = "/cli/porter_plugins_search/"
-    identifier = "cli-plugins-search"
-    weight = 174
-    parent = "cli"
-  [[menu.main]]
-    name = "porter schema"
-    url = "/cli/porter_schema"
-    identifier = "cli-schema"
-    weight = 198
-    parent = "cli"
-  [[menu.main]]
-    name = "porter version"
-    url = "/cli/porter_version"
-    identifier = "cli-version"
-    weight = 199
     parent = "cli"
 
 [[menu.main]]


### PR DESCRIPTION
# What does this change
Link to top level command resources, e.g. bundle, credentials
instead of to each individual command from the side bar. This keeps the
side nav more manageable to navigagte and to keep updated.

https://deploy-preview-957--porter.netlify.com/docs/

![Screen Shot 2020-03-23 at 1 25 38 PM](https://user-images.githubusercontent.com/1368985/77349969-d3934a00-6d09-11ea-86a9-3377a3d51c1a.png)


# What issue does it fix
Keeping the side-bar up-to-date and not scrolling forever on small screens.

# Notes for the reviewer
Do you think this is a good change?

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
