### PR TITLE
feat(*): introduce Parameter Set

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -102,6 +102,7 @@ Porter uses the Docker driver as the default runtime for executing a bundle's in
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle install
   porter bundle install MyAppInDev --file myapp/bundle.json
+  porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle install --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle install --cred azure --cred kubernetes
   porter bundle install --driver debug
@@ -122,10 +123,13 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
+	f.StringSliceVarP(&opts.ParameterSets, "parameter-set", "p", nil,
+		"Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.")
+	// TODO: remove param-file opt here and in other actions (be sure to remove CLI examples as well)
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
-		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
+		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.")
 	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
@@ -152,6 +156,7 @@ Porter uses the Docker driver as the default runtime for executing a bundle's in
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle upgrade
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
+  porter bundle upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle upgrade --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle upgrade --cred azure --cred kubernetes
   porter bundle upgrade --driver debug
@@ -172,10 +177,13 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
+	f.StringSliceVarP(&opts.ParameterSets, "parameter-set", "p", nil,
+		"Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.")
+	// TODO: remove param-file opt here and in other actions (be sure to remove CLI examples as well)
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
-		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
+		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.")
 	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
@@ -203,6 +211,7 @@ Porter uses the Docker driver as the default runtime for executing a bundle's in
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle invoke --action ACTION
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
+  porter bundle invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle invoke --action ACTION --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle invoke --action ACTION --cred azure --cred kubernetes
   porter bundle invoke --action ACTION --driver debug
@@ -225,10 +234,13 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
+	f.StringSliceVarP(&opts.ParameterSets, "parameter-set", "p", nil,
+		"Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.")
+	// TODO: remove param-file opt here and in other actions (be sure to remove CLI examples as well)
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
-		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
+		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.")
 	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
@@ -256,6 +268,7 @@ Porter uses the Docker driver as the default runtime for executing a bundle's in
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle uninstall
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
+  porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle uninstall --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
   porter bundle uninstall --driver debug
