### PR TITLE
Explain plugins on the listing page

### DIFF
--- a/docs/content/plugins/_index.md
+++ b/docs/content/plugins/_index.md
@@ -1,16 +1,21 @@
 ---
 title: Plugins
-description: Available plugins for Porter
+description: Learn what a Porter plugin can do and see a listing of available plugins
 ---
 
 The Porter client is extensible and anyone can write a plugin to integrate with
-Porter. [Plugins are very different from mixins][vs], which give you building
-blocks for authoring bundles. There are a couple [types of plugins][types] and
-each plugin binary may contain multiple implementations.
+Porter. Plugins extend the Porter client, reimplementing Porter's default
+functionality. For example, Porter saves claims and credential sets using the local
+filesystem to ~/.porter by default. A plugin can change that behavior to save
+them to cloud storage instead. 
+
+[Plugins are very different from mixins][vs], which give you building blocks for
+authoring bundles. There are a couple [types of plugins][types] and a single
+plugin binary may contain multiple implementations.
 
 See the [Search Guide][search-guide] on how to search for available plugins and/or
 add your own to the list.
 
 [vs]: /mixins-vs-plugins/
 [types]: /plugins/types/
-[search-guide]: /package-search
+[search-guide]: /package-search/


### PR DESCRIPTION
# What does this change
People may come to the listing page for plugins /plugins to understand
what plugins are. Make sure we have some introductory text there that
leads them to the more detailed plugin types page and the plugins vs
mixins page as well.

https://deploy-preview-966--porter.netlify.com/plugins/

# What issue does it fix
This is based on feedback given from users on the /plugins page.

# Notes for the reviewer
🐱 

# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted
