### PR TITLE
docs(*): add a few missing parameters config items

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -92,6 +92,9 @@ parameters:
 - name: mysql_password
   type: string
   sensitive: true
+  applyTo:
+    - install
+    - upgrade
 - name: database_name
   type: string
   default: "wordpress"
@@ -99,10 +102,12 @@ parameters:
 ```
 
 * `name`: The name of the parameter.
-* `type`: The data type of the parameter: string, integer, number, boolean.
-* `env`: The name for the destination environment variable in the bundle. Defaults to the name of the parameter in upper case, if path is not specified.
-* `path`: The destination file path in the bundle.
-* `sensitive`: Optional. Designate this parameter's value as sensitive, for masking in console output.
+* `type`: The data type of the parameter: string, integer, number, boolean or file.
+* `default`: (Optional) The default value for the parameter, which will be used if not supplied elsewhere.
+* `env`: (Optional) The name for the destination environment variable in the bundle. Defaults to the name of the parameter in upper case, if path is not specified.
+* `path`: (Optional) The destination file path in the bundle.
+* `sensitive`: (Optional) Designate this parameter's value as sensitive, for masking in console output.
+* `applyTo`: (Optional) Designate which actions this parameter is applicable. When not supplied, it is assumed the parameter applies to all actions.
  
 ## Outputs
 

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -54,7 +54,7 @@ The syntax to pass a parameter to porter is the same for both regular and file p
 $ porter install --param mytar=./my.tar.gz
 ```
 
-See the [Parameters section of the Author Bundles doc](author-bundles#Parameters) for additional examples and configuration.
+See the [Parameters section of the Author Bundles doc](/author-bundles#parameters) for additional examples and configuration.
 
 ## Wiring Parameters
 

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -54,6 +54,8 @@ The syntax to pass a parameter to porter is the same for both regular and file p
 $ porter install --param mytar=./my.tar.gz
 ```
 
+See the [Parameters section of the Author Bundles doc](author-bundles#Parameters) for additional examples and configuration.
+
 ## Wiring Parameters
 
 Once a parameter has been declared in the `porter.yaml`, Porter provides a simple mechanism for specifying how the parameter value should be wired into the mixin. To reference a parameter in the bundle, you use a notation of the form `"{{ bundle.parameters.PARAM_NAME }}"`. This can be used anywhere within step definition. For example, to use the `database_name` parameter defined above in the `set` block of the helm mixin:


### PR DESCRIPTION
# What does this change

* Adds documentation around a few additional configuration options for parameters

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/934

# Notes for the reviewer

# Checklist
- [x] Unit Tests - N/A
- [x] Documentation
- [X] Schema (porter.yaml) - N/A
