### PR TITLE
docs(*): add parameters links to config; fix typo

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -57,22 +57,28 @@ defaultContentLanguage = "en"
     weight = 124
     parent = "cli"
   [[menu.main]]
+    name = "Parameters"
+    url = "/cli/porter_parameters"
+    identifier = "cli-parameters"
+    weight = 125
+    parent = "cli"
+  [[menu.main]]
     name = "Instances"
     url = "/cli/porter_instances"
     identifier = "cli-instances"
-    weight = 125
+    weight = 126
     parent = "cli"
   [[menu.main]]
     name = "Mixins"
     url = "/cli/porter_mixins"
     identifier = "cli-mixins"
-    weight = 126
+    weight = 127
     parent = "cli"
   [[menu.main]]
     name = "Plugins"
     url = "/cli/porter_plugins"
     identifier = "cli-plugins"
-    weight = 127
+    weight = 128
     parent = "cli"
 
 [[menu.main]]
@@ -235,6 +241,12 @@ defaultContentLanguage = "en"
     url = "/credentials/"
     identifier = "credentials"
     weight = 405
+    parent = "porter-architecture"
+  [[menu.main]]
+    name = "Parameters"
+    url = "/parameters/"
+    identifier = "parameters"
+    weight = 406
     parent = "porter-architecture"
 
 [[menu.main]]

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -105,7 +105,7 @@ install:
 
 NOTE: These references must be quoted, as in the examples above.
 
-See [Parameters][parmeters] to learn how parameters are passed in to Porter prior to bundle execution.
+See [Parameters][parameters] to learn how parameters are passed in to Porter prior to bundle execution.
 
 
 ## Credentials


### PR DESCRIPTION
# What does this change
 * Adds sidebar links to relevant Parameters documentation
 * Fixes link typo

Docs preview: https://deploy-preview-1093--porter.netlify.app/

# What issue does it fix
n/a
# Notes for the reviewer
n/a
# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
