### PR TITLE
Fix specifying credentials by path

### DIFF
--- a/pkg/cnab/provider/credentials.go
+++ b/pkg/cnab/provider/credentials.go
@@ -1,9 +1,11 @@
 package cnabprovider
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/credentials"
 )
@@ -18,7 +20,13 @@ func (d *Runtime) loadCredentials(b *bundle.Bundle, creds []string) (credentials
 	// in which they were supplied on the CLI.
 	resolvedCredentials := credentials.Set{}
 	for _, name := range creds {
-		cset, err := d.credentials.Read(name)
+		var cset credentials.CredentialSet
+		var err error
+		if d.isPathy(name) {
+			cset, err = d.loadCredentialFromFile(name)
+		} else {
+			cset, err = d.credentials.Read(name)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -40,4 +48,15 @@ func (d *Runtime) isPathy(name string) bool {
 	// TODO: export back outta Compton
 
 	return strings.Contains(name, string(filepath.Separator))
+}
+
+func (d *Runtime) loadCredentialFromFile(path string) (credentials.CredentialSet, error) {
+	data, err := d.FileSystem.ReadFile(path)
+	if err != nil {
+		return credentials.CredentialSet{}, errors.Wrapf(err, "could not read file %s", path)
+	}
+
+	var cs credentials.CredentialSet
+	err = json.Unmarshal(data, &cs)
+	return cs, errors.Wrapf(err, "error loading credential set in %s", path)
 }

--- a/pkg/cnab/provider/credentials_test.go
+++ b/pkg/cnab/provider/credentials_test.go
@@ -1,0 +1,62 @@
+package cnabprovider
+
+import (
+	"testing"
+	"time"
+
+	"get.porter.sh/porter/pkg/secrets"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntime_loadCredentials(t *testing.T) {
+	r := NewTestRuntime(t)
+
+	r.TestCredentials.TestSecrets.AddSecret("password", "mypassword")
+	r.TestCredentials.TestSecrets.AddSecret("db-password", "topsecret")
+
+	r.TestConfig.TestContext.AddTestFile("testdata/db-creds.json", "/db-creds.json")
+
+	cs1 := credentials.CredentialSet{
+		Name:     "mycreds",
+		Created:  time.Now(),
+		Modified: time.Now(),
+		Credentials: []credentials.CredentialStrategy{
+			{
+				Name: "password",
+				Source: credentials.Source{
+					Key:   secrets.SourceSecret,
+					Value: "password",
+				},
+			},
+		},
+	}
+	err := r.credentials.Save(cs1)
+	require.NoError(t, err, "Save credential set failed")
+
+	b := bundle.Bundle{
+		Credentials: map[string]bundle.Credential{
+			"password": {
+				Location: bundle.Location{
+					EnvironmentVariable: "PASSWORD",
+				},
+			},
+			"db-password": {
+				Location: bundle.Location{
+					EnvironmentVariable: "DB_PASSWORD",
+				},
+			},
+		},
+	}
+
+	gotValues, err := r.loadCredentials(&b, []string{"mycreds", "/db-creds.json"})
+	require.NoError(t, err, "loadCredentials failed")
+
+	wantValues := credentials.Set{
+		"password":    "mypassword",
+		"db-password": "topsecret",
+	}
+	assert.Equal(t, wantValues, gotValues, "resolved unexpected credential values")
+}

--- a/pkg/cnab/provider/helpers.go
+++ b/pkg/cnab/provider/helpers.go
@@ -3,10 +3,10 @@ package cnabprovider
 import (
 	"testing"
 
-	"github.com/cnabio/cnab-go/bundle"
 	"get.porter.sh/porter/pkg/claims"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/credentials"
+	"github.com/cnabio/cnab-go/bundle"
 )
 
 const debugDriver = "debug"
@@ -15,7 +15,8 @@ var _ CNABProvider = &TestRuntime{}
 
 type TestRuntime struct {
 	*Runtime
-	TestConfig *config.TestConfig
+	TestCredentials credentials.TestCredentialProvider
+	TestConfig      *config.TestConfig
 }
 
 func NewTestRuntime(t *testing.T) *TestRuntime {
@@ -27,8 +28,9 @@ func NewTestRuntime(t *testing.T) *TestRuntime {
 
 func NewTestRuntimeWithConfig(tc *config.TestConfig, testClaims claims.ClaimProvider, testCredentials credentials.TestCredentialProvider) *TestRuntime {
 	return &TestRuntime{
-		TestConfig: tc,
-		Runtime:    NewRuntime(tc.Config, testClaims, testCredentials),
+		TestConfig:      tc,
+		TestCredentials: testCredentials,
+		Runtime:         NewRuntime(tc.Config, testClaims, testCredentials),
 	}
 }
 

--- a/pkg/cnab/provider/testdata/db-creds.json
+++ b/pkg/cnab/provider/testdata/db-creds.json
@@ -1,0 +1,13 @@
+{
+  "name": "db-creds",
+  "created": "0001-01-01T00:00:00Z",
+  "modified": "0001-01-01T00:00:00Z",
+  "credentials": [
+    {
+      "name": "db-password",
+      "source": {
+        "secret": "db-password"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# What does this change
When credentials were refactored to support secret stores, there was a regression around loading credentials by path. This allowed people to supply a one-off credential set when running a bundle and has now been corrected.

e.g. `porter install -c ./mycreds.json`

# What issue does it fix
Closes #988 

# Notes for the reviewer
🐶 

# Checklist
- [x] Unit Tests
- [x] Documentation - not impacted
- [x] Schema (porter.yaml) - not impacted
