### PR TITLE
fix(generate.go): update mixin regex; add tests

### DIFF
--- a/pkg/pkgmgmt/feed/generate.go
+++ b/pkg/pkgmgmt/feed/generate.go
@@ -64,9 +64,9 @@ func (feed *MixinFeed) Generate(opts GenerateOptions) error {
 		}
 	}
 
-	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z]+)-(linux|windows|darwin)-(amd64)(\.exe)?`)
+	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z0-9]+)-(linux|windows|darwin)-(amd64)(\.exe)?`)
 
-	return feed.FileSystem.Walk(opts.SearchDirectory, func(path string, info os.FileInfo, err error) error {
+	err = feed.FileSystem.Walk(opts.SearchDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -109,6 +109,16 @@ func (feed *MixinFeed) Generate(opts GenerateOptions) error {
 
 		return nil
 	})
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to traverse the %s directory", opts.SearchDirectory)
+	}
+
+	if len(feed.Index) == 0 {
+		return fmt.Errorf("no mixin binaries found in %s matching the regex %q", opts.SearchDirectory, mixinRegex)
+	}
+
+	return nil
 }
 
 func (feed *MixinFeed) Save(opts GenerateOptions) error {

--- a/pkg/pkgmgmt/feed/generate_test.go
+++ b/pkg/pkgmgmt/feed/generate_test.go
@@ -1,6 +1,7 @@
 package feed
 
 import (
+	"fmt"
 	"io/ioutil"
 	"sort"
 	"testing"
@@ -73,6 +74,52 @@ func TestGenerate(t *testing.T) {
 	wantXml := string(b)
 
 	assert.Equal(t, wantXml, gotXml)
+}
+
+func TestGenerate_RegexMatch(t *testing.T) {
+	testcases := []struct {
+		name      string
+		mixinName string
+		wantError string
+	}{{
+		name:      "no bins",
+		mixinName: "",
+		wantError: `failed to traverse the bin directory: open bin: file does not exist`,
+	}, {
+		name:      "valid mixin name",
+		mixinName: "my42ndmixin",
+		wantError: "",
+	}, {
+		name:      "invalid mixin name",
+		mixinName: "my42ndmixin!",
+		wantError: `no mixin binaries found in bin matching the regex "(.*/)?(.+)/([a-z0-9]+)-(linux|windows|darwin)-(amd64)(\\.exe)?"`,
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.NewTestContext(t)
+			ctx.AddTestFile("testdata/atom-template.xml", "template.xml")
+
+			if tc.mixinName != "" {
+				ctx.FileSystem.Create(fmt.Sprintf("bin/v1.2.3/%s-darwin-amd64", tc.mixinName))
+				ctx.FileSystem.Create(fmt.Sprintf("bin/v1.2.3/%s-linux-amd64", tc.mixinName))
+				ctx.FileSystem.Create(fmt.Sprintf("bin/v1.2.3/%s-windows-amd64.exe", tc.mixinName))
+			}
+
+			opts := GenerateOptions{
+				AtomFile:        "atom.xml",
+				SearchDirectory: "bin",
+				TemplateFile:    "template.xml",
+			}
+			f := NewMixinFeed(ctx.Context)
+			err := f.Generate(opts)
+			if tc.wantError != "" {
+				require.EqualError(t, err, tc.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestGenerate_ExistingFeed(t *testing.T) {


### PR DESCRIPTION
# What does this change
* Updates the mixin regex that `generate.go` uses to allow for alphanumeric mixin names
* `Generate(...)` now returns an error if no entries were created

# What issue does it fix
@MChorfa noted that running `porter mixin feed generate ...` failed for a mixin named [helm3](https://github.com/MChorfa/porter-helm3):

```shell
~/go/src/github.com/porter-helm3 ϟ porter mixins feed generate -d bin/mixins -f bin/atom.xml -t build/atom-template.xml
panic: runtime error: index out of range [0] with length 0
```

It appears that this mixin name did not match the previous version of the regex (it precluded numeric characters), so we ended up with an empty list of entries when we tried to save the generated feed.  Therefore, a bit of logic has been added to fail faster if no entries are generated in the `Generate(...)` method.  (Open to suggestions/changes here, if we'd rather go a different route to prevent the panic.)

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
