### PR TITLE
Fix formatting for required docker extension

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -337,17 +337,20 @@ Access to the host Docker daemon is necessary to run this bundle.
 When the bundle is executed, this elevated privilege must be explicitly granted to the bundle using the
 [Allow Docker Host Access configuration](/configuration/#allow-docker-host-access) setting.
 
-**Name:** `docker`
+**Name:** 
+
+`docker`
 
 **Configuration:**
-  * `Privileged: boolean` - Whether or not the `--privileged` flag should be set on the container run invocation
+
+  * `privileged: BOOLEAN` - OPTIONAL. Whether or not the `--privileged` flag should be set when the bundle's invocation image runs. Defaults to false.
 
 Example:
 
 ```yaml
 required:
   - docker:
-      privileged: false
+      privileged: true
 ```
 
 ## Generated Files


### PR DESCRIPTION
# What does this change
* Fix formatting for required docker extension. The heading/text was ending up on the same line.
* Also tweak the text to improve clarity and make sure people understand the default value (false).

# What issue does it fix
N/A

# Notes for the reviewer
Just found this while writing up a blog post about our docker support.

# Checklist
- [x] Unit Tests - not impacted
- [x] Documentation
- [x] Schema (porter.yaml) - not impacted
