### PR TITLE
Add --force flag to commands that pull tags

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -347,5 +347,8 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
 	f.StringVarP(&opts.Tag, "tag", "t", "",
 		"Use a bundle in an OCI registry specified by the given tag")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle")
+
 	return &cmd
 }

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -83,6 +83,9 @@ will then provide it to the bundle in the correct location. `,
 		"Generate credential but do not save it.")
 	f.StringVar(&opts.Tag, "tag", "",
 		"Use a bundle in an OCI registry specified by the given tag.")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle")
+
 	return cmd
 }
 

--- a/cmd/porter/explain.go
+++ b/cmd/porter/explain.go
@@ -30,6 +30,8 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
 	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
 	f.StringVarP(&opts.Tag, "tag", "t", "",
 		"Use a bundle in an OCI registry specified by the given tag")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
 	return &cmd

--- a/cmd/porter/inspect.go
+++ b/cmd/porter/inspect.go
@@ -33,6 +33,8 @@ like parameters, credentials, outputs and custom actions available.
 	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
 	f.StringVarP(&opts.Tag, "tag", "t", "",
 		"Use a bundle in an OCI registry specified by the given tag")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
 	return &cmd

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -30,6 +30,7 @@ porter archive [flags]
 ```
       --cnab-file string   Path to the CNAB bundle.json file.
   -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force              Force a fresh pull of the bundle
   -h, --help               help for archive
   -t, --tag string         Use a bundle in an OCI registry specified by the given tag
 ```

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -30,6 +30,7 @@ porter bundles archive [flags]
 ```
       --cnab-file string   Path to the CNAB bundle.json file.
   -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force              Force a fresh pull of the bundle
   -h, --help               help for archive
   -t, --tag string         Use a bundle in an OCI registry specified by the given tag
 ```

--- a/docs/content/cli/bundles_explain.md
+++ b/docs/content/cli/bundles_explain.md
@@ -30,6 +30,7 @@ porter bundles explain [flags]
 ```
       --cnab-file string   Path to the CNAB bundle.json file.
   -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force              Force a fresh pull of the bundle
   -h, --help               help for explain
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
   -t, --tag string         Use a bundle in an OCI registry specified by the given tag

--- a/docs/content/cli/bundles_inspect.md
+++ b/docs/content/cli/bundles_inspect.md
@@ -34,6 +34,7 @@ porter bundles inspect [flags]
 ```
       --cnab-file string   Path to the CNAB bundle.json file.
   -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force              Force a fresh pull of the bundle
   -h, --help               help for inspect
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
   -t, --tag string         Use a bundle in an OCI registry specified by the given tag

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -47,6 +47,7 @@ porter credentials generate [NAME] [flags]
       --cnab-file string   Path to the CNAB bundle.json file.
       --dry-run            Generate credential but do not save it.
   -f, --file string        Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force              Force a fresh pull of the bundle
   -h, --help               help for generate
       --tag string         Use a bundle in an OCI registry specified by the given tag.
 ```

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -30,6 +30,7 @@ porter explain [flags]
 ```
       --cnab-file string   Path to the CNAB bundle.json file.
   -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force              Force a fresh pull of the bundle
   -h, --help               help for explain
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
   -t, --tag string         Use a bundle in an OCI registry specified by the given tag

--- a/docs/content/cli/inspect.md
+++ b/docs/content/cli/inspect.md
@@ -34,6 +34,7 @@ porter inspect [flags]
 ```
       --cnab-file string   Path to the CNAB bundle.json file.
   -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force              Force a fresh pull of the bundle
   -h, --help               help for inspect
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
   -t, --tag string         Use a bundle in an OCI registry specified by the given tag

