### PR TITLE
Document GitHub Package Registry failure

### DIFF
--- a/docs/content/compatible-registries.md
+++ b/docs/content/compatible-registries.md
@@ -19,7 +19,8 @@ out a particular registry and know that it will work for you.
 | Docker Hub | Yes | Yes |
 | Digital Ocean | Yes | Yes |
 | ECR | No |  |
-| GCR | Yes |  |
+| GCR | Yes |  
+| GitHub Packages | No |  | 
 | Nexus | No |  |
 | Quay | No | No
  


### PR DESCRIPTION
# What does this change
Updates documentation on supported registries. GitHub Packages has limited support currently. porter publish will fail to GitHub Packages. This just updates the documentation to reflect this.
Source: https://help.github.com/en/packages/publishing-and-managing-packages/about-github-packages

# What issue does it fix
Closes #695 

# Checklist
- [ ] Unit Tests
- [X] Documentation
- [ ] Schema (porter.yaml)
