### PR TITLE
Fix release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test: clean-last-testrun test-unit test-integration test-cli
 test-unit:
 	$(GO) test ./...
 
-test-integration: 
+test-integration: build
 	$(GO) build -o $(PORTER_HOME)/testplugin ./cmd/testplugin
 	PROJECT_ROOT=$(shell pwd) $(GO) test -timeout 20m -tags=integration ./...
 


### PR DESCRIPTION
# What does this change

Build before running integration tests.  We accidentally lost the build prerequisite in #1028 so this adds it back.

# What issue does it fix
The broken master release.

# Notes for the reviewer
https://github.com/deislabs/porter/pull/1028/files#diff-b67911656ef5d18c4ae36cb6741b7965L82

# Checklist
- [x] Unit Tests - not impacted
- [x] Documentation - not impacted
- [x] Schema (porter.yaml) - not impacted