--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -1,0 +1,41 @@
+package cnabtooci
+
+import (
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-to-oci/relocation"
+)
+
+var _ RegistryProvider = &TestRegistry{}
+
+type TestRegistry struct {
+	MockPullBundle          func(tag string, insecureRegistry bool) (bun bundle.Bundle, reloMap *relocation.ImageRelocationMap, err error)
+	MockPushBundle          func(bun bundle.Bundle, tag string, insecureRegistry bool) (reloMap *relocation.ImageRelocationMap, err error)
+	MockPushInvocationImage func(invocationImage string) (imageDigest string, err error)
+}
+
+func NewTestRegistry() *TestRegistry {
+	return &TestRegistry{}
+}
+
+func (t TestRegistry) PullBundle(tag string, insecureRegistry bool) (bundle.Bundle, *relocation.ImageRelocationMap, error) {
+	if t.MockPullBundle != nil {
+		return t.MockPullBundle(tag, insecureRegistry)
+	}
+
+	return bundle.Bundle{}, nil, nil
+}
+
+func (t TestRegistry) PushBundle(bun bundle.Bundle, tag string, insecureRegistry bool) (*relocation.ImageRelocationMap, error) {
+	if t.MockPushBundle != nil {
+		return t.MockPushBundle(bun, tag, insecureRegistry)
+	}
+
+	return nil, nil
+}
+
+func (t TestRegistry) PushInvocationImage(invocationImage string) (string, error) {
+	if t.MockPushInvocationImage != nil {
+		return t.MockPushInvocationImage(invocationImage)
+	}
+	return "", nil
+}

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -1,4 +1,4 @@
-package porter
+package cnabtooci
 
 import (
 	"github.com/cnabio/cnab-go/bundle"
@@ -6,7 +6,7 @@ import (
 )
 
 // Registry handles talking with an OCI registry.
-type Registry interface {
+type RegistryProvider interface {
 	// PullBundle pulls a bundle from an OCI registry.
 	PullBundle(tag string, insecureRegistry bool) (bundle.Bundle, *relocation.ImageRelocationMap, error)
 

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -23,6 +23,8 @@ import (
 	portercontext "get.porter.sh/porter/pkg/context"
 )
 
+var _ RegistryProvider = &Registry{}
+
 type Registry struct {
 	*portercontext.Context
 }

--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -24,7 +24,7 @@ type Porter struct {
 	Cache       cache.BundleCache
 	Credentials credentials.CredentialProvider
 	Claims      claims.ClaimProvider
-	Registry    Registry
+	Registry    cnabtooci.RegistryProvider
 	Templates   *templates.Templates
 	Builder     BuildProvider
 	Manifest    *manifest.Manifest

--- a/pkg/porter/resolver.go
+++ b/pkg/porter/resolver.go
@@ -2,24 +2,27 @@ package porter
 
 import (
 	"get.porter.sh/porter/pkg/cache"
+	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
 	"github.com/pkg/errors"
 )
 
 type BundleResolver struct {
 	Cache    cache.BundleCache
-	Registry Registry
+	Registry cnabtooci.RegistryProvider
 }
 
 // Resolves a bundle from the cache, or pulls it and caches it
 // Returns the location of the bundle or an error
 func (r *BundleResolver) Resolve(opts BundlePullOptions) (cache.CachedBundle, error) {
-	cachedBundle, ok, err := r.Cache.FindBundle(opts.Tag)
-	if err != nil {
-		return cache.CachedBundle{}, errors.Wrapf(err, "unable to load bundle %s from cache", opts.Tag)
-	}
-	// If we found the bundle, return the path to the bundle.json
-	if ok && !opts.Force {
-		return cachedBundle, nil
+	if !opts.Force {
+		cachedBundle, ok, err := r.Cache.FindBundle(opts.Tag)
+		if err != nil {
+			return cache.CachedBundle{}, errors.Wrapf(err, "unable to load bundle %s from cache", opts.Tag)
+		}
+		// If we found the bundle, return the path to the bundle.json
+		if ok {
+			return cachedBundle, nil
+		}
 	}
 
 	b, rMap, err := r.Registry.PullBundle(opts.Tag, opts.InsecureRegistry)

--- a/pkg/porter/resolver_test.go
+++ b/pkg/porter/resolver_test.go
@@ -1,0 +1,98 @@
+package porter
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/cache"
+	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
+	"get.porter.sh/porter/pkg/config"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-to-oci/relocation"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBundleResolver_Resolve_ForcePull(t *testing.T) {
+	tc := config.NewTestConfig(t)
+	testReg := cnabtooci.NewTestRegistry()
+	testCache := cache.NewTestCache(cache.New(tc.Config))
+	resolver := BundleResolver{
+		Cache:    testCache,
+		Registry: testReg,
+	}
+
+	cacheSearched := false
+	testCache.FindBundleMock = func(tag string) (cache.CachedBundle, bool, error) {
+		cacheSearched = true
+		return cache.CachedBundle{}, true, nil
+	}
+
+	pulled := false
+	testReg.MockPullBundle = func(tag string, insecureRegistry bool) (bundle.Bundle, *relocation.ImageRelocationMap, error) {
+		pulled = true
+		return bundle.Bundle{}, nil, nil
+	}
+
+	opts := BundlePullOptions{
+		Force: true,
+	}
+	resolver.Resolve(opts)
+
+	assert.False(t, cacheSearched, "Force should have skipped the cache")
+	assert.True(t, pulled, "The bundle should have been re-pulled")
+}
+
+func TestBundleResolver_Resolve_CacheHit(t *testing.T) {
+	tc := config.NewTestConfig(t)
+	testReg := cnabtooci.NewTestRegistry()
+	testCache := cache.NewTestCache(cache.New(tc.Config))
+	resolver := BundleResolver{
+		Cache:    testCache,
+		Registry: testReg,
+	}
+
+	cacheSearched := false
+	testCache.FindBundleMock = func(tag string) (cache.CachedBundle, bool, error) {
+		cacheSearched = true
+		return cache.CachedBundle{}, true, nil
+	}
+
+	pulled := false
+	testReg.MockPullBundle = func(tag string, insecureRegistry bool) (bundle.Bundle, *relocation.ImageRelocationMap, error) {
+		pulled = true
+		return bundle.Bundle{}, nil, nil
+	}
+
+	opts := BundlePullOptions{}
+	resolver.Resolve(opts)
+
+	assert.True(t, cacheSearched, "The cache should be searched when force is not specified")
+	assert.False(t, pulled, "The bundle should NOT be pulled because it was found in the cache")
+}
+
+func TestBundleResolver_Resolve_CacheMiss(t *testing.T) {
+	tc := config.NewTestConfig(t)
+	testReg := cnabtooci.NewTestRegistry()
+	testCache := cache.NewTestCache(cache.New(tc.Config))
+	resolver := BundleResolver{
+		Cache:    testCache,
+		Registry: testReg,
+	}
+
+	cacheSearched := false
+	testCache.FindBundleMock = func(tag string) (cache.CachedBundle, bool, error) {
+		cacheSearched = true
+		return cache.CachedBundle{}, false, nil
+	}
+
+	pulled := false
+	testReg.MockPullBundle = func(tag string, insecureRegistry bool) (bundle.Bundle, *relocation.ImageRelocationMap, error) {
+		pulled = true
+		return bundle.Bundle{}, nil, nil
+	}
+
+	opts := BundlePullOptions{}
+	resolver.Resolve(opts)
+
+	assert.True(t, cacheSearched, "The cache should be searched when force is not specified")
+	assert.True(t, pulled, "The bundle should have been pulled because the bundle was not in the cache")
+}


### PR DESCRIPTION
# What does this change
* Add --force flag to commands that pull tags
  Any command that pulls a bundle using --tag also needs its buddy flag --force so that it can repull when the bundle has been repushed, and the bundle needs to be repulled (the cached bundle refreshed).

  This adds --force to the following commands:
  * inspect
  * explain
  * credentials generate
  * archive

* Skip cache query on --force
  When --force is specified do not query the cache at all, immediately skip to pulling the bundle again. This helps avoid any errors that could arrise from an invalid cached bundle.

# What issue does it fix
Closes #992 

# Notes for the reviewer
🍰 

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml) - not impacted
