### PR TITLE
Assign issues and PRs to our project board

### DIFF
--- a/.github/workflows/assign-issues.yaml
+++ b/.github/workflows/assign-issues.yaml
@@ -1,0 +1,20 @@
+# https://github.com/marketplace/actions/assign-to-one-project
+
+name: Assign Issue to Project
+
+on:
+  issues:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign Issue to Project
+    steps:
+    - name: Assign Issue to Project
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      with:
+        project: 'https://github.com/orgs/deislabs/projects/2'
+        column_name: 'Inbox'

--- a/.github/workflows/assign-pr.yaml
+++ b/.github/workflows/assign-pr.yaml
@@ -1,0 +1,20 @@
+# https://github.com/marketplace/actions/assign-to-one-project
+
+name: Assign Pull Requests
+
+on:
+  pull_request:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign Pull Request to Project
+    steps:
+    - name: Assign Pull Request to Project
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      with:
+        project: 'https://github.com/orgs/deislabs/projects/2'
+        column_name: 'In Progress'


### PR DESCRIPTION
# What does this change
Automatically assign new issues and pull requests to our main project board, https://github.com/orgs/deislabs/projects/2

# What issue does it fix
This will save us time adding issues to the board. Existing issues are not added but this should help going forward.

# Notes for the reviewer
It was tested on https://github.com/deislabs/porter-test/issue

# Checklist
- [x] Unit Tests - not impacted
- [x] Documentation - in keybase
- [x] Schema (porter.yaml) - not impacted
