### PR TITLE
Document suppress-output for mixins that support it

### DIFF
--- a/docs/content/mixins/aws.md
+++ b/docs/content/mixins/aws.md
@@ -31,11 +31,22 @@ aws:
     REPEATED_FLAG:
     - FLAGVALUE1
     - FLAGVALUE2
+  suppress-output: false
   outputs:
   - name: NAME
     jsonPath: JSONPATH
 ```
 
+### Suppress Output
+
+The `suppress-output` field controls whether output from the mixin should be
+prevented from printing to the console. By default this value is false, using
+Porter's default behavior of hiding known sensitive values. When 
+`suppress-output: true` all output from the mixin (stderr and stdout) are hidden.
+
+Step outputs (below) are still collected when output is suppressed. This allows
+you to prevent sensitive data from being exposed while still collecting it from
+a command and using it in your bundle.
 
 ### Outputs
 

--- a/docs/content/mixins/az.md
+++ b/docs/content/mixins/az.md
@@ -48,12 +48,24 @@ az:
     REPEATED_FLAG:
     - FLAGVALUE1
     - FLAGVALUE2
+  supress-output: false
   outputs:
     - name: NAME
       jsonPath: JSONPATH
     - name: NAME
       path: SOURCE_FILEPATH
 ```
+
+### Suppress Output
+
+The `suppress-output` field controls whether output from the mixin should be
+prevented from printing to the console. By default this value is false, using
+Porter's default behavior of hiding known sensitive values. When 
+`suppress-output: true` all output from the mixin (stderr and stdout) are hidden.
+
+Step outputs (below) are still collected when output is suppressed. This allows
+you to prevent sensitive data from being exposed while still collecting it from
+a command and using it in your bundle.
 
 ### Outputs
 

--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -30,6 +30,13 @@ exec:
     - flag-value1
     - flag-value2
   suppress-output: false
+  outputs:
+  - name: NAME
+    jsonPath: JSONPATH
+  - name: NAME
+    regex: GOLANG_REGULAR_EXPRESSION
+  - name: NAME
+    path: FILEPATH
 ```
 
 This is executed as:
@@ -42,9 +49,8 @@ $ cmd arg1 arg2 -a flag-value --long-flag true --repeated-flag flag-value1 --rep
 
 The `suppress-output` field controls whether output from the mixin should be
 prevented from printing to the console. By default this value is false, using
-Porter's default behavior of hiding known sensitive values, all credentials,
-outputs and parameters with `sensitive: true`. When `suppress-output: true` all
-output from the mixin (stderr and stdout) are hidden.
+Porter's default behavior of hiding known sensitive values. When 
+`suppress-output: true` all output from the mixin (stderr and stdout) are hidden.
 
 Step outputs (below) are still collected when output is suppressed. This allows
 you to prevent sensitive data from being exposed while still collecting it from
@@ -89,7 +95,6 @@ Then then output would have the following contents:
 #### Regular Expressions
 
 The `regex` output applies a Go-syntax regular expression to stdout and saves every capture group, one per line, to the output.
-
 
 ```yaml
 outputs:

--- a/docs/content/mixins/gcloud.md
+++ b/docs/content/mixins/gcloud.md
@@ -31,10 +31,13 @@ gcloud:
     REPEATED_FLAG:
     - FLAGVALUE1
     - FLAGVALUE2
+  suppress-output: false
   outputs:
     - name: NAME
       jsonPath: JSONPATH
 ```
+
+You can also specify a list of `groups`:
 
 ```yaml
 gcloud:
@@ -43,19 +46,18 @@ gcloud:
   - GROUP 1
   - GROUP 2
   command: COMMAND
-  arguments:
-  - arg1
-  - arg2
-  flags:
-    FLAGNAME: FLAGVALUE
-    REPEATED_FLAG:
-    - FLAGVALUE1
-    - FLAGVALUE2
-  outputs:
-    - name: NAME
-      jsonPath: JSONPATH
 ```
 
+### Suppress Output
+
+The `suppress-output` field controls whether output from the mixin should be
+prevented from printing to the console. By default this value is false, using
+Porter's default behavior of hiding known sensitive values. When 
+`suppress-output: true` all output from the mixin (stderr and stdout) are hidden.
+
+Step outputs (below) are still collected when output is suppressed. This allows
+you to prevent sensitive data from being exposed while still collecting it from
+a command and using it in your bundle.
 
 ### Outputs
 


### PR DESCRIPTION
# What does this change
Document suppress-output for aws, az, and gcloud. Also updated exec to match the wording used by the other mixins for consistency.

https://deploy-preview-965--porter.netlify.com/mixins/aws/
https://deploy-preview-965--porter.netlify.com/mixins/az/
https://deploy-preview-965--porter.netlify.com/mixins/exec/
https://deploy-preview-965--porter.netlify.com/mixins/gcloud/

# What issue does it fix
Final follow-up to #956.

# Notes for the reviewer
🐶 

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
