### PR TITLE
Fix link on copy bundles page

### DIFF
--- a/docs/content/copy-bundles.md
+++ b/docs/content/copy-bundles.md
@@ -21,7 +21,7 @@ images:
       digest: "sha256:85b1a9b4b60a4cf73a23517dad677e64edf467107fa7d58fce9c50e6a3e4c914"
 ```
 
-When this bundle is copied, the invocation image, along with the `backend` and `websvc` images will be copied to the new repository. If the bundle author has properly used image (wiring)[/wiring#wiring-images], the new image references will be available within the bundle at run-time.
+When this bundle is copied, the invocation image, along with the `backend` and `websvc` images will be copied to the new repository. If the bundle author has properly used image [wiring](/wiring/#wiring-images), the new image references will be available within the bundle at run-time.
 
 This is useful when you have restrictions on where you can pull Docker images from or would otherwise like to have control over assets you will be using. Any operation on the copied bundle will utilize these copied images as well. IIf you'd like to rename something within a registry, Porter also allows you to copy from one bundle tag to another bundle tag inside the same registry.
 


### PR DESCRIPTION
# What does this change
The link had the markdown syntax for links flipflopped

See https://deploy-preview-1048--porter.netlify.app/copy-bundles/

![Screen Shot 2020-05-15 at 4 55 09 PM](https://user-images.githubusercontent.com/1368985/82099377-db99b580-96cc-11ea-9ddc-8601134c4e50.png)



# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests - Not impacted
- [x] Documentation
- [x] Schema (porter.yaml) - Not impacted
