### PR TITLE
fix(migrateClaimsWrapper_test.go): sort list before validation

### DIFF
--- a/pkg/claims/migrateClaimsWrapper_test.go
+++ b/pkg/claims/migrateClaimsWrapper_test.go
@@ -3,6 +3,7 @@ package claims
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"testing"
 
 	"get.porter.sh/porter/pkg/context"
@@ -56,8 +57,9 @@ func TestMigrateClaimsWrapper_List(t *testing.T) {
 	loadTestClaim(t, "migrated", dataStore)
 
 	names, err := claimStore.List()
+	sort.Strings(names)
 	require.NoError(t, err, "could not list claims")
-	assert.Equal(t, []string{"unmigrated", "migrated"}, names, "unexpected list of claim installation names")
+	assert.Equal(t, []string{"migrated", "unmigrated"}, names, "unexpected list of claim installation names")
 }
 
 func loadTestClaim(t *testing.T, claimName string, store crud.Store) {


### PR DESCRIPTION
# What does this change
Apparently, this particular test may fail in [CI](https://dev.azure.com/deislabs/porter/_build/results?buildId=5777&view=logs&j=dc3bdf25-abe2-53a3-4b0b-7fee357bcfdc&t=0e2fdf7b-745b-5b2f-40e5-29886a6d1e8c).

In the test, we were adding each claim in order and checking the list against that order, but perhaps there's a race if we rely on the stock list order (by date).  Let me know if the quick fix of sorting by name and checking against that order isn't desired.

# What issue does it fix
N/A
# Notes for the reviewer
N/A
# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
