### PR TITLE
remove dry-run flags

### DIFF
--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -79,8 +79,6 @@ will then provide it to the bundle in the correct location. `,
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
-	f.BoolVar(&opts.DryRun, "dry-run", false,
-		"Generate credential but do not save it.")
 	f.StringVar(&opts.Tag, "tag", "",
 		"Use a bundle in an OCI registry specified by the given tag.")
 	f.BoolVar(&opts.Force, "force", false,

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -79,8 +79,6 @@ will then provide it to the bundle in the correct location. `,
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
-	f.BoolVar(&opts.DryRun, "dry-run", false,
-		"Generate parameter set but do not save it.")
 	f.StringVar(&opts.Tag, "tag", "",
 		"Use a bundle in an OCI registry specified by the given tag.")
 	f.BoolVar(&opts.Force, "force", false,

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -45,7 +45,6 @@ porter credentials generate [NAME] [flags]
 
 ```
       --cnab-file string   Path to the CNAB bundle.json file.
-      --dry-run            Generate credential but do not save it.
   -f, --file string        Path to the porter manifest file. Defaults to the bundle in the current directory.
       --force              Force a fresh pull of the bundle
   -h, --help               help for generate

--- a/docs/content/cli/parameters_generate.md
+++ b/docs/content/cli/parameters_generate.md
@@ -45,7 +45,6 @@ porter parameters generate [NAME] [flags]
 
 ```
       --cnab-file string   Path to the CNAB bundle.json file.
-      --dry-run            Generate parameter set but do not save it.
   -f, --file string        Path to the porter manifest file. Defaults to the bundle in the current directory.
       --force              Force a fresh pull of the bundle
   -h, --help               help for generate


### PR DESCRIPTION
# What does this change

removes dry-run flag from `porter credentials generate` and `porter parameters generate`
# What issue does it fix
Closes #1086 

[1]: /CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer

Very tiny fix but working my way throughout the project and can contribute saner PRs in the future :)

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
