### PR TITLE
fix(docker.go): read .dockerignore file for appropriate build exclusions

### DIFF
--- a/pkg/build/provider/docker.go
+++ b/pkg/build/provider/docker.go
@@ -10,6 +10,7 @@ import (
 	portercontext "get.porter.sh/porter/pkg/context"
 	"get.porter.sh/porter/pkg/manifest"
 	"github.com/docker/cli/cli/command"
+	clibuild "github.com/docker/cli/cli/command/image/build"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/archive"
@@ -43,7 +44,12 @@ func (b *DockerBuilder) BuildInvocationImage(manifest *manifest.Manifest) error 
 			"BUNDLE_DIR": &build.BUNDLE_DIR,
 		},
 	}
-	tar, err := archive.TarWithOptions(path, &archive.TarOptions{})
+
+	excludes, err := clibuild.ReadDockerignore(path)
+	if err != nil {
+		return err
+	}
+	tar, err := archive.TarWithOptions(path, &archive.TarOptions{ExcludePatterns: excludes})
 	if err != nil {
 		return err
 	}

--- a/tests/build_test.go
+++ b/tests/build_test.go
@@ -1,0 +1,30 @@
+// +build integration
+
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"get.porter.sh/porter/pkg/porter"
+)
+
+func TestBuild_withDockerignore(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+	p.Debug = false
+
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.TestDir, "testdata/bundles/outputs-example"), ".")
+
+	// Create .dockerignore file which ignores the Dockerfile
+	err := p.FileSystem.WriteFile(".dockerignore", []byte("Dockerfile"), 0644)
+	require.NoError(t, err)
+
+	// Verify Porter uses the .dockerignore file
+	opts := porter.BuildOptions{}
+	err = p.Build(opts)
+	require.EqualError(t, err, "unable to build CNAB invocation image: Error response from daemon: Cannot locate specified Dockerfile: Dockerfile")
+}


### PR DESCRIPTION
# What does this change
* Adds appropriate exclusions to the Docker build context per the `.dockerignore` in the working directory

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/960

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
