### PR TITLE
fix(cmd/porter/bundle.go): update archive cmd text

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -327,13 +327,13 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 
 	opts := porter.ArchiveOptions{}
 	cmd := cobra.Command{
-		Use:   "archive",
+		Use:   "archive FILENAME",
 		Short: "Archive a bundle",
 		Long:  "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
-		Example: `  porter bundle archive [FILENAME]
-  porter bundle archive --file another/porter.yaml [FILENAME]
-  porter bundle archive --cnab-file some/bundle.json [FILENAME]
-  porter bundle archive --tag repo/bundle:tag [FILENAME]
+		Example: `  porter bundle archive mybun.tgz
+  porter bundle archive mybun.tgz --file another/porter.yaml
+  porter bundle archive mybun.tgz --cnab-file some/bundle.json
+  porter bundle archive mybun.tgz --tag repo/bundle:tag
 		  `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -12,16 +12,16 @@ Archive a bundle
 Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.
 
 ```
-porter archive [flags]
+porter archive FILENAME [flags]
 ```
 
 ### Examples
 
 ```
-  porter archive [FILENAME]
-  porter archive --file another/porter.yaml [FILENAME]
-  porter archive --cnab-file some/bundle.json [FILENAME]
-  porter archive --tag repo/bundle:tag [FILENAME]
+  porter archive mybun.tgz
+  porter archive mybun.tgz --file another/porter.yaml
+  porter archive mybun.tgz --cnab-file some/bundle.json
+  porter archive mybun.tgz --tag repo/bundle:tag
 		  
 ```
 

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -12,16 +12,16 @@ Archive a bundle
 Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.
 
 ```
-porter bundles archive [flags]
+porter bundles archive FILENAME [flags]
 ```
 
 ### Examples
 
 ```
-  porter bundle archive [FILENAME]
-  porter bundle archive --file another/porter.yaml [FILENAME]
-  porter bundle archive --cnab-file some/bundle.json [FILENAME]
-  porter bundle archive --tag repo/bundle:tag [FILENAME]
+  porter bundle archive mybun.tgz
+  porter bundle archive mybun.tgz --file another/porter.yaml
+  porter bundle archive mybun.tgz --cnab-file some/bundle.json
+  porter bundle archive mybun.tgz --tag repo/bundle:tag
 		  
 ```
 


### PR DESCRIPTION
# What does this change

* Updates `archive` cmd usage to show that a destination filename is currently mandatory

# What issue does it fix
N/A, noticed while reading docs in this area.

# Notes for the reviewer
It could be neat to file an enhancement wherein the destination filename could be optional.  If not provided, it could perhaps be auto-derived from the provided manifest or bundle.json?  Thoughts?

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
