### PR TITLE
Remove old cached bundle on refresh

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -75,6 +75,12 @@ func (c *Cache) StoreBundle(bundleTag string, bun bundle.Bundle, reloMap *reloca
 	}
 	cb.SetCacheDir(cacheDir)
 
+	// Remove any previously cached bundle files
+	err = c.FileSystem.RemoveAll(cb.cacheDir)
+	if err != nil {
+		return CachedBundle{}, errors.Wrapf(err, "cannot remove existing cache directory %s", cb.BundlePath)
+	}
+
 	cb.BundlePath = cb.BuildBundlePath()
 	err = c.FileSystem.MkdirAll(filepath.Dir(cb.BundlePath), os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
# What does this change
When we refresh the cached files for a bundle, delete the old directory so that any files that would not be overwritten, for example the updated bundle doesn't have a relocation mapping file or manifest, are removed.

# What issue does it fix
Fixes #991

# Notes for the reviewer
As a follow-up I am working on #992 since per the original issue, they are using `porter explain` which doesn't have a `--force` flag to make it easy for them to repull the bundle and use this fix.

# Checklist
- [x] Unit Tests
- [x] Documentation - not impacted
- [x] Schema (porter.yaml) - not impacted
