### PR TITLE
Fix regression in loading bundle from claim

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -127,6 +127,11 @@ func (c *Cache) cacheManifest(cb *CachedBundle) error {
 	if configadapter.IsPorterBundle(cb.Bundle) {
 		stamp, err := configadapter.LoadStamp(cb.Bundle)
 		if err != nil {
+			fmt.Fprintf(c.Err, "WARNING: Bundle %s was created by porter but could not load the Porter stamp. This may be because it was created by an older version of Porter.\n", cb.Tag)
+			return nil
+		}
+
+		if stamp.EncodedManifest == "" {
 			fmt.Fprintf(c.Err, "WARNING: Bundle %s was created by porter but could not find a porter manifest embedded. This may be because it was created by an older version of Porter.\n", cb.Tag)
 			return nil
 		}

--- a/pkg/cnab/config-adapter/stamp.go
+++ b/pkg/cnab/config-adapter/stamp.go
@@ -34,6 +34,10 @@ type Stamp struct {
 
 // DecodeManifest base64 decodes the manifest stored in the stamp
 func (s Stamp) DecodeManifest() ([]byte, error) {
+	if s.EncodedManifest == "" {
+		return nil, errors.New("no Porter manifest was embedded in the bundle")
+	}
+
 	resultB, err := base64.StdEncoding.DecodeString(s.EncodedManifest)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not base64 decode the manifest in the stamp\n%s", s.EncodedManifest)

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -150,3 +150,30 @@ func TestBundleLifecycleOpts_ToActionArgs(t *testing.T) {
 		assert.Equal(t, opts.RelocationMapping, args.RelocationMapping, "RelocationMapping not populated correctly")
 	})
 }
+
+func TestInstallFromTag_ManageFromClaim(t *testing.T) {
+	p := NewTestPorter(t)
+
+	installOpts := InstallOptions{}
+	installOpts.Name = "hello"
+	installOpts.Tag = "getporter/porter-hello:v0.1.0"
+	err := installOpts.Validate(nil, p.Context)
+	require.NoError(t, err, "InstallOptions.Validate failed")
+
+	err = p.InstallBundle(installOpts)
+	require.NoError(t, err, "InstallBundle failed")
+
+	upgradeOpts := UpgradeOptions{}
+	upgradeOpts.Name = installOpts.Name
+	err = upgradeOpts.Validate(nil, p.Context)
+
+	err = p.UpgradeBundle(upgradeOpts)
+	require.NoError(t, err, "UpgradeBundle failed")
+
+	uninstallOpts := UninstallOptions{}
+	uninstallOpts.Name = installOpts.Name
+	err = uninstallOpts.Validate(nil, p.Context)
+
+	err = p.UninstallBundle(uninstallOpts)
+	require.NoError(t, err, "UninstallBundle failed")
+}


### PR DESCRIPTION
# What does this change
v0.26.0-beta.1 (specifically #976) caused a regression where an error aborted actions that relied on the bundle instance name to identity and retrieve the bundle.

* Some porter bundles will have a stamp, but not an embedded manifest. Gracefully handle this when caching the bundle, and return hard errors when people try to read the manifest out of the cache.
* Previously we were accidentally ignoring errors when bundle load failed in the dependencies code. This helped cover up not handling when the bundle was supplied through just an instance name. In the latest release, I fixed the lack of error handling but didn't catch that the
code wasn't loading bundles from the claim name too (just from the file or tag). This adds in logic to also load the bundle from an instance name.

# What issue does it fix
Closes #981 

# Notes for the reviewer
There were two bugs in one with this, both had to be fixed for all bundles (those made by porter post v0.26.0-beta1, those made by porter earlier, and non-porter bundles) to load properly.

# Checklist
- [x] Unit Tests
- [ ] Documentation - not impacted
- [ ] Schema (porter.yaml) - not impacted
