### PR TITLE
fix(query.go): actually propogate mixin runErr

### DIFF
--- a/pkg/mixin/helpers.go
+++ b/pkg/mixin/helpers.go
@@ -2,6 +2,7 @@ package mixin
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -16,6 +17,10 @@ type TestMixinProvider struct {
 	// LintResults allows you to provide linter.Results for your unit tests.
 	// It isn't of type linter.Results directly to avoid package cycles
 	LintResults interface{}
+
+	// ReturnBuildError will force the TestMixinProvider to return a build error
+	// if set to true
+	ReturnBuildError bool
 }
 
 // NewTestMixinProvider helps us test Porter.Mixins in our unit tests without actually hitting any real plugins on the file system.
@@ -38,21 +43,25 @@ func NewTestMixinProvider() *TestMixinProvider {
 		},
 	}
 
-	provider.RunAssertions = []func(pkgContext *context.Context, name string, commandOpts pkgmgmt.CommandOptions){
+	provider.RunAssertions = []func(pkgContext *context.Context, name string, commandOpts pkgmgmt.CommandOptions) error{
 		provider.PrintExecOutput,
 	}
 
 	return &provider
 }
 
-func (p *TestMixinProvider) PrintExecOutput(pkgContext *context.Context, name string, commandOpts pkgmgmt.CommandOptions) {
+func (p *TestMixinProvider) PrintExecOutput(pkgContext *context.Context, name string, commandOpts pkgmgmt.CommandOptions) error {
 	switch commandOpts.Command {
 	case "build":
+		if p.ReturnBuildError {
+			return errors.New("encountered build error")
+		}
 		fmt.Fprintln(pkgContext.Out, "# exec mixin has no buildtime dependencies")
 	case "lint":
 		b, _ := json.Marshal(p.LintResults)
 		fmt.Fprintln(pkgContext.Out, string(b))
 	}
+	return nil
 }
 
 func (p *TestMixinProvider) GetSchema(name string) (string, error) {

--- a/pkg/mixin/query/query.go
+++ b/pkg/mixin/query/query.go
@@ -110,20 +110,21 @@ func (q *MixinQuery) Execute(cmd string, inputGenerator MixinInputGenerator) (ma
 		if response.runErr == nil {
 			results[response.mixinName] = response.output
 		} else {
-			runErr = multierror.Append(runErr, response.runErr)
+			runErr = multierror.Append(runErr,
+				errors.Wrapf(response.runErr, "error encountered from mixin %q", response.mixinName))
 		}
 	}
 
 	if runErr != nil {
 		if q.RequireAllMixinResponses {
-			return nil, err
+			return nil, runErr
 		}
 
 		// This is a debug because we expect not all mixins to implement some
 		// optional commands, like lint and don't want to print their error
 		// message when we query them with a command they don't support.
 		if q.Debug {
-			fmt.Fprintln(q.Err, errors.Wrap(err, "not all mixins responded successfully"))
+			fmt.Fprintln(q.Err, errors.Wrap(runErr, "not all mixins responded successfully"))
 		}
 	}
 

--- a/pkg/pkgmgmt/client/helpers.go
+++ b/pkg/pkgmgmt/client/helpers.go
@@ -16,7 +16,7 @@ var _ pkgmgmt.PackageManager = &TestPackageManager{}
 type TestPackageManager struct {
 	PkgType       string
 	Packages      []pkgmgmt.PackageMetadata
-	RunAssertions []func(pkgContext *context.Context, name string, commandOpts pkgmgmt.CommandOptions)
+	RunAssertions []func(pkgContext *context.Context, name string, commandOpts pkgmgmt.CommandOptions) error
 }
 
 func (p *TestPackageManager) List() ([]string, error) {
@@ -52,7 +52,10 @@ func (p *TestPackageManager) Uninstall(o pkgmgmt.UninstallOptions) error {
 
 func (p *TestPackageManager) Run(pkgContext *context.Context, name string, commandOpts pkgmgmt.CommandOptions) error {
 	for _, assert := range p.RunAssertions {
-		assert(pkgContext, name, commandOpts)
+		err := assert(pkgContext, name, commandOpts)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/porter/run_test.go
+++ b/pkg/porter/run_test.go
@@ -6,11 +6,10 @@ import (
 
 	"get.porter.sh/porter/pkg/mixin"
 
-	"get.porter.sh/porter/pkg/pkgmgmt"
-
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/context"
 	"get.porter.sh/porter/pkg/manifest"
+	"get.porter.sh/porter/pkg/pkgmgmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,10 +19,11 @@ func TestPorter_Run(t *testing.T) {
 
 	// Mock the mixin test runner and verify that we are calling runtime mixins, e.g. exec-runtime and not exec
 	mp := p.Mixins.(*mixin.TestMixinProvider)
-	mp.RunAssertions = append(mp.RunAssertions, func(mixinCxt *context.Context, mixinName string, commandOpts pkgmgmt.CommandOptions) {
+	mp.RunAssertions = append(mp.RunAssertions, func(mixinCxt *context.Context, mixinName string, commandOpts pkgmgmt.CommandOptions) error {
 		assert.Equal(t, "exec", mixinName, "expected to call the exec mixin")
 		assert.True(t, commandOpts.Runtime, "the mixin command should be executed in runtime mode")
 		assert.Equal(t, "install", commandOpts.Command, "should have executed the mixin's install command")
+		return nil
 	})
 	p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "/cnab/bundle.json")
 	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")


### PR DESCRIPTION
# What does this change
* updates logic in `query.go` to return mixin errors

It appears we hadn't actually been returning mixin errors if they occurred during mixin build invocations (e.g. when assembling the mixin section of the invocation image Dockerfile).  This makes sure we capture such errors and halt the bundle build appropriately.

# What issue does it fix
N/A
# Notes for the reviewer
Note the changes in order to cover under test.  Open to suggestions on a different way.

# Checklist
- [x] Unit Tests
- [x] Documentation - not impacted
- [x] Schema (porter.yaml) - not impacted
