### PR TITLE
ref(parameters.go): remove zero value/default param logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/containerd/ttrpc v1.0.0 // indirect
 	github.com/containerd/typeurl v1.0.0 // indirect
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017
-	github.com/docker/cnab-to-oci v0.3.0-beta4
+	github.com/docker/cnab-to-oci v0.3.0-beta4 // indirect
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v1.4.2-0.20181229214054-f76d6a078d88
 	github.com/docker/go-metrics v0.0.1 // indirect
@@ -58,3 +58,5 @@ replace github.com/hashicorp/go-plugin => github.com/carolynvs/go-plugin v1.0.1-
 // See https://github.com/containerd/containerd/issues/3031
 // When I try to just use the require, go is shortening it to v2.7.1+incompatible which then fails to build...
 replace github.com/docker/distribution => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
+
+replace github.com/cnabio/cnab-go => github.com/vdice/cnab-go v0.0.0-20200416174429-5ab209b0f008

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.0 // indirect
 	github.com/carolynvs/datetime-printer v0.2.0
 	github.com/cbroglie/mustache v1.0.1
-	github.com/cnabio/cnab-go v0.10.1-beta1
+	github.com/cnabio/cnab-go v0.11.0-beta1
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
 	github.com/containerd/cgroups v0.0.0-20200108155730-918ed86e29cc // indirect
 	github.com/containerd/containerd v1.3.0
@@ -58,5 +58,3 @@ replace github.com/hashicorp/go-plugin => github.com/carolynvs/go-plugin v1.0.1-
 // See https://github.com/containerd/containerd/issues/3031
 // When I try to just use the require, go is shortening it to v2.7.1+incompatible which then fails to build...
 replace github.com/docker/distribution => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
-
-replace github.com/cnabio/cnab-go => github.com/vdice/cnab-go v0.0.0-20200416174429-5ab209b0f008

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/cnabio/cnab-go v0.9.0-beta1/go.mod h1:5c4uOP6ZppR4nUGtCMAElscRiYEUi44
 github.com/cnabio/cnab-go v0.10.0-beta1/go.mod h1:5c4uOP6ZppR4nUGtCMAElscRiYEUi44vNQwtSAvISXk=
 github.com/cnabio/cnab-go v0.10.1-beta1 h1:ZxeHSuasovGuL2LmyKR8WH/jGy+RbDun9kS482kRO30=
 github.com/cnabio/cnab-go v0.10.1-beta1/go.mod h1:5c4uOP6ZppR4nUGtCMAElscRiYEUi44vNQwtSAvISXk=
+github.com/cnabio/cnab-go v0.11.0-beta1 h1:S8M3sHzVC6kKcPBKDx/o1WdEUKsoWFGodPl8xp8RKHY=
+github.com/cnabio/cnab-go v0.11.0-beta1/go.mod h1:5c4uOP6ZppR4nUGtCMAElscRiYEUi44vNQwtSAvISXk=
 github.com/cnabio/cnab-to-oci v0.3.0-beta4.0.20200409173701-00159a9fe7bb/go.mod h1:8BomA5Vye+3V/Kd2NSFblCBmp1rJV5NfXBYKbIGT5Rw=
 github.com/cnabio/cnab-to-oci v0.3.1-beta1 h1:qAuLRt+2J7U7wIB5YG+COtS630NQCf4G1h1p0Yk6llo=
 github.com/cnabio/cnab-to-oci v0.3.1-beta1/go.mod h1:8BomA5Vye+3V/Kd2NSFblCBmp1rJV5NfXBYKbIGT5Rw=

--- a/go.sum
+++ b/go.sum
@@ -526,6 +526,8 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/vdice/cnab-go v0.0.0-20200416174429-5ab209b0f008 h1:kVQ6XW6Ry3leuC+ceEl1R4g4ouk2F9MVQ1/9fDVQfI0=
+github.com/vdice/cnab-go v0.0.0-20200416174429-5ab209b0f008/go.mod h1:5c4uOP6ZppR4nUGtCMAElscRiYEUi44vNQwtSAvISXk=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg2K1HrLU=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
@@ -672,6 +674,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -38,44 +38,9 @@ func (d *Runtime) loadParameters(claim *claim.Claim, rawOverrides map[string]str
 		}
 
 		overrides[key] = value
-		// If this parameter does not apply to the current action, defer to the claim value, if exists
-		if !param.AppliesTo(action) {
-			if _, exists := claim.Parameters[key]; exists {
-				overrides[key] = claim.Parameters[key]
-			}
-		}
 	}
 
