### PR TITLE
Skip params at runtime that don't apply

### DIFF
--- a/build/testdata/bundles/terraform/porter.yaml
+++ b/build/testdata/bundles/terraform/porter.yaml
@@ -35,8 +35,6 @@ status:
 uninstall:
   - terraform:
       description: "Uninstall Terraform assets"
-      vars:
-        file_contents: "{{bundle.parameters.file_contents}}"
 
 outputs:
   - name: file_contents

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -174,6 +174,20 @@ func (pd *ParameterDefinition) DeepCopy() *ParameterDefinition {
 	return &p2
 }
 
+// AppliesTo returns a boolean value specifying whether or not
+// the Parameter applies to the provided action
+func (pd *ParameterDefinition) AppliesTo(action string) bool {
+	if len(pd.ApplyTo) == 0 {
+		return true
+	}
+	for _, act := range pd.ApplyTo {
+		if action == act {
+			return true
+		}
+	}
+	return false
+}
+
 // CredentialDefinition represents the structure or fields of a credential parameter
 type CredentialDefinition struct {
 	Name        string `yaml:"name"`

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -230,7 +230,10 @@ func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 	params := make(map[string]interface{})
 	bun["parameters"] = params
 	for _, param := range m.Parameters {
-		//pe := strings.ToUpper(param.Name)
+		if !param.AppliesTo(string(m.Action)) {
+			continue
+		}
+
 		pe := param.Name
 		var val string
 		val, err := resolveParameter(param)
@@ -381,6 +384,10 @@ func (m *RuntimeManifest) Prepare() error {
 	// For parameters of type "file", we may need to decode files on the filesystem
 	// before execution of the step/action
 	for _, param := range m.Parameters {
+		if !param.AppliesTo(string(m.Action)) {
+			continue
+		}
+
 		if param.Type == "file" {
 			if param.Destination.Path == "" {
 				return fmt.Errorf("destination path is not supplied for parameter %s", param.Name)


### PR DESCRIPTION
# What does this change
* Do not inject parameters into the manifest template that do not apply to
  the current action.
* Do not process file type parameters that do not apply to the current
  action.

# What issue does it fix
Closes #1016 

# Notes for the reviewer
I looked around in the cnab/provider actions and the usages of the manifest parameters but couldn't think of where else we should be limiting by appliesTo.

I have a follow-up https://github.com/deislabs/porter/issues/1018 to have the linter catch people using `{{bundle.parameters.foo}}` in actions where it doesn't apply.

# Checklist
- [x] Unit Tests
- [x] Documentation - not affected
- [x] Schema (porter.yaml) - not affected
