### PR TITLE
ref(linter.go): update Location

### DIFF
--- a/pkg/exec/lint_test.go
+++ b/pkg/exec/lint_test.go
@@ -25,7 +25,7 @@ func TestMixin_LintError(t *testing.T) {
 	gotInstallWarning := results[0]
 	wantInstallWarning := linter.Result{
 		Level:   linter.LevelWarning,
-		Key:     "echo Hello World",
+		Key:     "c: echo Hello World",
 		Code:    CodeEmbeddedBash,
 		Title:   "Best Practice: Avoid Embedded Bash",
 		Message: "",

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -77,4 +77,45 @@ func TestLinter_Lint(t *testing.T) {
 		require.Len(t, results, 0, "linter should ignore mixins that doesn't support the lint command")
 	})
 
+	t.Run("multiple results", func(t *testing.T) {
+		cxt := context.NewTestContext(t)
+		cxt.AddTestFile("./testdata/porter-multiple-linter-results.yaml", "porter.yaml")
+		mixins := mixin.NewTestMixinProvider()
+		l := New(cxt.Context, mixins)
+		m := &manifest.Manifest{
+			ManifestPath: "porter.yaml",
+			Mixins: []manifest.MixinDeclaration{
+				{
+					Name: "exec",
+				},
+			},
+		}
+		mixins.LintResults = Results{
+			{
+				Level: LevelWarning,
+				Code:  "exec-101",
+				Title: "warning stuff isn't working",
+				Key:   "echo Hello World",
+				Location: Location{
+					Line:   9,
+					Column: 12,
+				},
+			},
+			{
+				Level: LevelWarning,
+				Code:  "exec-101",
+				Title: "warning stuff isn't working",
+				Key:   "echo Hello World",
+				Location: Location{
+					Line:   14,
+					Column: 12,
+				},
+			},
+		}
+
+		results, err := l.Lint(m)
+		require.NoError(t, err, "Lint failed")
+		require.Len(t, results, 2, "linter should have returned 2 results")
+		require.Equal(t, mixins.LintResults, results, "unexpected lint results")
+	})
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -30,9 +30,11 @@ func TestLinter_Lint(t *testing.T) {
 
 	t.Run("has results", func(t *testing.T) {
 		cxt := context.NewTestContext(t)
+		cxt.AddTestFile("./testdata/porter.yaml", "porter.yaml")
 		mixins := mixin.NewTestMixinProvider()
 		l := New(cxt.Context, mixins)
 		m := &manifest.Manifest{
+			ManifestPath: "porter.yaml",
 			Mixins: []manifest.MixinDeclaration{
 				{
 					Name: "exec",
@@ -44,6 +46,11 @@ func TestLinter_Lint(t *testing.T) {
 				Level: LevelWarning,
 				Code:  "exec-101",
 				Title: "warning stuff isn't working",
+				Key:   "echo Hello World",
+				Location: Location{
+					Line:   9,
+					Column: 12,
+				},
 			},
 		}
 

--- a/pkg/linter/testdata/porter-multiple-linter-results.yaml
+++ b/pkg/linter/testdata/porter-multiple-linter-results.yaml
@@ -1,0 +1,14 @@
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      flags:
+        c: echo Hello World
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      flags:
+        c: echo Hello World

--- a/pkg/linter/testdata/porter.yaml
+++ b/pkg/linter/testdata/porter.yaml
@@ -1,0 +1,10 @@
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+      flags:
+        c: echo Hello World
+

--- a/pkg/porter/lint_test.go
+++ b/pkg/porter/lint_test.go
@@ -34,12 +34,7 @@ func TestPorter_PrintLintResults(t *testing.T) {
 	lintResults := linter.Results{
 		{
 			Level: linter.LevelError,
-			Location: linter.Location{
-				Action:          "install",
-				Mixin:           "exec",
-				StepNumber:      2,
-				StepDescription: "Install Hello World",
-			},
+			Key:   "echo Hello World",
 			Code:  "exec-100",
 			Title: "bash -c argument missing wrapping quotes",
 			Message: `The bash -c flag argument must be wrapped in quotes, for example

--- a/pkg/porter/testdata/lint/results.json
+++ b/pkg/porter/testdata/lint/results.json
@@ -1,11 +1,10 @@
 [
   {
     "Level": 0,
+    "Key": "echo Hello World",
     "Location": {
-      "Action": "install",
-      "Mixin": "exec",
-      "StepNumber": 2,
-      "StepDescription": "Install Hello World"
+      "Line": 57,
+      "Column": 12
     },
     "Code": "exec-100",
     "Title": "bash -c argument missing wrapping quotes",

--- a/pkg/porter/testdata/lint/results.txt
+++ b/pkg/porter/testdata/lint/results.txt
@@ -1,5 +1,5 @@
 error(exec-100) - bash -c argument missing wrapping quotes
-install: 2nd step in the exec mixin (Install Hello World)
+Location in manifest: Line: 57, Column: 12
 The bash -c flag argument must be wrapped in quotes, for example
 exec:
   description: Say Hello


### PR DESCRIPTION
# What does this change
* Update linting result location to contain line and column number of result culprit in manifest

# What issue does it fix
This came up whilst working on https://github.com/deislabs/porter/issues/978... during discussions with @carolynvs , it sounds like to support VS Code integration, the location should at least contain line and column number.  We voted to simplify down to just these two values during the process.

# Notes for the reviewer
Help with testing VS Code integration -- if we're ready.

# Checklist
- [x] Unit Tests
- [x] Documentation - N/A
- [x] Schema (porter.yaml) - N/A