-	// rawOverrides (meaning, user-supplied overrides at time of action invocation)
-	// may supply no entry for a parameter designated as required *but* that does not apply to this action.
-	//
-	// When this occurs, we set an override to either the current value in the claim or the default value.
-	// If neither exists, the zero value according to the parameter type will be used.
-	// Otherwise, if unset/nil, json validation in bundle.ValuesOrDefaults would return an error
-	for name, param := range bun.Parameters {
-		def, ok := bun.Definitions[param.Definition]
-		if !ok {
-			return nil, fmt.Errorf("parameter definition %s not defined in bundle", param.Definition)
-		}
-		if param.Required {
-			if _, exists := rawOverrides[name]; !exists {
-				if !param.AppliesTo(action) {
-					// First defer to a pre-existing value in the claim
-					if claim.Parameters[name] != nil {
-						overrides[name] = claim.Parameters[name]
-					} else if def.Default != nil {
-						// Next defer to a default value
-						overrides[name] = def.Default
-					} else {
-						// Finally, use a zero value if no other option exists
-						overrides[name] = getZeroValue(name, def)
-					}
-				}
-			}
-		}
-	}
-
-	return bundle.ValuesOrDefaults(overrides, bun)
+	return bundle.ValuesOrDefaults(overrides, bun, action)
 }
 
 func (d *Runtime) getUnconvertedValueFromRaw(def *definition.Schema, key, rawValue string) (string, error) {
@@ -90,27 +55,4 @@ func (d *Runtime) getUnconvertedValueFromRaw(def *definition.Schema, key, rawVal
 		}
 	}
 	return rawValue, nil
-}
-
-// getZeroValue returns the zero value for a parameter according to its type
-func getZeroValue(name string, def *definition.Schema) interface{} {
-	switch def.Type {
-	// Technically, only integer types are supported by CNAB/cnab-go
-	// to represent numbers, due to limitations in the canonical json library used.
-	// However, we have support for the number type (decimal numbers) here as well,
-	// just in case. See also https://github.com/cnabio/cnab-go/issues/115
-	case "integer", "number":
-		return 0
-	case "string":
-		return ""
-	case "boolean":
-		return false
-	case "array":
-		return []interface{}{}
-	case "object":
-		var emptyStruct struct{}
-		return emptyStruct
-	default:
-		return nil
-	}
 }

--- a/pkg/cnab/provider/parameters_test.go
+++ b/pkg/cnab/provider/parameters_test.go
@@ -50,7 +50,7 @@ func Test_loadParameters_definitionNotDefined(t *testing.T) {
 	require.EqualError(t, err, "definition foo not defined in bundle")
 }
 
