### PR TITLE
ref(bundles/terraform): update terraform bundle

### DIFF
--- a/build/testdata/bundles/terraform/terraform/main.tf
+++ b/build/testdata/bundles/terraform/terraform/main.tf
@@ -1,4 +1,4 @@
 resource "local_file" "foo" {
-    content  = "${var.file_contents}"
+    content  = var.file_contents
     filename = "${path.module}/foo"
 }

--- a/build/testdata/bundles/terraform/terraform/outputs.tf
+++ b/build/testdata/bundles/terraform/terraform/outputs.tf
@@ -1,4 +1,4 @@
 output "file_contents" {
-  value = "${var.file_contents}"
+  value = var.file_contents
   description = "Contents of the file 'foo'"
 }


### PR DESCRIPTION
# What does this change

A wee PR to update pertinent `.tf` files in the terraform bundle per the mixin terraform version (`0.12.17` at time of writing):

```
Warning: Interpolation-only expressions are deprecated

  on main.tf line 2, in resource "local_file" "foo":
   2:     content  = "${var.file_contents}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

# What issue does it fix
N/A
# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests - n/a
- [x] Documentation - n/a
- [x] Schema (porter.yaml) - n/a
