### PR TITLE
Fix docker required extension schema and processing

### DIFF
--- a/pkg/cnab/extensions/docker.go
+++ b/pkg/cnab/extensions/docker.go
@@ -43,12 +43,25 @@ func DockerExtensionReader(bun *bundle.Bundle) (interface{}, error) {
 			DockerExtensionKey, string(dataB))
 	}
 
-	dha := &Docker{}
-	err = json.Unmarshal(dataB, dha)
+	dha := Docker{}
+	err = json.Unmarshal(dataB, &dha)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not unmarshal the %q extension %q",
 			DockerExtensionKey, string(dataB))
 	}
 
 	return dha, nil
+}
+
+// GetDockerExtension checks if the docker extension is present and returns its
+// extension configuration.
+func (e ProcessedExtensions) GetDockerExtension() (dockerExt Docker, dockerRequired bool, err error) {
+	ext, extensionRequired := e[DockerExtensionKey]
+
+	dockerExt, ok := ext.(Docker)
+	if !ok && extensionRequired {
+		return Docker{}, extensionRequired, errors.Errorf("unable to parse Docker extension config: %+v", dockerExt)
+	}
+
+	return dockerExt, extensionRequired, nil
 }

--- a/pkg/cnab/extensions/docker_test.go
+++ b/pkg/cnab/extensions/docker_test.go
@@ -1,0 +1,43 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessedExtensions_GetDockerExtension(t *testing.T) {
+	t.Run("extension present", func(t *testing.T) {
+		ext := ProcessedExtensions{
+			DockerExtensionKey: Docker{
+				Privileged: true,
+			},
+		}
+
+		dockerExt, dockerRequired, err := ext.GetDockerExtension()
+		require.NoError(t, err, "GetDockerExtension failed")
+		assert.True(t, dockerRequired, "docker should be a required extension")
+		assert.Equal(t, Docker{Privileged: true}, dockerExt, "docker config was not populated properly")
+	})
+
+	t.Run("extension missing", func(t *testing.T) {
+		ext := ProcessedExtensions{}
+
+		dockerExt, dockerRequired, err := ext.GetDockerExtension()
+		require.NoError(t, err, "GetDockerExtension failed")
+		assert.False(t, dockerRequired, "docker should NOT be a required extension")
+		assert.Equal(t, Docker{}, dockerExt, "Docker config should default to empty when not required")
+	})
+
+	t.Run("extension invalid", func(t *testing.T) {
+		ext := ProcessedExtensions{
+			DockerExtensionKey: map[string]string{"ponies": "are great"},
+		}
+
+		dockerExt, dockerRequired, err := ext.GetDockerExtension()
+		require.Error(t, err, "GetDockerExtension failed")
+		assert.True(t, dockerRequired, "docker should be a required extension")
+		assert.Equal(t, Docker{}, dockerExt, "Docker config should default to empty")
+	})
+}

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -437,7 +437,10 @@
               "type": "object"
             }
           },
-          "type": "object"
+          "type": [
+            "string",
+            "object"
+          ]
         }
       ],
       "type": "array",

--- a/pkg/templates/templates/schema.json
+++ b/pkg/templates/templates/schema.json
@@ -238,7 +238,7 @@
       "type": "array",
       "items": [
         {
-          "type": "object",
+          "type": ["string","object"],
           "properties": {
             "docker": {
               "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
# What does this change
*  Default docker extension config to empty, not nil
    When reading the docker required extension config from the porter.yaml,
when none is specified, return an empty docker config, not nil. Also
I've changed the signature so that the docker config is a struct not
pointer, to make it clear it's required and avoid a nil reference
exception.
* Fix schema for docker required extension
  Allow for an entry that is just the name
  
  ```
  required:
    - docker
  ```
  and for a required extension with config

  ```
  required:
    - docker:
        privileged: true
  ```


# What issue does it fix
Closes #983

# Notes for the reviewer
🥧 

# Checklist
- [x] Unit Tests
- [x] Documentation - not impacted
- [x] Schema (porter.yaml)