@@ -277,10 +290,13 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
+	f.StringSliceVarP(&opts.ParameterSets, "parameter-set", "p", nil,
+		"Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.")
+	// TODO: remove param-file opt here and in other actions (be sure to remove CLI examples as well)
 	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
 		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
 	f.StringSliceVar(&opts.Params, "param", nil,
-		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
+		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.")
 	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
 		"Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,

--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -84,6 +84,8 @@ See [Using Mixins](/use-mixins) to learn more about how mixins work.
 Parameters are part of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#parameters) and
 allow you to pass in configuration values when you execute the bundle.
 
+Learn more about [how parameters work in Porter](/parameters/).
+
 ```yaml
 parameters:
 - name: mysql_user

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -25,6 +25,7 @@ porter bundles install [INSTANCE] [flags]
 ```
   porter bundle install
   porter bundle install MyAppInDev --file myapp/bundle.json
+  porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle install --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle install --cred azure --cred kubernetes
   porter bundle install --driver debug
@@ -43,8 +44,9 @@ porter bundles install [INSTANCE] [flags]
       --force                      Force a fresh pull of the bundle and all dependencies
   -h, --help                       help for install
       --insecure-registry          Don't require TLS for the registry
-      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.
+      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.
       --param-file strings         Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.
+  -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
 ```
 

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -25,6 +25,7 @@ porter bundles invoke [INSTANCE] --action ACTION [flags]
 ```
   porter bundle invoke --action ACTION
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
+  porter bundle invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle invoke --action ACTION --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle invoke --action ACTION --cred azure --cred kubernetes
   porter bundle invoke --action ACTION --driver debug
@@ -44,8 +45,9 @@ porter bundles invoke [INSTANCE] --action ACTION [flags]
       --force                      Force a fresh pull of the bundle and all dependencies
   -h, --help                       help for invoke
       --insecure-registry          Don't require TLS for the registry
-      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.
+      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.
       --param-file strings         Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.
+  -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
 ```
 

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -25,6 +25,7 @@ porter bundles uninstall [INSTANCE] [flags]
 ```
   porter bundle uninstall
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
+  porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle uninstall --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
   porter bundle uninstall --driver debug
@@ -44,8 +45,9 @@ porter bundles uninstall [INSTANCE] [flags]
       --force                      Force a fresh pull of the bundle and all dependencies
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
-      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.
+      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.
       --param-file strings         Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.
+  -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
 ```
 

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -25,6 +25,7 @@ porter bundles upgrade [INSTANCE] [flags]
 ```
   porter bundle upgrade
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
+  porter bundle upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle upgrade --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter bundle upgrade --cred azure --cred kubernetes
   porter bundle upgrade --driver debug
@@ -43,8 +44,9 @@ porter bundles upgrade [INSTANCE] [flags]
       --force                      Force a fresh pull of the bundle and all dependencies
   -h, --help                       help for upgrade
       --insecure-registry          Don't require TLS for the registry
-      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.
+      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.
       --param-file strings         Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.
+  -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
 ```
 

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -25,6 +25,7 @@ porter install [INSTANCE] [flags]
 ```
   porter install
   porter install MyAppInDev --file myapp/bundle.json
+  porter install --parameter-set azure --param test-mode=true --param header-color=blue
   porter install --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter install --cred azure --cred kubernetes
   porter install --driver debug
@@ -43,8 +44,9 @@ porter install [INSTANCE] [flags]
       --force                      Force a fresh pull of the bundle and all dependencies
   -h, --help                       help for install
       --insecure-registry          Don't require TLS for the registry
-      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.
+      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.
       --param-file strings         Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.
+  -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
 ```
 

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -25,6 +25,7 @@ porter invoke [INSTANCE] --action ACTION [flags]
 ```
   porter invoke --action ACTION
   porter invoke --action ACTION MyAppInDev --file myapp/bundle.json
+  porter invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter invoke --action ACTION --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter invoke --action ACTION --cred azure --cred kubernetes
   porter invoke --action ACTION --driver debug
@@ -44,8 +45,9 @@ porter invoke [INSTANCE] --action ACTION [flags]
       --force                      Force a fresh pull of the bundle and all dependencies
   -h, --help                       help for invoke
       --insecure-registry          Don't require TLS for the registry
-      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.
+      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.
       --param-file strings         Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.
+  -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
 ```
 

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -25,6 +25,7 @@ porter uninstall [INSTANCE] [flags]
 ```
   porter uninstall
   porter uninstall MyAppInDev --file myapp/bundle.json
+  porter uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter uninstall --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter uninstall --cred azure --cred kubernetes
   porter uninstall --driver debug
@@ -44,8 +45,9 @@ porter uninstall [INSTANCE] [flags]
       --force                      Force a fresh pull of the bundle and all dependencies
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
-      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.
+      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.
       --param-file strings         Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.
+  -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
 ```
 

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -25,6 +25,7 @@ porter upgrade [INSTANCE] [flags]
 ```
   porter upgrade
   porter upgrade MyAppInDev --file myapp/bundle.json
+  porter upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter upgrade --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
   porter upgrade --cred azure --cred kubernetes
   porter upgrade --driver debug
@@ -43,8 +44,9 @@ porter upgrade [INSTANCE] [flags]
       --force                      Force a fresh pull of the bundle and all dependencies
   -h, --help                       help for upgrade
       --insecure-registry          Don't require TLS for the registry
-      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.
+      --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file or --parameter-set. May be specified multiple times.
       --param-file strings         Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.
+  -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
 ```
 

--- a/docs/content/parameters.md
+++ b/docs/content/parameters.md
@@ -27,8 +27,6 @@ can have a secret source (`secret`).  See the [secrets
 plugin docs](/plugins/types/#secrets) to learn how to configure Porter to use
 an external secret store.
 
-TODO: add docs on generate when functionality is added.
-
 Now when you execute the bundle you can pass the parameter set to the command
 using the `--parameter-set` or `-p` flag, e.g. `porter install -p myparamset`.
 

--- a/docs/content/parameters.md
+++ b/docs/content/parameters.md
@@ -1,0 +1,59 @@
+---
+title: Parameters
+description: The lifecycle of a parameter from definition, to resolution, and finally injection at runtime
+aliases:
+- /how-parameters-work/
+---
+
+When you are authoring a bundle, you can define what parameters your bundle
+requires such as username and password values for a backing database, or the
+region that a certain resource should be deployed in, etc. Then in your
+action's steps you can reference the parameters using porter's template
+language `{{ bundle.parameters.db_name }}`.
+
+Parameter values are resolved from a combination of supplied parameter set
+files, user-specified overrides and defaults defined by the bundle itself.
+The resolved values are added to a claim receipt, which is passed in to
+the bundle execution environment, e.g. the docker container, when the bundle
+action is executed (install/upgrade/uninstall/invoke).
+
+## Parameter Sets
+
+A Parameter Set is a file which maps parameters to their strategies for value
+resolution.  Strategies include resolving from a source on the user's machine
+such as an environment variable (`env`), filepath (`path`), command result
+(`command`) or simply the value itself (`value`).  In addition, a parameter
+can have a secret source (`secret`).  See the [secrets
+plugin docs](/plugins/types/#secrets) to learn how to configure Porter to use
+an external secret store.
+
+TODO: add docs on generate when functionality is added.
+
+Now when you execute the bundle you can pass the parameter set to the command
+using the `--parameter-set` or `-p` flag, e.g. `porter install -p myparamset`.
+
+## User-specified values
+
+A user may also supply parameter values when invoking an action on the bundle.
+User-supplied values take precedence over both the bundle defaults and any
+included in a provided parameter set file.  The CLI flag for supplying a
+parameter override is `--param`.
+
+For example, you may decide to override the `db_name` parameter for a given
+installation via `porter install --param db_name=mydb -p myparamset`.
+
+## Bundle defaults
+
+The bundle author may have decided to supply a default value for a given
+parameter as well.  This value would be used when neither a user-specified
+value nor a parameter set value is supplied.  See the `Parameters` section in
+the [Author Bundles](/author-bundlesd#parameters/) doc for more info.
+
+## Q & A
+
+### Why can't the parameter source be defined in porter.yaml?
+
+See the helpful explanation in the [credentials](/credentials/) doc, which
+applies to parameter sources as well.
+
+[generate]: /cli/porter_parameters_generate/

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -105,6 +105,8 @@ install:
 
 NOTE: These references must be quoted, as in the examples above.
 
+See [Parameters][parmeters] to learn how parameters are passed in to Porter prior to bundle execution.
+
 
 ## Credentials
 
@@ -255,7 +257,7 @@ install:
       key: mysql-password
 ```
 
-In this bundle, we see the normal declaration of credentials, parameters and outputs, along with the use of `"{{  bundle.x.y.z }}"` to use these. With this bundle definition, we can build a second bundle to install wordpress and declare a dependency on this bundle. The `porter.yaml` for this might look something like:
+In this bundle, we see the normal declaration of credentials, parameters and outputs, along with the use of `"{{ bundle.x.y.z }}"` to use these. With this bundle definition, we can build a second bundle to install wordpress and declare a dependency on this bundle. The `porter.yaml` for this might look something like:
 
 ```yaml
 mixins:
@@ -330,3 +332,4 @@ install:
 
 [mixin-architecture]: /mixin-dev-guide/architecture/
 [credentials]: /credentials/
+[parameters]: /parameters/

--- a/go.mod
+++ b/go.mod
@@ -57,3 +57,5 @@ replace github.com/hashicorp/go-plugin => github.com/carolynvs/go-plugin v1.0.1-
 // See https://github.com/containerd/containerd/issues/3031
 // When I try to just use the require, go is shortening it to v2.7.1+incompatible which then fails to build...
 replace github.com/docker/distribution => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
+
+replace github.com/cnabio/cnab-go => github.com/vdice/cnab-go v0.0.0-20200602210128-57db872f67fa

--- a/go.mod
+++ b/go.mod
@@ -58,4 +58,4 @@ replace github.com/hashicorp/go-plugin => github.com/carolynvs/go-plugin v1.0.1-
 // When I try to just use the require, go is shortening it to v2.7.1+incompatible which then fails to build...
 replace github.com/docker/distribution => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 
-replace github.com/cnabio/cnab-go => github.com/vdice/cnab-go v0.0.0-20200602210128-57db872f67fa
+replace github.com/cnabio/cnab-go => github.com/vdice/cnab-go v0.0.0-20200604175151-7484e185ff27

--- a/go.sum
+++ b/go.sum
@@ -545,6 +545,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vdice/cnab-go v0.0.0-20200602210128-57db872f67fa h1:R8sSuj+gKJmFY2jQ2iKVmYc/gw++deNNvAhwyF1AxKc=
 github.com/vdice/cnab-go v0.0.0-20200602210128-57db872f67fa/go.mod h1:KHrNh0073dP3+twrgOo6GLFEXqZcz2Glma7prVRBoBg=
+github.com/vdice/cnab-go v0.0.0-20200604175151-7484e185ff27 h1:1KFDBQCgh+r1L753qX038Hm1MvpGGVK+Ws8eweANP1g=
+github.com/vdice/cnab-go v0.0.0-20200604175151-7484e185ff27/go.mod h1:KHrNh0073dP3+twrgOo6GLFEXqZcz2Glma7prVRBoBg=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg2K1HrLU=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=

--- a/go.sum
+++ b/go.sum
@@ -543,6 +543,8 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/vdice/cnab-go v0.0.0-20200602210128-57db872f67fa h1:R8sSuj+gKJmFY2jQ2iKVmYc/gw++deNNvAhwyF1AxKc=
+github.com/vdice/cnab-go v0.0.0-20200602210128-57db872f67fa/go.mod h1:KHrNh0073dP3+twrgOo6GLFEXqZcz2Glma7prVRBoBg=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg2K1HrLU=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -23,8 +23,12 @@ type ActionArguments struct {
 	// Target Path => File Contents
 	Files map[string]string
 
-	// Params is the set of parameters to pass to the bundle.
+	// Params is the set of raw parameter values to pass to the bundle.
 	Params map[string]string
+
+	// ParameterSets is a list of strings representing either a filepath to a
+	// parameter set file or the name of a set of a parameters.
+	ParameterSets []string
 
 	// Either a filepath to a credential file or the name of a set of a credentials.
 	CredentialIdentifiers []string

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -23,7 +23,7 @@ type ActionArguments struct {
 	// Target Path => File Contents
 	Files map[string]string
 
-	// Params is the set of raw parameter values to pass to the bundle.
+	// Params is the set of user-specified parameter values to pass to the bundle.
 	Params map[string]string
 
 	// ParameterSets is a list of strings representing either a filepath to a

--- a/pkg/cnab/provider/credentials.go
+++ b/pkg/cnab/provider/credentials.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/pkg/errors"
 )
 
-func (d *Runtime) loadCredentials(b *bundle.Bundle, creds []string) (credentials.Set, error) {
+func (d *Runtime) loadCredentials(b *bundle.Bundle, creds []string) (valuesource.Set, error) {
 	if len(creds) == 0 {
 		return nil, credentials.Validate(nil, b.Credentials)
 	}
@@ -18,7 +19,7 @@ func (d *Runtime) loadCredentials(b *bundle.Bundle, creds []string) (credentials
 	// The strategy here is "last one wins". We loop through each credential file and
 	// calculate its credentials. Then we insert them into the creds map in the order
 	// in which they were supplied on the CLI.
-	resolvedCredentials := credentials.Set{}
+	resolvedCredentials := valuesource.Set{}
 	for _, name := range creds {
 		var cset credentials.CredentialSet
 		var err error

--- a/pkg/cnab/provider/credentials.go
+++ b/pkg/cnab/provider/credentials.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/credentials"
+	"github.com/pkg/errors"
 )
 
 func (d *Runtime) loadCredentials(b *bundle.Bundle, creds []string) (credentials.Set, error) {

--- a/pkg/cnab/provider/credentials_test.go
+++ b/pkg/cnab/provider/credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"get.porter.sh/porter/pkg/secrets"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,10 +24,10 @@ func TestRuntime_loadCredentials(t *testing.T) {
 		Name:     "mycreds",
 		Created:  time.Now(),
 		Modified: time.Now(),
-		Credentials: []credentials.CredentialStrategy{
+		Credentials: []valuesource.Strategy{
 			{
 				Name: "password",
-				Source: credentials.Source{
+				Source: valuesource.Source{
 					Key:   secrets.SourceSecret,
 					Value: "password",
 				},
@@ -54,7 +55,7 @@ func TestRuntime_loadCredentials(t *testing.T) {
 	gotValues, err := r.loadCredentials(&b, []string{"mycreds", "/db-creds.json"})
 	require.NoError(t, err, "loadCredentials failed")
 
-	wantValues := credentials.Set{
+	wantValues := valuesource.Set{
 		"password":    "mypassword",
 		"db-password": "topsecret",
 	}

--- a/pkg/cnab/provider/helpers.go
+++ b/pkg/cnab/provider/helpers.go
@@ -6,6 +6,7 @@ import (
 	"get.porter.sh/porter/pkg/claims"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/credentials"
+	"get.porter.sh/porter/pkg/parameters"
 	"github.com/cnabio/cnab-go/bundle"
 )
 
@@ -23,14 +24,19 @@ func NewTestRuntime(t *testing.T) *TestRuntime {
 	tc := config.NewTestConfig(t)
 	claimStorage := claims.NewTestClaimProvider()
 	credentialStorage := credentials.NewTestCredentialProvider(t, tc)
-	return NewTestRuntimeWithConfig(tc, claimStorage, credentialStorage)
+	parameterStorage := parameters.NewTestParameterProvider(t, tc)
+	return NewTestRuntimeWithConfig(tc, claimStorage, credentialStorage, parameterStorage)
 }
 
-func NewTestRuntimeWithConfig(tc *config.TestConfig, testClaims claims.ClaimProvider, testCredentials credentials.TestCredentialProvider) *TestRuntime {
+func NewTestRuntimeWithConfig(
+	tc *config.TestConfig,
+	testClaims claims.ClaimProvider,
+	testCredentials credentials.TestCredentialProvider,
+	testParameters parameters.TestParameterProvider) *TestRuntime {
 	return &TestRuntime{
 		TestConfig:      tc,
 		TestCredentials: testCredentials,
-		Runtime:         NewRuntime(tc.Config, testClaims, testCredentials),
+		Runtime:         NewRuntime(tc.Config, testClaims, testCredentials, testParameters),
 	}
 }
 

--- a/pkg/cnab/provider/helpers.go
+++ b/pkg/cnab/provider/helpers.go
@@ -17,6 +17,7 @@ var _ CNABProvider = &TestRuntime{}
 type TestRuntime struct {
 	*Runtime
 	TestCredentials credentials.TestCredentialProvider
+	TestParameters  *parameters.TestParameterProvider
 	TestConfig      *config.TestConfig
 }
 
@@ -36,6 +37,7 @@ func NewTestRuntimeWithConfig(
 	return &TestRuntime{
 		TestConfig:      tc,
 		TestCredentials: testCredentials,
+		TestParameters:  &testParameters,
 		Runtime:         NewRuntime(tc.Config, testClaims, testCredentials, testParameters),
 	}
 }

--- a/pkg/cnab/provider/install.go
+++ b/pkg/cnab/provider/install.go
@@ -35,7 +35,7 @@ func (d *Runtime) Install(args ActionArguments) error {
 	}
 	d.Extensions = exts
 
-	params, err := d.loadParameters(c, args.Params, string(manifest.ActionInstall))
+	params, err := d.loadParameters(c, args.Params, args.ParameterSets, string(manifest.ActionInstall))
 	if err != nil {
 		return errors.Wrap(err, "invalid parameters")
 	}

--- a/pkg/cnab/provider/invoke.go
+++ b/pkg/cnab/provider/invoke.go
@@ -70,7 +70,7 @@ func (d *Runtime) Invoke(action string, args ActionArguments) error {
 	}
 	d.Extensions = exts
 
-	c.Parameters, err = d.loadParameters(c, args.Params, action)
+	c.Parameters, err = d.loadParameters(c, args.Params, args.ParameterSets, action)
 	if err != nil {
 		return errors.Wrap(err, "invalid parameters")
 	}

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -21,7 +21,7 @@ func (d *Runtime) loadParameters(claim *claim.Claim, rawOverrides map[string]str
 	// Loop through each parameter set file and load the parameter values
 	loaded, err := d.loadParameterSets(bun, parameterSets)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to process provided parameter sets")
+		return nil, errors.Wrapf(err, "unable to process provided parameter sets: %v", parameterSets)
 	}
 
 	for key, val := range loaded {

--- a/pkg/cnab/provider/parameters.go
+++ b/pkg/cnab/provider/parameters.go
@@ -7,10 +7,8 @@ import (
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-go/claim"
-	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/pkg/errors"
-
-	"get.porter.sh/porter/pkg/parameters"
 )
 
 // loadParameters accepts a set of parameter overrides as well as parameter set
@@ -59,12 +57,8 @@ func (d *Runtime) loadParameters(claim *claim.Claim, rawOverrides map[string]str
 }
 
 // loadParameterSets loads parameter values per their parameter set strategies
-func (d *Runtime) loadParameterSets(b *bundle.Bundle, params []string) (credentials.Set, error) {
-	if len(params) == 0 {
-		return nil, parameters.Validate(nil, b.Parameters)
-	}
-
-	resolvedParameters := credentials.Set{}
+func (d *Runtime) loadParameterSets(b *bundle.Bundle, params []string) (valuesource.Set, error) {
+	resolvedParameters := valuesource.Set{}
 	for _, name := range params {
 		pset, err := d.parameters.Read(name)
 		if err != nil {
@@ -81,7 +75,7 @@ func (d *Runtime) loadParameterSets(b *bundle.Bundle, params []string) (credenti
 		}
 	}
 
-	return resolvedParameters, parameters.Validate(resolvedParameters, b.Parameters)
+	return resolvedParameters, nil
 }
 
 func (d *Runtime) getUnconvertedValueFromRaw(def *definition.Schema, key, rawValue string) (string, error) {

--- a/pkg/cnab/provider/parameters_test.go
+++ b/pkg/cnab/provider/parameters_test.go
@@ -24,7 +24,7 @@ func Test_loadParameters_paramNotDefined(t *testing.T) {
 		"foo": "bar",
 	}
 
-	_, err = d.loadParameters(claim, overrides, "action")
+	_, err = d.loadParameters(claim, overrides, nil, "action")
 	require.EqualError(t, err, "parameter foo not defined in bundle")
 }
 
@@ -46,7 +46,7 @@ func Test_loadParameters_definitionNotDefined(t *testing.T) {
 		"foo": "bar",
 	}
 
-	_, err = d.loadParameters(claim, overrides, "action")
+	_, err = d.loadParameters(claim, overrides, nil, "action")
 	require.EqualError(t, err, "definition foo not defined in bundle")
 }
 
@@ -104,7 +104,7 @@ func Test_loadParameters_applyTo(t *testing.T) {
 		"true": "false",
 	}
 
-	params, err := d.loadParameters(claim, overrides, "action")
+	params, err := d.loadParameters(claim, overrides, nil, "action")
 	require.NoError(t, err)
 
 	require.Equal(t, "FOO", params["foo"], "expected param 'foo' to be updated")
@@ -139,7 +139,7 @@ func Test_loadParameters_applyToBundleDefaults(t *testing.T) {
 
 	overrides := map[string]string{}
 
-	params, err := d.loadParameters(claim, overrides, "action")
+	params, err := d.loadParameters(claim, overrides, nil, "action")
 	require.NoError(t, err)
 
 	require.Equal(t, nil, params["foo"], "expected param 'foo' to be nil, regardless of the bundle default, as it does not apply")
@@ -174,7 +174,7 @@ func Test_loadParameters_requiredButDoesNotApply(t *testing.T) {
 
 	overrides := map[string]string{}
 
-	params, err := d.loadParameters(claim, overrides, "action")
+	params, err := d.loadParameters(claim, overrides, nil, "action")
 	require.NoError(t, err)
 
 	require.Equal(t, nil, params["foo"], "expected param 'foo' to be nil, regardless of claim value, as it does not apply")
@@ -210,7 +210,7 @@ func Test_loadParameters_fileParameter(t *testing.T) {
 		"foo": "/path/to/file",
 	}
 
-	params, err := d.loadParameters(claim, overrides, "action")
+	params, err := d.loadParameters(claim, overrides, nil, "action")
 	require.NoError(t, err)
 
 	require.Equal(t, "SGVsbG8gV29ybGQh", params["foo"], "expected param 'foo' to be the base64-encoded file contents")
@@ -392,3 +392,5 @@ func Test_Paramapalooza(t *testing.T) {
 		})
 	}
 }
+
+// TODO: test intersection of param overrides and provided parameter sets (currently, overrides should take precedence)

--- a/pkg/cnab/provider/runtime.go
+++ b/pkg/cnab/provider/runtime.go
@@ -5,6 +5,7 @@ import (
 	"get.porter.sh/porter/pkg/cnab/extensions"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/credentials"
+	"get.porter.sh/porter/pkg/parameters"
 )
 
 var _ CNABProvider = &Runtime{}
@@ -12,15 +13,17 @@ var _ CNABProvider = &Runtime{}
 type Runtime struct {
 	*config.Config
 	credentials credentials.CredentialProvider
+	parameters  parameters.ParameterProvider
 	claims      claims.ClaimProvider
 	Extensions  extensions.ProcessedExtensions
 }
 
-func NewRuntime(c *config.Config, claims claims.ClaimProvider, credentials credentials.CredentialProvider) *Runtime {
+func NewRuntime(c *config.Config, claims claims.ClaimProvider, credentials credentials.CredentialProvider, parameters parameters.ParameterProvider) *Runtime {
 	return &Runtime{
 		Config:      c,
 		claims:      claims,
 		credentials: credentials,
+		parameters:  parameters,
 		Extensions:  extensions.ProcessedExtensions{},
 	}
 }

--- a/pkg/cnab/provider/testdata/paramset.json
+++ b/pkg/cnab/provider/testdata/paramset.json
@@ -1,0 +1,13 @@
+{
+  "name": "myparameterset",
+  "created": "1983-04-18T01:02:03.000000004Z",
+  "modified": "1983-04-18T01:02:03.000000004Z",
+  "parameters": [
+    {
+      "name": "foo",
+      "source": {
+        "secret": "foo_secret"
+      }
+    }
+  ]
+}

--- a/pkg/cnab/provider/uninstall.go
+++ b/pkg/cnab/provider/uninstall.go
@@ -33,7 +33,7 @@ func (d *Runtime) Uninstall(args ActionArguments) error {
 	}
 	d.Extensions = exts
 
-	c.Parameters, err = d.loadParameters(&c, args.Params, string(manifest.ActionUninstall))
+	c.Parameters, err = d.loadParameters(&c, args.Params, args.ParameterSets, string(manifest.ActionUninstall))
 	if err != nil {
 		return errors.Wrap(err, "invalid parameters")
 	}

--- a/pkg/cnab/provider/upgrade.go
+++ b/pkg/cnab/provider/upgrade.go
@@ -29,7 +29,7 @@ func (d *Runtime) Upgrade(args ActionArguments) error {
 	}
 	d.Extensions = exts
 
-	c.Parameters, err = d.loadParameters(&c, args.Params, string(manifest.ActionUpgrade))
+	c.Parameters, err = d.loadParameters(&c, args.Params, args.ParameterSets, string(manifest.ActionUpgrade))
 	if err != nil {
 		return errors.Wrap(err, "invalid parameters")
 	}

--- a/pkg/credentials/credentialProvider.go
+++ b/pkg/credentials/credentialProvider.go
@@ -2,12 +2,13 @@ package credentials
 
 import (
 	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/valuesource"
 )
 
 // CredentialProvider interface for managing sets of credentials.
 type CredentialProvider interface {
 	CredentialStore
-	ResolveAll(creds credentials.CredentialSet) (credentials.Set, error)
+	ResolveAll(creds credentials.CredentialSet) (valuesource.Set, error)
 	Validate(credentials.CredentialSet) error
 }
 

--- a/pkg/credentials/credentialStorage.go
+++ b/pkg/credentials/credentialStorage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cnabio/cnab-go/credentials"
 	cnabsecrets "github.com/cnabio/cnab-go/secrets"
 	"github.com/cnabio/cnab-go/secrets/host"
+	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
@@ -38,8 +39,8 @@ func NewCredentialStorage(c *config.Config, storagePlugin *crudplugins.Store) *C
 	}
 }
 
-func (s CredentialStorage) ResolveAll(creds credentials.CredentialSet) (credentials.Set, error) {
-	resolvedCreds := make(credentials.Set)
+func (s CredentialStorage) ResolveAll(creds credentials.CredentialSet) (valuesource.Set, error) {
+	resolvedCreds := make(valuesource.Set)
 	var resolveErrors error
 
 	for _, cred := range creds.Credentials {

--- a/pkg/credentials/credentialStorage_test.go
+++ b/pkg/credentials/credentialStorage_test.go
@@ -4,21 +4,22 @@ import (
 	"testing"
 
 	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCredentialStorage_Validate_GoodSources(t *testing.T) {
 	s := CredentialStorage{}
 	testCreds := credentials.CredentialSet{
-		Credentials: []credentials.CredentialStrategy{
+		Credentials: []valuesource.Strategy{
 			{
-				Source: credentials.Source{
+				Source: valuesource.Source{
 					Key:   "env",
 					Value: "SOME_ENV",
 				},
 			},
 			{
-				Source: credentials.Source{
+				Source: valuesource.Source{
 					Key:   "value",
 					Value: "somevalue",
 				},
@@ -33,15 +34,15 @@ func TestCredentialStorage_Validate_GoodSources(t *testing.T) {
 func TestCredentialStorage_Validate_BadSources(t *testing.T) {
 	s := CredentialStorage{}
 	testCreds := credentials.CredentialSet{
-		Credentials: []credentials.CredentialStrategy{
+		Credentials: []valuesource.Strategy{
 			{
-				Source: credentials.Source{
+				Source: valuesource.Source{
 					Key:   "wrongthing",
 					Value: "SOME_ENV",
 				},
 			},
 			{
-				Source: credentials.Source{
+				Source: valuesource.Source{
 					Key:   "anotherwrongthing",
 					Value: "somevalue",
 				},

--- a/pkg/credentialsgenerator/generator.go
+++ b/pkg/credentialsgenerator/generator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/credentials"
 	"github.com/cnabio/cnab-go/secrets/host"
+	"github.com/cnabio/cnab-go/valuesource"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 
@@ -38,7 +39,7 @@ const (
 	questionCommand = "shell command"
 )
 
-type credentialGenerator func(name string) (credentials.CredentialStrategy, error)
+type credentialGenerator func(name string) (valuesource.Strategy, error)
 
 // GenerateCredentials will generate a credential set based on the given options
 func GenerateCredentials(opts GenerateOptions) (*credentials.CredentialSet, error) {
@@ -60,7 +61,7 @@ func genCredentialSet(name string, creds map[string]bundle.Credential, fn creden
 	cs := credentials.CredentialSet{
 		Name: name,
 	}
-	cs.Credentials = []credentials.CredentialStrategy{}
+	cs.Credentials = []valuesource.Strategy{}
 
 	if strings.ContainsAny(name, "./\\") {
 		return cs, fmt.Errorf("credentialset name '%s' cannot contain the following characters: './\\'", name)
@@ -84,14 +85,14 @@ func genCredentialSet(name string, creds map[string]bundle.Credential, fn creden
 	return cs, nil
 }
 
-func genEmptyCredentials(name string) (credentials.CredentialStrategy, error) {
-	return credentials.CredentialStrategy{
+func genEmptyCredentials(name string) (valuesource.Strategy, error) {
+	return valuesource.Strategy{
 		Name:   name,
-		Source: credentials.Source{Value: "TODO"},
+		Source: valuesource.Source{Value: "TODO"},
 	}, nil
 }
 
-func genCredentialSurvey(name string) (credentials.CredentialStrategy, error) {
+func genCredentialSurvey(name string) (valuesource.Strategy, error) {
 
 	sourceTypePrompt := &survey.Select{
 		Message: fmt.Sprintf("How would you like to set credential %q", name),
@@ -101,7 +102,7 @@ func genCredentialSurvey(name string) (credentials.CredentialStrategy, error) {
 
 	sourceValuePromptTemplate := "Enter the %s that will be used to set credential %q"
 
-	c := credentials.CredentialStrategy{Name: name}
+	c := valuesource.Strategy{Name: name}
 
 	source := ""
 	if err := survey.AskOne(sourceTypePrompt, &source, nil); err != nil {

--- a/pkg/parameters/helpers.go
+++ b/pkg/parameters/helpers.go
@@ -24,14 +24,14 @@ type TestParameterProvider struct {
 
 func NewTestParameterProvider(t *testing.T, tc *config.TestConfig) TestParameterProvider {
 	backingSecrets := inmemorysecrets.NewStore()
-	backingCreds := inmemorystorage.NewStore()
-	credStore := NewParameterStore(backingCreds)
+	backingParams := inmemorystorage.NewStore()
+	paramStore := NewParameterStore(backingParams)
 	return TestParameterProvider{
 		T:           t,
 		TestConfig:  tc,
 		TestSecrets: backingSecrets,
 		ParameterStorage: &ParameterStorage{
-			ParametersStore: &credStore,
+			ParametersStore: &paramStore,
 			SecretsStore:    secrets.NewSecretStore(backingSecrets),
 		},
 	}

--- a/pkg/parameters/helpers.go
+++ b/pkg/parameters/helpers.go
@@ -1,0 +1,62 @@
+package parameters
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/secrets"
+	inmemorysecrets "get.porter.sh/porter/pkg/secrets/in-memory"
+	inmemorystorage "get.porter.sh/porter/pkg/storage/in-memory"
+	"github.com/pkg/errors"
+)
+
+var _ ParameterProvider = &TestParameterProvider{}
+
+type TestParameterProvider struct {
+	T          *testing.T
+	TestConfig *config.TestConfig
+	// TestSecrets allows you to set up secrets for unit testing
+	TestSecrets *inmemorysecrets.Store
+	*ParameterStorage
+}
+
+func NewTestParameterProvider(t *testing.T, tc *config.TestConfig) TestParameterProvider {
+	backingSecrets := inmemorysecrets.NewStore()
+	backingCreds := inmemorystorage.NewStore()
+	credStore := NewParameterStore(backingCreds)
+	return TestParameterProvider{
+		T:           t,
+		TestConfig:  tc,
+		TestSecrets: backingSecrets,
+		ParameterStorage: &ParameterStorage{
+			ParametersStore: &credStore,
+			SecretsStore:    secrets.NewSecretStore(backingSecrets),
+		},
+	}
+}
+
+func (p *TestParameterProvider) AddTestParameters(path string) {
+	cs, err := Load(path)
+	if err != nil {
+		p.T.Fatal(errors.Wrapf(err, "could not read test parameters from %s", path))
+	}
+
+	err = p.ParameterStorage.Save(*cs)
+	if err != nil {
+		p.T.Fatal(errors.Wrap(err, "could not load test parameters into in memory parameter storage"))
+	}
+}
+
+func (p *TestParameterProvider) AddTestParametersDirectory(dir string) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		p.T.Fatal(errors.Wrapf(err, "could not list test directory %s", dir))
+	}
+
+	for _, fi := range files {
+		path := filepath.Join(dir, fi.Name())
+		p.AddTestParameters(path)
+	}
+}

--- a/pkg/parameters/parameterProvider.go
+++ b/pkg/parameters/parameterProvider.go
@@ -1,8 +1,6 @@
 package parameters
 
-import (
-	"github.com/cnabio/cnab-go/credentials"
-)
+import "github.com/cnabio/cnab-go/valuesource"
 
 // TODO: clone of credentialProvider from credentials pkg
 // Generalize to DRY out?
@@ -10,7 +8,7 @@ import (
 // ParameterProvider interface for managing sets of parameters.
 type ParameterProvider interface {
 	ParameterStore
-	ResolveAll(creds ParameterSet) (credentials.Set, error)
+	ResolveAll(creds ParameterSet) (valuesource.Set, error)
 	Validate(ParameterSet) error
 }
 

--- a/pkg/parameters/parameterProvider.go
+++ b/pkg/parameters/parameterProvider.go
@@ -2,9 +2,6 @@ package parameters
 
 import "github.com/cnabio/cnab-go/valuesource"
 
-// TODO: clone of credentialProvider from credentials pkg
-// Generalize to DRY out?
-
 // ParameterProvider interface for managing sets of parameters.
 type ParameterProvider interface {
 	ParameterStore

--- a/pkg/parameters/parameterProvider.go
+++ b/pkg/parameters/parameterProvider.go
@@ -1,0 +1,24 @@
+package parameters
+
+import (
+	"github.com/cnabio/cnab-go/credentials"
+)
+
+// TODO: clone of credentialProvider from credentials pkg
+// Generalize to DRY out?
+
+// ParameterProvider interface for managing sets of parameters.
+type ParameterProvider interface {
+	ParameterStore
+	ResolveAll(creds ParameterSet) (credentials.Set, error)
+	Validate(ParameterSet) error
+}
+
+// ParameterStore is an interface representing parameters.Store
+type ParameterStore interface {
+	List() ([]string, error)
+	Save(ParameterSet) error
+	Read(name string) (ParameterSet, error)
+	ReadAll() ([]ParameterSet, error)
+	Delete(name string) error
+}

--- a/pkg/parameters/parameterStorage.go
+++ b/pkg/parameters/parameterStorage.go
@@ -1,0 +1,81 @@
+package parameters
+
+import (
+	"fmt"
+	"strings"
+
+	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/secrets"
+	secretplugins "get.porter.sh/porter/pkg/secrets/pluginstore"
+	crudplugins "get.porter.sh/porter/pkg/storage/pluginstore"
+	"github.com/cnabio/cnab-go/credentials"
+	cnabsecrets "github.com/cnabio/cnab-go/secrets"
+	"github.com/cnabio/cnab-go/secrets/host"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+// TODO: clone of credentialStorage.go in credentials pkg
+// Can generalize/share/DRY out?
+
+type ParametersStore = Store
+type SecretsStore = cnabsecrets.Store
+
+var _ ParameterProvider = &ParameterStorage{}
+
+// ParameterStorage provides access to parameter sets by instantiating plugins that
+// implement CRUD storage.
+type ParameterStorage struct {
+	*config.Config
+	*ParametersStore
+	SecretsStore
+}
+
+func NewParameterStorage(c *config.Config, storagePlugin *crudplugins.Store) *ParameterStorage {
+	paramStore := NewParameterStore(storagePlugin)
+	return &ParameterStorage{
+		Config:          c,
+		ParametersStore: &paramStore,
+		SecretsStore:    secrets.NewSecretStore(secretplugins.NewStore(c)),
+	}
+}
+
+func (s ParameterStorage) ResolveAll(params ParameterSet) (credentials.Set, error) {
+	resolvedParams := make(credentials.Set)
+	var resolveErrors error
+
+	for _, param := range params.Parameters {
+		value, err := s.Resolve(param.Source.Key, param.Source.Value)
+		if err != nil {
+			resolveErrors = multierror.Append(resolveErrors, errors.Wrapf(err, "unable to resolve parameter %s.%s from %s %s", params.Name, param.Name, param.Source.Key, param.Source.Value))
+		}
+
+		resolvedParams[param.Name] = value
+	}
+
+	return resolvedParams, resolveErrors
+}
+
+func (s ParameterStorage) Validate(params ParameterSet) error {
+	validSources := []string{secrets.SourceSecret, host.SourceValue, host.SourceEnv, host.SourcePath, host.SourceCommand}
+	var errors error
+
+	for _, cs := range params.Parameters {
+		valid := false
+		for _, validSource := range validSources {
+			if cs.Source.Key == validSource {
+				valid = true
+				break
+			}
+		}
+		if valid == false {
+			errors = multierror.Append(errors, fmt.Errorf(
+				"%s is not a valid source. Valid sources are: %s",
+				cs.Source.Key,
+				strings.Join(validSources, ", "),
+			))
+		}
+	}
+
+	return errors
+}

--- a/pkg/parameters/parameterStorage.go
+++ b/pkg/parameters/parameterStorage.go
@@ -15,9 +15,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TODO: clone of credentialStorage.go in credentials pkg
-// Can generalize/share/DRY out?
-
 type ParametersStore = Store
 type SecretsStore = cnabsecrets.Store
 

--- a/pkg/parameters/parameterStorage.go
+++ b/pkg/parameters/parameterStorage.go
@@ -8,9 +8,9 @@ import (
 	"get.porter.sh/porter/pkg/secrets"
 	secretplugins "get.porter.sh/porter/pkg/secrets/pluginstore"
 	crudplugins "get.porter.sh/porter/pkg/storage/pluginstore"
-	"github.com/cnabio/cnab-go/credentials"
 	cnabsecrets "github.com/cnabio/cnab-go/secrets"
 	"github.com/cnabio/cnab-go/secrets/host"
+	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
@@ -40,8 +40,8 @@ func NewParameterStorage(c *config.Config, storagePlugin *crudplugins.Store) *Pa
 	}
 }
 
-func (s ParameterStorage) ResolveAll(params ParameterSet) (credentials.Set, error) {
-	resolvedParams := make(credentials.Set)
+func (s ParameterStorage) ResolveAll(params ParameterSet) (valuesource.Set, error) {
+	resolvedParams := make(valuesource.Set)
 	var resolveErrors error
 
 	for _, param := range params.Parameters {

--- a/pkg/parameters/parameterStorage_test.go
+++ b/pkg/parameters/parameterStorage_test.go
@@ -1,0 +1,155 @@
+package parameters
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/secrets"
+	inmemorysecrets "get.porter.sh/porter/pkg/secrets/in-memory"
+	inmemorystorage "get.porter.sh/porter/pkg/storage/in-memory"
+	"github.com/cnabio/cnab-go/valuesource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParameterStorage_ResolveAll(t *testing.T) {
+	// The inmemory secret store currently only supports secret sources
+	// So all of these have this same source
+	testParameterSet := ParameterSet{
+		Name: "myparamset",
+		Parameters: []valuesource.Strategy{
+			{
+				Name: "param1",
+				Source: valuesource.Source{
+					Key:   "secret",
+					Value: "param1",
+				},
+			},
+			{
+				Name: "param2",
+				Source: valuesource.Source{
+					Key:   "secret",
+					Value: "param2",
+				},
+			},
+		},
+	}
+
+	t.Run("resolve params success", func(t *testing.T){
+		tc := config.NewTestConfig(t)
+		backingSecrets := inmemorysecrets.NewStore()
+		backingParams := inmemorystorage.NewStore()
+		paramStore := NewParameterStore(backingParams)
+		secretStore := secrets.NewSecretStore(backingSecrets)
+	
+		parameterStorage := ParameterStorage{
+			Config:          tc.Config,
+			ParametersStore: &paramStore,
+			SecretsStore:    secretStore,
+		}
+
+		backingSecrets.AddSecret("param1", "param1_value")
+		backingSecrets.AddSecret("param2", "param2_value")
+
+		expected := valuesource.Set{
+			"param1":"param1_value",
+			"param2":"param2_value",
+		}
+
+		resolved, err := parameterStorage.ResolveAll(testParameterSet)
+		require.NoError(t, err)
+		require.Equal(t, expected, resolved)
+	})
+
+	t.Run("resolve params failure", func(t *testing.T){
+		tc := config.NewTestConfig(t)
+		backingSecrets := inmemorysecrets.NewStore()
+		backingParams := inmemorystorage.NewStore()
+		paramStore := NewParameterStore(backingParams)
+		secretStore := secrets.NewSecretStore(backingSecrets)
+	
+		parameterStorage := ParameterStorage{
+			Config:          tc.Config,
+			ParametersStore: &paramStore,
+			SecretsStore:    secretStore,
+		}
+
+		// Purposefully only adding one secret
+		backingSecrets.AddSecret("param1", "param1_value")
+
+		expected := valuesource.Set{
+			"param1":"param1_value",
+			"param2":"",
+		}
+
+		resolved, err := parameterStorage.ResolveAll(testParameterSet)
+		require.EqualError(t, err, "1 error occurred:\n\t* unable to resolve parameter myparamset.param2 from secret param2: secret not found\n\n")
+		require.Equal(t, expected, resolved)
+	})
+}
+
+func TestParameterStorage_Validate(t *testing.T) {
+	t.Run("valid sources", func(t *testing.T) {
+		s := ParameterStorage{}
+
+		testParameterSet := ParameterSet{
+			Parameters: []valuesource.Strategy{
+				{
+					Source: valuesource.Source{
+						Key:   "env",
+						Value: "SOME_ENV",
+					},
+				},
+				{
+					Source: valuesource.Source{
+						Key:   "value",
+						Value: "somevalue",
+					},
+				},
+				{
+					Source: valuesource.Source{
+						Key:   "path",
+						Value: "/some/path",
+					},
+				},
+				{
+					Source: valuesource.Source{
+						Key:   "command",
+						Value: "some command",
+					},
+				},
+				{
+					Source: valuesource.Source{
+						Key:   "secret",
+						Value: "secret",
+					},
+				},
+			},
+		}
+	
+		err := s.Validate(testParameterSet)
+		require.NoError(t, err, "Validate did not return errors")
+	})
+
+	t.Run("invalid sources", func(t *testing.T){
+		s := ParameterStorage{}
+		testParameterSet := ParameterSet{
+			Parameters: []valuesource.Strategy{
+				{
+					Source: valuesource.Source{
+						Key:   "wrongthing",
+						Value: "SOME_ENV",
+					},
+				},
+				{
+					Source: valuesource.Source{
+						Key:   "anotherwrongthing",
+						Value: "somevalue",
+					},
+				},
+			},
+		}
+	
+		err := s.Validate(testParameterSet)
+		require.Error(t, err, "Validate returned errors")
+	})
+}

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -5,8 +5,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/cnabio/cnab-go/bundle"
-	"github.com/cnabio/cnab-go/credentials"
 	"gopkg.in/yaml.v2"
 )
 
@@ -45,30 +43,4 @@ func Load(path string) (*ParameterSet, error) {
 		return pset, err
 	}
 	return pset, yaml.Unmarshal(data, pset)
-}
-
-// Validate compares the given parameters with the spec.
-//
-// This will result in an error only when the following conditions are true:
-// - a parameter in the spec is not present in the given set
-// - the parameter is required
-//
-// It is allowed for spec to specify both an env var and a file. In such case, if
-// the given set provides either, it will be considered valid.
-func Validate(given credentials.Set, spec map[string]bundle.Parameter) error {
-	for name, param := range spec {
-		if !isValidParam(given, name) && param.Required {
-			return fmt.Errorf("bundle requires parameter for %s", name)
-		}
-	}
-	return nil
-}
-
-func isValidParam(haystack credentials.Set, needle string) bool {
-	for name := range haystack {
-		if name == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -2,7 +2,12 @@ package parameters
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/credentials"
+	"gopkg.in/yaml.v2"
 )
 
 // ParseVariableAssignments converts a string array of variable assignments
@@ -28,4 +33,42 @@ func ParseVariableAssignments(params []string) (map[string]string, error) {
 	}
 
 	return variables, nil
+}
+
+// Load a ParameterSet from a file at a given path.
+//
+// It does not load the individual parameters.
+func Load(path string) (*ParameterSet, error) {
+	pset := &ParameterSet{}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return pset, err
+	}
+	return pset, yaml.Unmarshal(data, pset)
+}
+
+// Validate compares the given parameters with the spec.
+//
+// This will result in an error only when the following conditions are true:
+// - a parameter in the spec is not present in the given set
+// - the parameter is required
+//
+// It is allowed for spec to specify both an env var and a file. In such case, if
+// the given set provides either, it will be considered valid.
+func Validate(given credentials.Set, spec map[string]bundle.Parameter) error {
+	for name, param := range spec {
+		if !isValidParam(given, name) && param.Required {
+			return fmt.Errorf("bundle requires parameter for %s", name)
+		}
+	}
+	return nil
+}
+
+func isValidParam(haystack credentials.Set, needle string) bool {
+	for name := range haystack {
+		if name == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -67,7 +67,7 @@ func TestLoad(t *testing.T) {
 			Name:     "mybun",
 			Created:  time.Date(1983, time.April, 18, 1, 2, 3, 4, time.UTC),
 			Modified: time.Date(1983, time.April, 18, 1, 2, 3, 4, time.UTC),
-			Parameters: []ParameterStrategy{
+			Parameters: []valuesource.Strategy{
 				{
 					Name: "param_env",
 					Source: valuesource.Source{

--- a/pkg/parameters/parameterset.go
+++ b/pkg/parameters/parameterset.go
@@ -1,0 +1,64 @@
+package parameters
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/secrets"
+)
+
+// ParameterSet represents a collection of parameters and their
+// sources/strategies for value resolution
+type ParameterSet struct {
+	// Name is the name of the parameter set.
+	Name string `json:"name" yaml:"name"`
+	// Created timestamp of the parameter set.
+	Created time.Time `json:"created" yaml:"created"`
+	// Modified timestamp of the parameter set.
+	Modified time.Time `json:"modified" yaml:"modified"`
+	// Parameters is a list of parameter specs.
+	Parameters []ParameterStrategy `json:"parameters" yaml:"parameters"`
+}
+
+// TODO: is this needed?  Clone of cnab-go's credentials.ResolveCredentials(...)
+//
+// Resolve looks up the parameters as described in Source, then copies
+// the resulting value into the Value field of each parameter strategy.
+//
+// The typical workflow for working with a parameter set is:
+//
+//	- Load the set
+//	- Validate the parameters against a spec
+//	- Resolve the parameters
+//	- Expand them into bundle values
+func (p *ParameterSet) Resolve(s secrets.Store) (credentials.Set, error) {
+	l := len(p.Parameters)
+	res := make(map[string]string, l)
+	for i := 0; i < l; i++ {
+		param := p.Parameters[i]
+		val, err := s.Resolve(param.Source.Key, param.Source.Value)
+		if err != nil {
+			return nil, fmt.Errorf("parameter %q: %v", p.Parameters[i].Name, err)
+		}
+		param.Value = val
+		res[p.Parameters[i].Name] = param.Value
+	}
+	return res, nil
+}
+
+// ParameterStrategy represents a strategy to resolve a value source
+// for a parameter
+type ParameterStrategy struct {
+	// Name is the name of the parameter.
+	// Name is used to match a parameter strategy to a bundle's parameter.
+	Name string `json:"name" yaml:"name"`
+	// Source is the location of the parameter.
+	// During resolution, the source will be loaded, and the result temporarily placed
+	// into Value.
+	Source credentials.Source `json:"source,omitempty" yaml:"source,omitempty"`
+	// Value holds the parameter value.
+	// When a parameter is loaded, it is loaded into this field. In all
+	// other cases, it is empty. This field is omitted during serialization.
+	Value string `json:"-" yaml:"-"`
+}

--- a/pkg/parameters/parameterset.go
+++ b/pkg/parameters/parameterset.go
@@ -1,10 +1,8 @@
 package parameters
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/cnabio/cnab-go/secrets"
 	"github.com/cnabio/cnab-go/valuesource"
 )
 
@@ -18,47 +16,5 @@ type ParameterSet struct {
 	// Modified timestamp of the parameter set.
 	Modified time.Time `json:"modified" yaml:"modified"`
 	// Parameters is a list of parameter specs.
-	Parameters []ParameterStrategy `json:"parameters" yaml:"parameters"`
-}
-
-// TODO: is this needed?  Clone of cnab-go's credentials.ResolveCredentials(...)
-//
-// Resolve looks up the parameters as described in Source, then copies
-// the resulting value into the Value field of each parameter strategy.
-//
-// The typical workflow for working with a parameter set is:
-//
-//	- Load the set
-//	- Validate the parameters against a spec
-//	- Resolve the parameters
-//	- Expand them into bundle values
-func (p *ParameterSet) Resolve(s secrets.Store) (valuesource.Set, error) {
-	l := len(p.Parameters)
-	res := make(map[string]string, l)
-	for i := 0; i < l; i++ {
-		param := p.Parameters[i]
-		val, err := s.Resolve(param.Source.Key, param.Source.Value)
-		if err != nil {
-			return nil, fmt.Errorf("parameter %q: %v", p.Parameters[i].Name, err)
-		}
-		param.Value = val
-		res[p.Parameters[i].Name] = param.Value
-	}
-	return res, nil
-}
-
-// ParameterStrategy represents a strategy to resolve a value source
-// for a parameter
-type ParameterStrategy struct {
-	// Name is the name of the parameter.
-	// Name is used to match a parameter strategy to a bundle's parameter.
-	Name string `json:"name" yaml:"name"`
-	// Source is the location of the parameter.
-	// During resolution, the source will be loaded, and the result temporarily placed
-	// into Value.
-	Source valuesource.Source `json:"source,omitempty" yaml:"source,omitempty"`
-	// Value holds the parameter value.
-	// When a parameter is loaded, it is loaded into this field. In all
-	// other cases, it is empty. This field is omitted during serialization.
-	Value string `json:"-" yaml:"-"`
+	Parameters []valuesource.Strategy `json:"parameters" yaml:"parameters"`
 }

--- a/pkg/parameters/parameterset.go
+++ b/pkg/parameters/parameterset.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cnabio/cnab-go/credentials"
 	"github.com/cnabio/cnab-go/secrets"
+	"github.com/cnabio/cnab-go/valuesource"
 )
 
 // ParameterSet represents a collection of parameters and their
@@ -32,7 +32,7 @@ type ParameterSet struct {
 //	- Validate the parameters against a spec
 //	- Resolve the parameters
 //	- Expand them into bundle values
-func (p *ParameterSet) Resolve(s secrets.Store) (credentials.Set, error) {
+func (p *ParameterSet) Resolve(s secrets.Store) (valuesource.Set, error) {
 	l := len(p.Parameters)
 	res := make(map[string]string, l)
 	for i := 0; i < l; i++ {
@@ -56,7 +56,7 @@ type ParameterStrategy struct {
 	// Source is the location of the parameter.
 	// During resolution, the source will be loaded, and the result temporarily placed
 	// into Value.
-	Source credentials.Source `json:"source,omitempty" yaml:"source,omitempty"`
+	Source valuesource.Source `json:"source,omitempty" yaml:"source,omitempty"`
 	// Value holds the parameter value.
 	// When a parameter is loaded, it is loaded into this field. In all
 	// other cases, it is empty. This field is omitted during serialization.

--- a/pkg/parameters/parameterstore.go
+++ b/pkg/parameters/parameterstore.go
@@ -9,10 +9,6 @@ import (
 	"github.com/cnabio/cnab-go/utils/crud"
 )
 
-// TODO: very much a clone of cnab-go/credentials/credstore.go
-// Ideas on how to generalize for re-use?
-// Perhaps update methods to all take an additional ItemType param?
-
 // ItemType is the location in the backing store where parameters are persisted.
 const ItemType = "parameters"
 

--- a/pkg/parameters/parameterstore.go
+++ b/pkg/parameters/parameterstore.go
@@ -11,8 +11,7 @@ import (
 
 // TODO: very much a clone of cnab-go/credentials/credstore.go
 // Ideas on how to generalize for re-use?
-//
-// TODO: unit tests; depending on ^^
+// Perhaps update methods to all take an additional ItemType param?
 
 // ItemType is the location in the backing store where parameters are persisted.
 const ItemType = "parameters"

--- a/pkg/parameters/parameterstore.go
+++ b/pkg/parameters/parameterstore.go
@@ -32,7 +32,7 @@ func NewParameterStore(store crud.Store) Store {
 	}
 }
 
-// List lists the names of the stored parameter sets.
+// List the names of the stored parameter sets.
 func (s Store) List() ([]string, error) {
 	return s.backingStore.List(ItemType)
 }

--- a/pkg/parameters/parameterstore.go
+++ b/pkg/parameters/parameterstore.go
@@ -1,0 +1,87 @@
+package parameters
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cnabio/cnab-go/utils/crud"
+)
+
+// TODO: very much a clone of cnab-go/credentials/credstore.go
+// Ideas on how to generalize for re-use?
+//
+// TODO: unit tests; depending on ^^
+
+// ItemType is the location in the backing store where parameters are persisted.
+const ItemType = "parameters"
+
+// ErrNotFound represents a parameter set not found in storage
+var ErrNotFound = errors.New("Parameter set does not exist")
+
+// Store is a persistent store for parameter sets.
+type Store struct {
+	backingStore *crud.BackingStore
+}
+
+// NewParameterStore creates a persistent store for parameter sets using the specified
+// backing key-blob store.
+func NewParameterStore(store crud.Store) Store {
+	return Store{
+		backingStore: crud.NewBackingStore(store),
+	}
+}
+
+// List lists the names of the stored parameter sets.
+func (s Store) List() ([]string, error) {
+	return s.backingStore.List(ItemType)
+}
+
+// Save a parameter set. Any previous version of the parameter set is overwritten.
+func (s Store) Save(param ParameterSet) error {
+	bytes, err := json.MarshalIndent(param, "", "  ")
+	if err != nil {
+		return err
+	}
+	return s.backingStore.Save(ItemType, param.Name, bytes)
+}
+
+// Read loads the parameter set with the given name from the store.
+func (s Store) Read(name string) (ParameterSet, error) {
+	bytes, err := s.backingStore.Read(ItemType, name)
+	if err != nil {
+		if strings.Contains(err.Error(), crud.ErrRecordDoesNotExist.Error()) {
+			return ParameterSet{}, ErrNotFound
+		}
+		return ParameterSet{}, err
+	}
+	paramset := ParameterSet{}
+	err = json.Unmarshal(bytes, &paramset)
+	return paramset, err
+}
+
+// ReadAll retrieves all the parameter sets.
+func (s Store) ReadAll() ([]ParameterSet, error) {
+	results, err := s.backingStore.ReadAll(ItemType)
+	if err != nil {
+		return nil, err
+	}
+
+	params := make([]ParameterSet, len(results))
+	for i, bytes := range results {
+		var cs ParameterSet
+		err = json.Unmarshal(bytes, &cs)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshaling parameter set: %v", err)
+		}
+		params[i] = cs
+	}
+
+	return params, nil
+}
+
+// Delete deletes a parameter set from the store.
+func (s Store) Delete(name string) error {
+	return s.backingStore.Delete(ItemType, name)
+}

--- a/pkg/parameters/parameterstore_test.go
+++ b/pkg/parameters/parameterstore_test.go
@@ -1,0 +1,55 @@
+package parameters
+
+import (
+	"testing"
+
+	inmemorystorage "get.porter.sh/porter/pkg/storage/in-memory"
+	"github.com/cnabio/cnab-go/valuesource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewParameterStore(t *testing.T) {
+	backingParams := inmemorystorage.NewStore()
+	paramStore := NewParameterStore(backingParams)
+
+	params, err := paramStore.List()
+	require.NoError(t, err)
+	require.Equal(t, []string{}, params, "List should return no entries")
+
+	myParamSet := ParameterSet{
+		Name: "myparams",
+		Parameters: []valuesource.Strategy{
+			{
+				Name: "myparam",
+				Source: valuesource.Source{
+					Key: "value",
+					Value: "myparamvalue",
+				},
+			},
+		},
+	}
+	err = paramStore.Save(myParamSet)
+	require.NoError(t, err, "Save should successfully save")
+
+	params, err = paramStore.List()
+	require.NoError(t, err)
+	require.Equal(t, []string{"myparams"}, params, "List should return the saved entry")
+
+	pset, err := paramStore.Read("myparams")
+	require.NoError(t, err)
+	require.Equal(t, myParamSet, pset, "Read should return the saved parameter set")
+
+	psets, err := paramStore.ReadAll()
+	require.NoError(t, err)
+	require.Equal(t, []ParameterSet{myParamSet}, psets, "ReadAll should return all parameter sets")
+
+	err = paramStore.Delete("myparams")
+	require.NoError(t, err, "Delete should successfully delete the parameter set")
+
+	params, err = paramStore.List()
+	require.NoError(t, err)
+	require.Equal(t, []string{}, params, "List should return no entries")
+
+	pset, err = paramStore.Read("myparams")
+	require.EqualError(t, err, "Parameter set does not exist", "Read should return an error")
+}

--- a/pkg/parameters/testdata/paramset.json
+++ b/pkg/parameters/testdata/paramset.json
@@ -1,0 +1,37 @@
+{
+  "name": "mybun",
+  "created": "1983-04-18T01:02:03.000000004Z",
+  "modified": "1983-04-18T01:02:03.000000004Z",
+  "parameters": [
+    {
+      "name": "param_env",
+      "source": {
+        "env": "PARAM_ENV"
+      }
+    },
+    {
+      "name": "param_value",
+      "source": {
+        "value": "param_value"
+      }
+    },
+    {
+      "name": "param_command",
+      "source": {
+        "command": "echo hello world"
+      }
+    },
+    {
+      "name": "param_path",
+      "source": {
+        "path": "/path/to/param"
+      }
+    },
+    {
+      "name": "param_secret",
+      "source": {
+        "secret": "param_secret"
+      }
+    }
+  ]
+}

--- a/pkg/parameters/testdata/paramset_bad.json
+++ b/pkg/parameters/testdata/paramset_bad.json
@@ -1,0 +1,1 @@
+myparam=foo

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -81,9 +81,6 @@ type sharedOptions struct {
 	// parsedParamFiles is the parsed set of parameters from Params.
 	parsedParamFiles []map[string]string
 
-	// parsedParameterSets is the parsed set of parameters from ParameterSets.
-	parsedParameterSets []map[string]string
-
 	// combinedParameters is parsedParams merged on top of parsedParamSets.
 	combinedParameters map[string]string
 }

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -61,8 +61,12 @@ type sharedOptions struct {
 	// Params is the unparsed list of NAME=VALUE parameters set on the command line.
 	Params []string
 
+	// TODO: remove
 	// ParamFiles is a list of file paths containing lines of NAME=VALUE parameter definitions.
 	ParamFiles []string
+
+	// ParameterSets is a list of parameter sets containing parameter sources
+	ParameterSets []string
 
 	// CredentialIdentifiers is a list of credential names or paths to make available to the bundle.
 	CredentialIdentifiers []string
@@ -73,10 +77,14 @@ type sharedOptions struct {
 	// parsedParams is the parsed set of parameters from Params.
 	parsedParams map[string]string
 
+	// TODO: remove
 	// parsedParamFiles is the parsed set of parameters from Params.
 	parsedParamFiles []map[string]string
 
-	// combinedParameters is parsedParams merged on top of parsedParamFiles.
+	// parsedParameterSets is the parsed set of parameters from ParameterSets.
+	parsedParameterSets []map[string]string
+
+	// combinedParameters is parsedParams merged on top of parsedParamSets.
 	combinedParameters map[string]string
 }
 
@@ -233,6 +241,7 @@ func (o *sharedOptions) parseParams() error {
 	return nil
 }
 
+// TODO: remove
 // parseParamFiles parses the variable assignments in ParamFiles.
 func (o *sharedOptions) parseParamFiles(cxt *context.Context) error {
 	o.parsedParamFiles = make([]map[string]string, 0, len(o.ParamFiles))
@@ -247,6 +256,7 @@ func (o *sharedOptions) parseParamFiles(cxt *context.Context) error {
 	return nil
 }
 
+// TODO: remove
 func (o *sharedOptions) parseParamFile(path string, cxt *context.Context) error {
 	f, err := cxt.FileSystem.Open(path)
 	if err != nil {

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -14,6 +14,7 @@ import (
 	dtprinter "github.com/carolynvs/datetime-printer"
 	credentials "github.com/cnabio/cnab-go/credentials"
 	"github.com/cnabio/cnab-go/utils/crud"
+	"github.com/cnabio/cnab-go/valuesource"
 	tablewriter "github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 )
@@ -255,10 +256,10 @@ func (p *Porter) ShowCredential(opts CredentialShowOptions) error {
 	}
 }
 
-// GetCredentialSourceValueAndType takes a given credentials.Source struct and
+// GetCredentialSourceValueAndType takes a given valuesource.Source struct and
 // returns the source value itself as well as source type, e.g., 'path', 'env', etc.,
 // both in their string forms
-func GetCredentialSourceValueAndType(cs credentials.Source) (value string, key string) {
+func GetCredentialSourceValueAndType(cs valuesource.Source) (value string, key string) {
 	return cs.Value, cs.Key
 }
 

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cnabio/cnab-go/credentials"
 	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/cnabio/cnab-go/utils/crud"
+	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -386,7 +387,7 @@ func TestShowCredential_PreserveCase(t *testing.T) {
 
 type SourceTest struct {
 	name      string
-	source    credentials.Source
+	source    valuesource.Source
 	wantValue string
 	wantType  string
 }
@@ -395,7 +396,7 @@ func TestGetCredentialSourceValueAndType(t *testing.T) {
 	testcases := []SourceTest{
 		{
 			name: "Source: EnvVar",
-			source: credentials.Source{
+			source: valuesource.Source{
 				Key:   host.SourceEnv,
 				Value: "ENVY",
 			},
@@ -404,7 +405,7 @@ func TestGetCredentialSourceValueAndType(t *testing.T) {
 		},
 		{
 			name: "Source: Path",
-			source: credentials.Source{
+			source: valuesource.Source{
 				Key:   host.SourcePath,
 				Value: "/pathy/patheson",
 			},
@@ -413,7 +414,7 @@ func TestGetCredentialSourceValueAndType(t *testing.T) {
 		},
 		{
 			name: "Source: Command",
-			source: credentials.Source{
+			source: valuesource.Source{
 				Key:   host.SourceCommand,
 				Value: "sed s/true/false/g",
 			},
@@ -422,7 +423,7 @@ func TestGetCredentialSourceValueAndType(t *testing.T) {
 		},
 		{
 			name: "Source: Value",
-			source: credentials.Source{
+			source: valuesource.Source{
 				Key:   host.SourceValue,
 				Value: "abc123",
 			},

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -15,6 +15,7 @@ import (
 	"get.porter.sh/porter/pkg/credentials"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/mixin"
+	"get.porter.sh/porter/pkg/parameters"
 	"get.porter.sh/porter/pkg/plugins"
 	"get.porter.sh/porter/pkg/secrets"
 	cnabcreds "github.com/cnabio/cnab-go/credentials"
@@ -44,6 +45,7 @@ type TestPorter struct {
 func NewTestPorter(t *testing.T) *TestPorter {
 	tc := config.NewTestConfig(t)
 	testCredentials := credentials.NewTestCredentialProvider(t, tc)
+	testParameters := parameters.NewTestParameterProvider(t, tc)
 	testCache := cache.NewTestCache(cache.New(tc.Config))
 	testClaims := claims.NewTestClaimProvider()
 
@@ -55,7 +57,7 @@ func NewTestPorter(t *testing.T) *TestPorter {
 	p.Builder = NewTestBuildProvider()
 	p.Claims = testClaims
 	p.Credentials = testCredentials
-	p.CNAB = cnabprovider.NewTestRuntimeWithConfig(tc, testClaims, testCredentials)
+	p.CNAB = cnabprovider.NewTestRuntimeWithConfig(tc, testClaims, testCredentials, testParameters)
 
 	return &TestPorter{
 		Porter:          p,

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -8,6 +8,7 @@ import (
 	"get.porter.sh/porter/pkg/secrets"
 
 	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -212,10 +213,10 @@ func TestPorter_InstallBundle_WithDepsFromTag(t *testing.T) {
 	// Make some fake credentials to give to the install operation, they won't be used because it's a dummy driver
 	cs := credentials.CredentialSet{
 		Name: "wordpress",
-		Credentials: []credentials.CredentialStrategy{
+		Credentials: []valuesource.Strategy{
 			{
 				Name: "kubeconfig",
-				Source: credentials.Source{
+				Source: valuesource.Source{
 					Key:   secrets.SourceSecret,
 					Value: "kubeconfig",
 				},

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -33,6 +33,7 @@ func (o *BundleLifecycleOpts) ToActionArgs(deperator *dependencyExecutioner) cna
 		Claim:                 o.Name,
 		BundlePath:            o.CNABFile,
 		Params:                make(map[string]string, len(o.combinedParameters)),
+		ParameterSets:         o.ParameterSets,
 		CredentialIdentifiers: make([]string, len(o.CredentialIdentifiers)),
 		Driver:                o.Driver,
 		RelocationMapping:     o.RelocationMapping,

--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -12,6 +12,7 @@ import (
 	"get.porter.sh/porter/pkg/credentials"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/mixin"
+	"get.porter.sh/porter/pkg/parameters"
 	"get.porter.sh/porter/pkg/plugins"
 	"get.porter.sh/porter/pkg/storage/pluginstore"
 	"get.porter.sh/porter/pkg/templates"
@@ -23,6 +24,7 @@ type Porter struct {
 
 	Cache       cache.BundleCache
 	Credentials credentials.CredentialProvider
+	Parameters  parameters.ParameterProvider
 	Claims      claims.ClaimProvider
 	Registry    cnabtooci.RegistryProvider
 	Templates   *templates.Templates
@@ -44,17 +46,19 @@ func NewWithConfig(c *config.Config) *Porter {
 	storagePlugin := pluginstore.NewStore(c)
 	claimStorage := claims.NewClaimStorage(c, storagePlugin)
 	credStorage := credentials.NewCredentialStorage(c, storagePlugin)
+	paramStorage := parameters.NewParameterStorage(c, storagePlugin)
 	return &Porter{
 		Config:      c,
 		Cache:       cache,
 		Claims:      claimStorage,
 		Credentials: credStorage,
+		Parameters:  paramStorage,
 		Registry:    cnabtooci.NewRegistry(c.Context),
 		Templates:   templates.NewTemplates(),
 		Builder:     buildprovider.NewDockerBuilder(c.Context),
 		Mixins:      mixin.NewPackageManager(c),
 		Plugins:     plugins.NewPackageManager(c),
-		CNAB:        cnabprovider.NewRuntime(c, claimStorage, credStorage),
+		CNAB:        cnabprovider.NewRuntime(c, claimStorage, credStorage, paramStorage),
 	}
 }
 


### PR DESCRIPTION
# What does this change
* Introduces a Parameter Set as a way to describe sources/strategies for resolving parameter values to be passed in during runtime (a direct correlate to the current Credential Set, but with slightly different mechanics)

* Adds logic to consume/unmarshal the provided parameter set(s).  (Note that logic to interactively generate Parameter Sets is intended to be a separate PR as part of the broader [epic](https://github.com/deislabs/porter/issues/1053))

TODO
 - [x] Documentation additions/updates
 - [x] Incorporate fix in https://github.com/deislabs/porter/pull/1071 for Parameter Sets introduced here.

# What issue does it fix
* Contributes towards https://github.com/deislabs/porter/issues/1053

# Notes for the reviewer
There are a couple areas of attention still designated with TODOs
  * There may be further refactoring opportunities around re-use of logic currently duplicated between cred and param store.  Some refactoring has been done in a `cnabio/cnab-go` branch which this branch uses: https://github.com/cnabio/cnab-go/pull/219
  * There are some markers where we want to remove the older param file logic (to be replaced by a parameter set file)... I was intending to do this in a follow-up PR, but could also do it in a separate commit in this PR if preferable.

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml) - N/A
