### PR TITLE
fix(manifest.go): update default invocation image naming

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -532,7 +532,12 @@ func UnmarshalManifest(manifestData []byte) (*Manifest, error) {
 
 func (m *Manifest) SetDefaults() {
 	if m.Image == "" && m.BundleTag != "" {
-		registry := strings.Split(m.BundleTag, ":")[0]
+		tag := m.BundleTag
+		// Derive the last index of ":"
+		// This allows for a registry consisting of a domain:port to be included
+		li := strings.LastIndex(tag, ":")
+		// Split on this last index
+		registry := tag[0:li]
 		m.Image = strings.Join([]string{registry + "-installer", m.Version}, ":")
 	}
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -159,11 +159,21 @@ func TestReadManifest_File(t *testing.T) {
 }
 
 func TestSetDefaultInvocationImage(t *testing.T) {
-	cxt := context.NewTestContext(t)
-	cxt.AddTestFile("testdata/missing-invocation-image.porter.yaml", config.Name)
-	m, err := ReadManifest(cxt.Context, config.Name)
-	require.NoError(t, err)
-	assert.Equal(t, "getporter/missing-invocation-image-installer:"+m.Version, m.Image)
+	t.Run("missing invocation image", func(t *testing.T) {
+		cxt := context.NewTestContext(t)
+		cxt.AddTestFile("testdata/missing-invocation-image.porter.yaml", config.Name)
+		m, err := ReadManifest(cxt.Context, config.Name)
+		require.NoError(t, err)
+		assert.Equal(t, "getporter/missing-invocation-image-installer:"+m.Version, m.Image)
+	})
+
+	t.Run("missing invocation image; tag includes registry with port", func(t *testing.T) {
+		cxt := context.NewTestContext(t)
+		cxt.AddTestFile("testdata/missing-invocation-image-tag-has-port.porter.yaml", config.Name)
+		m, err := ReadManifest(cxt.Context, config.Name)
+		require.NoError(t, err)
+		assert.Equal(t, "localhost:5000/missing-invocation-image-installer:"+m.Version, m.Image)
+	})
 }
 
 func TestReadManifest_Validate_MissingFile(t *testing.T) {

--- a/pkg/manifest/testdata/missing-invocation-image-tag-has-port.porter.yaml
+++ b/pkg/manifest/testdata/missing-invocation-image-tag-has-port.porter.yaml
@@ -1,0 +1,28 @@
+mixins:
+  - exec
+
+name: hello
+description: "An example Porter with missing Invocation Image"
+version: 0.1.0
+tag: localhost:5000/missing-invocation-image:v0.1.0
+
+install:
+  - exec:
+      description: "Say Hello"
+      command: bash
+      flags:
+        c: echo Hello World
+
+status:
+  - exec:
+      description: "Get World Status"
+      command: bash
+      flags:
+        c: echo The world is on fire
+
+uninstall:
+  - exec:
+      description: "Say Goodbye"
+      command: bash
+      flags:
+        c: echo Goodbye World


### PR DESCRIPTION
# What does this change
* Updates default invocation image naming to allow for registries of the domain:port pattern
# What issue does it fix
N/A, but discovered via investigation into https://github.com/deislabs/porter/issues/1030

# Notes for the reviewer
N/A
# Checklist
- [x] Unit Tests
- [x] Documentation - N/A
- [x] Schema (porter.yaml) - N/A
