### PR TITLE
Update schema to set invocation image optional

### DIFF
--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -475,7 +475,6 @@
   "required": [
     "name",
     "version",
-    "invocationImage",
     "mixins"
   ],
   "type": "object"

--- a/pkg/templates/templates/schema.json
+++ b/pkg/templates/templates/schema.json
@@ -292,5 +292,5 @@
       "anyOf": []
     }
   },
-  "required": ["name", "version", "invocationImage", "mixins"]
+  "required": ["name", "version", "mixins"]
 }


### PR DESCRIPTION
# What does this change
The invocationImage field in porter.yaml is now optional, so remove it from the required list in the schema.

# What issue does it fix
Closes #383 

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Unit Tests
- [x] Documentation - not impacted
- [x] Schema (porter.yaml)
