### PR TITLE
remove immediate containers after innovation image built in docker provider's build action

### DIFF
--- a/pkg/build/provider/docker.go
+++ b/pkg/build/provider/docker.go
@@ -38,6 +38,7 @@ func (b *DockerBuilder) BuildInvocationImage(manifest *manifest.Manifest) error 
 	buildOptions := types.ImageBuildOptions{
 		SuppressOutput: false,
 		PullParent:     false,
+		Remove:         true,
 		Tags:           []string{manifest.Image},
 		Dockerfile:     "Dockerfile",
 		BuildArgs: map[string]*string{


### PR DESCRIPTION
Remove immediate containers after innovation image built in docker provider's build action.

# What does this change
Make `Remove` flag true for using docker provider to build invocation image. This parameter will make docker remove all immediate containers after invocation image built, and this will reduce disk usage.

This flag is same with `docker build --rm`
