### PR TITLE
Move contribution ladder into separate document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,6 @@
   * [How to get your pull request reviewed fast](#how-to-get-your-pull-request-reviewed-fast)
   * [The life of a pull request](#the-life-of-a-pull-request)
 * [Contribution Ladder](#contribution-ladder)
-  * [Contributor](#contributor)
-  * [How to become a contributor](#how-to-become-a-contributor)
-  * [Maintainer](#maintainer)
-  * [How to become a maintainer](#how-to-become-a-maintainer)
-  * [Admin](#admin)
-  * [How to become an admin](#admin)
 * [Developer Tasks](#developer-tasks)
   * [Initial setup](#initial-setup)
   * [Makefile explained](#makefile-explained)
@@ -179,97 +173,11 @@ kills contributor momentum.
 
 # Contribution Ladder
 
-Our ladder defines the roles and responsibilities on this project and how to
-participate with the goal of moving from a user to a maintainer. You will need
-to gain people's trust, demonstrate your competence and understanding, and meet
-the requirements of the role.
+Our [contribution ladder][ladder] defines the roles and responsibilities on this
+project and how to participate with the goal of moving from a user to a
+maintainer.
 
-## Community Members
-
-Everyone is a community member! 😄 You've read this far so you are already ahead. 💯
-
-Here are some ideas for how you can be more involved and participate in the community:
-
-* Comment on an issue that you’re interested in.
-* Submit a pull request to fix an issue.
-* Report a bug.
-* Share a bundle that you made and how it went.
-* Come chat with us in [Slack][slack].
-
-They must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
-
-## Contributor
-
-[Contributors][contributors] have the following capabilities:
-
-* Have issues and pull requests assigned to them
-* Apply labels, milestones and projects
-* [Mark issues as duplicates](https://help.github.com/en/articles/about-duplicate-issues-and-pull-requests)
-* Close, reopen, and assign issues and pull requests
-
-They must agree to and follow this Contributing Guide.
-
-### How to become a contributor
-
-To become a contributor, the maintainers of the project would like to see you:
-
-* Comment on issues with your experiences and opinions.
-* Add your comments and reviews on pull requests.
-* Contribute pull requests.
-* Open issues with bugs, experience reports, and questions.
-
-Contributors and maintainers will do their best to watch for community members
-who may make good contributors. But don’t be shy, if you feel that this is you,
-please reach out to one or more of the contributors or maintainers.
-
-[contributors]: https://github.com/orgs/deislabs/teams/porter-contributors
-
-## Maintainer
-
-[Maintainers][maintainers] are members with extra capabilities:
-
-* Be a [Code Owner](.github/CODEOWNERS) and have reviews automatically requested.
-* Review pull requests.
-* Merge pull requests.
-
-Maintainers also have additional responsibilities beyond just merging code:
-
-* Help foster a safe and welcoming environment for all project participants.
-  This will include understanding and enforcing our [Code of Conduct](CODE_OF_CONDUCT.md).
-* Organize and promote pull request reviews, e.g. prompting community members,
-  contributors, and other maintainers to review.
-* Triage issues, e.g. adding labels, promoting discussions, finalizing decisions.
-* Help organize our development meetings, e.g. schedule, organize and
-  execute agenda.
-
-They must agree to and follow the [Reviewing Guide](REVIEWING.md).
-
-[maintainers]: https://github.com/orgs/deislabs/teams/porter-maintainers
-
-### How to become a maintainer
-
-To become a maintainer, we would like you to see you be an effective
-contributor, and show that you can do some of the things maintainers do.
-Maintainers will do their best to regularly discuss promoting contributors. But
-don’t be shy, if you feel that this is you, please reach out to one or more of
-the maintainers.
-
-## Admin
-
-[Admins][admins] are maintainers with extra responsibilities:
-
-* Create new mixin repositories
-* Manage porter-* repositories
-* Manage porter-* teams
-
-[admins]: https://github.com/orgs/deislabs/teams/porter-admins
-
-### How to become an admin
-
-It isn't expected that all maintainers will need or want to move up to admin. If
-you are a maintainer, and find yourself often asking an admin to do certain
-tasks for you and you would like to help out with administrative tasks, please
-reach out to one or more of the admins.
+[ladder]: /CONTRIBUTION_LADDER.md
 
 # Developer Tasks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,14 +305,8 @@ Here are the most common Makefile tasks
   Documentation](#preview-documentation).
 * `test` runs all the tests.
 * `clean-packr` removes extra packr files that were a side-effect of the build.
-  Normally this is run automatically but if you run into issues with packr and
-  dep, run this command.
-* `dep-ensure` runs dep ensure for you while taking care of packr properly. Use
-  this if your PRs are often failing on `verify-vendor` because of packr. This
-  can be avoided entirely if you use `make build-porter-client` or `make build`.
-* `verify-vendor` cleans up packr generated files and verifies that dep's Gopkg.lock
-   and vendor/ are up-to-date. Use this makefile target instead of running
-   dep check manually.
+  Normally this is run automatically but if you run into issues with packr, 
+  run this command.
 
 ## Install mixins
 
@@ -384,7 +378,6 @@ dependency injection and testing strategies.
 * **scripts**:
   * **install**: Porter [installation](https://porter.sh/install) scripts
 * **tests** have Go-based integration tests.
-* **vendor** we use dep and check in vendor.
 
 ## Logging
 

--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -1,0 +1,102 @@
+# Contribution Ladder
+
+---
+* [Contributor](#contributor)
+* [How to become a contributor](#how-to-become-a-contributor)
+* [Maintainer](#maintainer)
+* [How to become a maintainer](#how-to-become-a-maintainer)
+* [Admin](#admin)
+* [How to become an admin](#admin)
+---
+
+Our ladder defines the roles and responsibilities on this project and how to
+participate with the goal of moving from a user to a maintainer. You will need
+to gain people's trust, demonstrate your competence and understanding, and meet
+the requirements of the role.
+
+## Community Members
+
+Everyone is a community member! 😄 You've read this far so you are already ahead. 💯
+
+Here are some ideas for how you can be more involved and participate in the community:
+
+* Comment on an issue that you’re interested in.
+* Submit a pull request to fix an issue.
+* Report a bug.
+* Share a bundle that you made and how it went.
+* Come chat with us in [Slack][slack].
+
+They must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Contributor
+
+[Contributors][contributors] have the following capabilities:
+
+* Have issues and pull requests assigned to them
+* Apply labels, milestones and projects
+* [Mark issues as duplicates](https://help.github.com/en/articles/about-duplicate-issues-and-pull-requests)
+* Close, reopen, and assign issues and pull requests
+
+They must agree to and follow this Contributing Guide.
+
+### How to become a contributor
+
+To become a contributor, the maintainers of the project would like to see you:
+
+* Comment on issues with your experiences and opinions.
+* Add your comments and reviews on pull requests.
+* Contribute pull requests.
+* Open issues with bugs, experience reports, and questions.
+
+Contributors and maintainers will do their best to watch for community members
+who may make good contributors. But don’t be shy, if you feel that this is you,
+please reach out to one or more of the contributors or maintainers.
+
+[contributors]: https://github.com/orgs/deislabs/teams/porter-contributors
+
+## Maintainer
+
+[Maintainers][maintainers] are members with extra capabilities:
+
+* Be a [Code Owner](.github/CODEOWNERS) and have reviews automatically requested.
+* Review pull requests.
+* Merge pull requests.
+
+Maintainers also have additional responsibilities beyond just merging code:
+
+* Help foster a safe and welcoming environment for all project participants.
+  This will include understanding and enforcing our [Code of Conduct](CODE_OF_CONDUCT.md).
+* Organize and promote pull request reviews, e.g. prompting community members,
+  contributors, and other maintainers to review.
+* Triage issues, e.g. adding labels, promoting discussions, finalizing decisions.
+* Help organize our development meetings, e.g. schedule, organize and
+  execute agenda.
+
+They must agree to and follow the [Reviewing Guide](REVIEWING.md).
+
+[maintainers]: https://github.com/orgs/deislabs/teams/porter-maintainers
+
+### How to become a maintainer
+
+To become a maintainer, we would like you to see you be an effective
+contributor, and show that you can do some of the things maintainers do.
+Maintainers will do their best to regularly discuss promoting contributors. But
+don’t be shy, if you feel that this is you, please reach out to one or more of
+the maintainers.
+
+## Admin
+
+[Admins][admins] are maintainers with extra responsibilities:
+
+* Create new mixin repositories
+* Manage porter-* repositories
+* Manage porter-* teams
+
+[admins]: https://github.com/orgs/deislabs/teams/porter-admins
+
+### How to become an admin
+
+It isn't expected that all maintainers will need or want to move up to admin. If
+you are a maintainer, and find yourself often asking an admin to do certain
+tasks for you and you would like to help out with administrative tasks, please
+reach out to one or more of the admins.

--- a/docs/content/contribute.md
+++ b/docs/content/contribute.md
@@ -98,5 +98,5 @@ maintainer to admin.
 
 <p align="center">Sound like fun? 🙋🏽‍♀️ Join us!</p>
 
-[ladder]: /src/CONTRIBUTING.md#contribution-ladder
+[ladder]: /src/CONTRIBUTION_LADDER.md
 [slack]: /community#slack

--- a/docs/content/contribute.md
+++ b/docs/content/contribute.md
@@ -16,7 +16,6 @@ maintainers.
 <p align="right">
 Carolyn Van Slyck<br/>
 ✨ Chief Emoji Offer<br/>
-Co-creator of Porter<br/>
 </p>
 
 # Getting Started
@@ -27,22 +26,13 @@ Co-creator of Porter<br/>
 
 ## What is the project?
 
-Porter is a command-line tool written in Go that implements the [Cloud Native
-Application Bundle Specification](https://deislabs.io/cnab). Bundles package up
-not just your application, but also the tools and logic needed to deploy and
-manage it.
+[Porter][porter] is a command-line tool written in Go that implements the [Cloud
+Native Application Bundle Specification](https://deislabs.io/cnab). Package your
+application artifact, client tools, configuration and deployment logic together
+as a versioned bundle that you can distribute, and then install with a single
+command.
 
-There are a lot of ways to make a bundle. Porter is designed to make robust
-bundles with your existing tools and scripts from your pipeline. Already using
-helm, terraform and bash? Perfect! Porter [glues][glue] that together for you into a
-CNAB bundle. Our goal is a great developer experience.
-
-Porter uses the concept of mixins to build existing tools into bundles. Here is
-a [demo][demo] that deploys to Digital Ocean and Kubernetes
-using the Terraform and Helm mixins.
-
-[glue]: https://carolynvanslyck.com/blog/2019/04/porter/
-[demo]: https://youtu.be/ciA1YuGOIo4
+[porter]: /
 
 ## Where should you start?
 
@@ -53,7 +43,7 @@ structure, makefile commands, how to preview documentation and other useful
 things to know.
 
 The contributing guide explains how to [find an issue][find-an-issue]. We do use
-two labels: [good first issues][good-first-issue] for new contributors and [help
+two labels: [good first issue][good-first-issue] for new contributors and [help
 wanted][help-wanted] issues for our other contributors.
 
 * `good first issue` has extra information to help you make your first contribution.
@@ -68,8 +58,9 @@ wanted][help-wanted] issues for our other contributors.
 
 ## What can you work on?
 
-We need help with everything! 😊 Whether you are new to Go, or are a
-cloud-native gopher expert, we have stuff for you to do.
+We need help with everything! 😊 Whether you are new to Go or cloud-native
+gopher expert, are interested in design or writing, we have stuff for you to
+do:
 
 * Add commands to the porter cli. This is work that never ends and is suitable
   for all levels of gophers.
@@ -79,6 +70,12 @@ cloud-native gopher expert, we have stuff for you to do.
   dependencies, and implementing it in Porter.
 * Implement new runtimes so that Porter can work inside Kubernetes, and other 
   virtualization providers.
+* Improve our website's design by contributing diagrams, graphics, improved layouts,
+  organizing the information.
+* Fill in gaps in our documentation by copying answers from Slack and GitHub into 
+  our FAQ, or creating new pages and content.
+* Project management or other skillsets would be amazing as well! Contact
+  Carolyn and let's coordiante. 🙌
 
 The [roadmap][roadmap] will give you a good idea of the larger features that we
 are working on right now. That may help you decide what you would like to work


### PR DESCRIPTION
# What does this change
Split up the mega contributing guide a bit, by moving the contribution ladder into its own document.

Also removed references to dep, since we are using go mods now.

# What issue does it fix
None

# Notes for the reviewer
Maybe want to do the same for the development, but I wanted to start small.

# Checklist
- [x] Unit Tests - not impacted
- [x] Documentation
- [x] Schema (porter.yaml) - not impacted
