### PR TITLE
Run build before integration test

### DIFF
--- a/build/azure-pipelines.pr-manual.yml
+++ b/build/azure-pipelines.pr-manual.yml
@@ -44,6 +44,11 @@ jobs:
       secureFile: kubeconfig
 
   - script: |
+      make build
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+    displayName: 'Build'
+
+  - script: |
       export KUBECONFIG=$DOWNLOADSECUREFILE_SECUREFILEPATH
       make test-integration
     workingDirectory: '$(System.DefaultWorkingDirectory)'


### PR DESCRIPTION
I'm not sure why this was implicitly running a build before... Let's make it explicit since a minor change to the Makefile caused the implicit run of the build target to go away and break CI.

We don't make it a hard dependency in the Makefile because this lets you iterate on just the test without doing a full rebuild inbetween.

I am hoping this fixes the weird broken integration test run for #1028 🤞 
