### PR TITLE
feat(generate.go): update the mixin regex to support hyphens

### DIFF
--- a/pkg/pkgmgmt/feed/generate.go
+++ b/pkg/pkgmgmt/feed/generate.go
@@ -64,7 +64,7 @@ func (feed *MixinFeed) Generate(opts GenerateOptions) error {
 		}
 	}
 
-	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z0-9]+)-(linux|windows|darwin)-(amd64)(\.exe)?`)
+	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z0-9-]+)-(linux|windows|darwin)-(amd64)(\.exe)?`)
 
 	err = feed.FileSystem.Walk(opts.SearchDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/pkg/pkgmgmt/feed/generate_test.go
+++ b/pkg/pkgmgmt/feed/generate_test.go
@@ -87,12 +87,12 @@ func TestGenerate_RegexMatch(t *testing.T) {
 		wantError: `failed to traverse the bin directory: open bin: file does not exist`,
 	}, {
 		name:      "valid mixin name",
-		mixinName: "my42ndmixin",
+		mixinName: "my-42nd-mixin",
 		wantError: "",
 	}, {
 		name:      "invalid mixin name",
-		mixinName: "my42ndmixin!",
-		wantError: `no mixin binaries found in bin matching the regex "(.*/)?(.+)/([a-z0-9]+)-(linux|windows|darwin)-(amd64)(\\.exe)?"`,
+		mixinName: "my-42nd-mixin!",
+		wantError: `no mixin binaries found in bin matching the regex "(.*/)?(.+)/([a-z0-9-]+)-(linux|windows|darwin)-(amd64)(\\.exe)?"`,
 	}}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
# What does this change
* Updates the mixin regex that the feed generate logic uses to allow for hyphens

Say, for a forthcoming `docker-compose` mixin!

# What issue does it fix
N/A
# Notes for the reviewer
N/A
# Checklist
- [x] Unit Tests
- [ ] Documentation
  - [ ] Documentation Not Impacted
