### PR TITLE
Remove dry-run backend implementation

### DIFF
--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -1,7 +1,6 @@
 package porter
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -64,7 +63,6 @@ func (p *Porter) ListCredentials(opts ListOptions) error {
 
 type CredentialOptions struct {
 	BundleLifecycleOpts
-	DryRun bool
 	Silent bool
 }
 
@@ -133,14 +131,6 @@ func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
 	cs.Created = time.Now()
 	cs.Modified = cs.Created
 
-	if opts.DryRun {
-		data, err := json.Marshal(cs)
-		if err != nil {
-			return errors.Wrap(err, "unable to generate credentials JSON")
-		}
-		fmt.Fprintf(p.Out, "%v", string(data))
-		return nil
-	}
 	err = p.Credentials.Save(*cs)
 	return errors.Wrapf(err, "unable to save credentials")
 }

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -1,7 +1,6 @@
 package porter
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -67,7 +66,6 @@ func (p *Porter) ListParameters(opts ListOptions) error {
 // ParameterOptions represent generic/base options for a Porter parameters command
 type ParameterOptions struct {
 	BundleLifecycleOpts
-	DryRun bool
 	Silent bool
 }
 
@@ -136,14 +134,6 @@ func (p *Porter) GenerateParameters(opts ParameterOptions) error {
 	pset.Created = time.Now()
 	pset.Modified = pset.Created
 
-	if opts.DryRun {
-		data, err := json.Marshal(pset)
-		if err != nil {
-			return errors.Wrap(err, "unable to generate parameters JSON")
-		}
-		fmt.Fprintf(p.Out, "%v", string(data))
-		return nil
-	}
 	err = p.Parameters.Save(*pset)
 	return errors.Wrapf(err, "unable to save parameter set")
 }


### PR DESCRIPTION
# What does this change
This removes the dry-run implementation that was backing the --dry-run flags for parameters and credentials. Now that the flag is gone, we don't need it anymore.

# What issue does it fix
Follow-up to #1094 

# Notes for the reviewer
Delete ALL THE CODE 🔥 

# Checklist
- [x] Unit Tests - not impacted
- [x] Documentation - not impacted
- [x] Schema (porter.yaml) - not impacted