-func Test_loadParameters_applyToClaimDefaults(t *testing.T) {
+func Test_loadParameters_applyTo(t *testing.T) {
 	d := NewTestRuntime(t)
 
 	claim, err := claim.New("test")
@@ -109,7 +109,7 @@ func Test_loadParameters_applyToClaimDefaults(t *testing.T) {
 
 	require.Equal(t, "FOO", params["foo"], "expected param 'foo' to be updated")
 	require.Equal(t, 456, params["bar"], "expected param 'bar' to be updated")
-	require.Equal(t, true, params["true"], "expected param 'true' to represent the preexisting claim value")
+	require.Equal(t, nil, params["true"], "expected param 'true' to be nil as it does not apply")
 }
 
 func Test_loadParameters_applyToBundleDefaults(t *testing.T) {
@@ -142,7 +142,7 @@ func Test_loadParameters_applyToBundleDefaults(t *testing.T) {
 	params, err := d.loadParameters(claim, overrides, "action")
 	require.NoError(t, err)
 
-	require.Equal(t, "foo-default", params["foo"], "expected param 'foo' to be the bundle default")
+	require.Equal(t, nil, params["foo"], "expected param 'foo' to be nil, regardless of the bundle default, as it does not apply")
 }
 
 func Test_loadParameters_requiredButDoesNotApply(t *testing.T) {
@@ -177,57 +177,7 @@ func Test_loadParameters_requiredButDoesNotApply(t *testing.T) {
 	params, err := d.loadParameters(claim, overrides, "action")
 	require.NoError(t, err)
 
-	require.Equal(t, "foo-claim-value", params["foo"], "expected param 'foo' to be the previous value from the claim")
-}
-
-func Test_loadParameters_zeroValues(t *testing.T) {
-	var emptyStruct struct{}
-
-	testcases := []struct {
-		paramType   string
-		expectedVal interface{}
-	}{
-		{"integer", 0},
-		{"number", 0},
-		{"string", ""},
-		{"boolean", false},
-		{"array", []interface{}{}},
-		{"object", emptyStruct},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.paramType, func(t *testing.T) {
-			d := NewTestRuntime(t)
-
-			claim, err := claim.New("test")
-			require.NoError(t, err)
-
-			claim.Bundle = &bundle.Bundle{
-				Definitions: definition.Definitions{
-					"foo": &definition.Schema{
-						Type: tc.paramType,
-					},
-				},
-				Parameters: map[string]bundle.Parameter{
-					"foo": bundle.Parameter{
-						Definition: "foo",
-						ApplyTo: []string{
-							"different-action",
-						},
-						Required: true,
-					},
-				},
-			}
-
-			claim.Parameters = map[string]interface{}{}
-			overrides := map[string]string{}
-
-			params, err := d.loadParameters(claim, overrides, "action")
-			require.NoError(t, err)
-
-			require.Equal(t, tc.expectedVal, params["foo"], "unexpected value for param 'foo")
-		})
-	}
+	require.Equal(t, nil, params["foo"], "expected param 'foo' to be nil, regardless of claim value, as it does not apply")
 }
 
 func Test_loadParameters_fileParameter(t *testing.T) {
@@ -286,13 +236,13 @@ func Test_Paramapalooza(t *testing.T) {
 					true, true, true, true, "my-param-value", "",
 				},
 				{"required, provided, default exists, does not apply to action",
-					true, true, true, false, "my-param-value", "",
+					true, true, true, false, nil, "",
 				},
 				{"required, provided, default does not exist, applies to action",
 					true, true, false, true, "my-param-value", "",
 				},
 				{"required, provided, default does not exist, does not apply to action",
-					true, true, false, false, "my-param-value", "",
+					true, true, false, false, nil, "",
 				},
 				// As of writing, bundle.ValuesOrDefaults in cnab-go requires a specific override
 				// be provided if applicable to an action.
@@ -301,31 +251,31 @@ func Test_Paramapalooza(t *testing.T) {
 					true, false, true, true, nil, "invalid parameters: parameter \"my-param\" is required",
 				},
 				{"required, not provided, default exists, does not apply to action",
-					true, false, true, false, "my-param-default", "",
+					true, false, true, false, nil, "",
 				},
 				{"required, not provided, default does not exist, applies to action",
 					true, false, false, true, nil, "invalid parameters: parameter \"my-param\" is required",
 				},
 				{"required, not provided, default does not exist, does not apply to action",
-					true, false, false, false, "", "",
+					true, false, false, false, nil, "",
 				},
 				{"not required, provided, default exists, applies to action",
 					false, true, true, true, "my-param-value", "",
 				},
 				{"not required, provided, default exists, does not apply to action",
-					false, true, true, false, "my-param-value", "",
+					false, true, true, false, nil, "",
 				},
 				{"not required, provided, default does not exist, applies to action",
 					false, true, false, true, "my-param-value", "",
 				},
 				{"not required, provided, default does not exist, does not apply to action",
-					false, true, false, false, "my-param-value", "",
+					false, true, false, false, nil, "",
 				},
 				{"not required, not provided, default exists, applies to action",
 					false, false, true, true, "my-param-default", "",
 				},
 				{"not required, not provided, default exists, does not apply to action",
-					false, false, true, false, "my-param-default", "",
+					false, false, true, false, nil, "",
 				},
 				{"not required, not provided, default does not exist, applies to action",
 					false, false, false, true, nil, "",


### PR DESCRIPTION
# What does this change
* Removes custom logic to supply a zero/empty or default value for parameters when they don't apply to a given action.  This had been added to appease cnab-go validation.  However, said validation is proposed to be changed in https://github.com/cnabio/cnab-go/pull/204.

Depends on https://github.com/cnabio/cnab-go/pull/204

TODO:
 - [x] remove override in go.mod

# What issue does it fix
Unintended behavior may result from populating parameters with zero/empty values even if not applicable to a given action.

# Notes for the reviewer
One of the subtle effects of the previous behavior is parameter persistence.  Since zero or default values (the default may originate from a previous claim value) are no longer being provided for parameters that don't apply to a particular action, these values will no longer 'persist' across actions.  

For example, if a value of 'foo' was provided for parameter A during install, but upgrade is run and parameter A does not apply, steps executed during upgrade may not access A's parameter value (it will be `nil`).  If a future action is run, which parameter A _does_ apply to, and a value is not provided for parameter A, parameter A's default will be used (as declared in the bundle) _or_, if no default is provided, the action will fail, returning an error along the lines of "parameter A is required but no value is provided".

# Checklist
- [x] Unit Tests
- [x] Documentation - n/a
- [x] Schema (porter.yaml) - n/a
