### PR TITLE
Use GoTool Task

### DIFF
--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -12,10 +12,7 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 variables:
-  GOROOT: '/usr/local/go1.13' # Go installation path
-  GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
-  GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  MODULE_PATH: '$(GOPATH)/src/get.porter.sh/porter' # Path to the module's code
+  GOVERSION: '1.13.10'
 
 jobs:
 - job: setup
@@ -28,45 +25,54 @@ jobs:
   dependsOn: setup
   condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
+  - task: GoTool@0
+    inputs:
+      version: '$(GOVERSION)'
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'
 
   - script: |
       make verify
-    workingDirectory: '$(MODULE_PATH)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Verify'
 
   - script: |
       make test-unit
-    workingDirectory: '$(MODULE_PATH)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Unit Test'
 
 - job: compile
   dependsOn: setup
   condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
+  - task: GoTool@0
+    inputs:
+      version: '$(GOVERSION)'
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'
 
   - script: |
         make xbuild-all
-    workingDirectory: '$(MODULE_PATH)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Cross Compile'
 
 - job: validate_example_bundles
   dependsOn: setup
   condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
+  - task: GoTool@0
+    inputs:
+      version: '$(GOVERSION)'
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'
 
   - script: |
       make build
-    workingDirectory: '$(MODULE_PATH)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Build'
 
   - script: |
       sudo make ajv
       make build-bundle validate-bundle
-    workingDirectory: '$(MODULE_PATH)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Validate Example Bundles'

--- a/build/azure-pipelines.pr-manual.yml
+++ b/build/azure-pipelines.pr-manual.yml
@@ -12,10 +12,7 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 variables:
-  GOROOT: '/usr/local/go1.13' # Go installation path
-  GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
-  GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  MODULE_PATH: '$(GOPATH)/src/get.porter.sh/porter' # Path to the module's code
+  GOVERSION: '1.13.10'
 
 jobs:
 - job: setup
@@ -28,6 +25,9 @@ jobs:
   dependsOn: setup
   condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
+  - task: GoTool@0
+    inputs:
+      version: '$(GOVERSION)'
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'
 
@@ -46,13 +46,16 @@ jobs:
   - script: |
       export KUBECONFIG=$DOWNLOADSECUREFILE_SECUREFILEPATH
       make test-integration
-    workingDirectory: '$(MODULE_PATH)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Integration Test'
 
 - job: cli_test
   dependsOn: setup
   condition: eq(dependencies.setup.outputs['BUILD.DOCS_ONLY'], 'false')
   steps:
+  - task: GoTool@0
+    inputs:
+      version: '$(GOVERSION)'
   - script: build/azure-pipelines.setup-go-workspace.sh
     displayName: 'Set up the Go workspace'
 
@@ -70,11 +73,11 @@ jobs:
 
   - script: |
        make build
-    workingDirectory: '$(MODULE_PATH)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Build'
 
   - script: |
       export KUBECONFIG=$DOWNLOADSECUREFILE_SECUREFILEPATH
       REGISTRY=getporterci make test-cli
-    workingDirectory: '$(MODULE_PATH)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'CLI Test'

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -13,29 +13,32 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 variables:
-  GOROOT: '/usr/local/go1.13' # Go installation path
-  GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
-  GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  MODULE_PATH: '$(GOPATH)/src/get.porter.sh/porter' # Path to the module's code
+  GOVERSION: '1.13.10'
 
 stages:
 - stage: Test
   jobs:
   - job: unit_test
     steps:
+    - task: GoTool@0
+      inputs:
+        version: '$(GOVERSION)'
     - script: build/azure-pipelines.setup-go-workspace.sh
       displayName: 'Set up the Go workspace'
 
     - script: make verify
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'Verify'
 
     - script: make test-unit
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'Unit Test'
 
   - job: integration_test
     steps:
+    - task: GoTool@0
+      inputs:
+        version: '$(GOVERSION)'
     - script: build/azure-pipelines.setup-go-workspace.sh
       displayName: 'Set up the Go workspace'
 
@@ -54,11 +57,14 @@ stages:
     - script: |
         export KUBECONFIG=$DOWNLOADSECUREFILE_SECUREFILEPATH
         make test-integration
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'Integration Test'
 
   - job: cli_test
     steps:
+    - task: GoTool@0
+      inputs:
+        version: '$(GOVERSION)'
     - script: build/azure-pipelines.setup-go-workspace.sh
       displayName: 'Set up the Go workspace'
 
@@ -75,30 +81,33 @@ stages:
         secureFile: kubeconfig
 
     - script: make build
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'Build'
 
     - script: |
         export KUBECONFIG=$DOWNLOADSECUREFILE_SECUREFILEPATH
         export REGISTRY=getporterci
         make test-cli
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'CLI Test'
 
 - stage: Publish
   jobs:
   - job: publish_binaries
     steps:
+    - task: GoTool@0
+      inputs:
+        version: '$(GOVERSION)'
     - script: build/azure-pipelines.setup-go-workspace.sh
       displayName: 'Set up the Go workspace'
     
     # Don't combine with the next step, it messes up the templates in the binaries
     - script: make build
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'Get yourself a porter'
 
     - script: make xbuild-all
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'Cross Compile'
 
     - task: Docker@1
@@ -111,19 +120,22 @@ stages:
     - script: |
         export AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING)
         make publish
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Publish Porter Binaries'
 
   - job: publish_example_bundles
     steps:
+    - task: GoTool@0
+      inputs:
+        version: '$(GOVERSION)'
     - script: build/azure-pipelines.setup-go-workspace.sh
       displayName: 'Set up the Go workspace'
 
     - script: |
         sudo make ajv
         make build build-bundle validate-bundle
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'Validate Example Bundles'
 
     - task: Docker@1
@@ -134,6 +146,6 @@ stages:
         command: login
 
     - script: make publish-bundle
-      workingDirectory: '$(MODULE_PATH)'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
       condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Publish Example Bundles'

--- a/build/azure-pipelines.setup-go-workspace.sh
+++ b/build/azure-pipelines.setup-go-workspace.sh
@@ -2,10 +2,7 @@
 
 set -xeuo pipefail
 
-mkdir -p "$GOBIN"
-mkdir -p "$GOPATH/pkg"
-mkdir -p "$MODULE_PATH"
-shopt -s extglob
-mv !(gopath) "$MODULE_PATH"
-echo "##vso[task.prependpath]$GOBIN"
-echo "##vso[task.prependpath]$GOROOT/bin"
+# Create GOPATH/bin and add it to our PATH so that
+# installed go binaries are available
+mkdir -p /home/vsts/go/bin/
+echo "##vso[task.prependpath]/home/vsts/go/bin/"


### PR DESCRIPTION
Azure Pipelines has changed how go is set up on their environments. Instead of using a script to configure GOROOT, we should now use the GoTool task. We still need an extra script to add GOPATH/bin to PATH since we rely on using tools installed there, like packr.

Our builds were failing because as part of this GOROOT moved from `/usr/local/go1.13` to `/usr/local/go1.13.PATCH` which since we don't actually specify patch, was a bit hard to intuit. 😅

https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/go?view=azure-devops&tabs=go-current#set-up-go