### PR TITLE
Remove internal params in `explain` output

### DIFF
--- a/docs/content/archive-bundles.md
+++ b/docs/content/archive-bundles.md
@@ -92,7 +92,6 @@ database_name   Name of database to create                                      
 helm_release    Helm release name                                               string    spring-music-helm   false      All Actions
 namespace       Namespace to install Spring Music app                           string    default             false      All Actions
 node_count      Number of database nodes                                        integer   1                   false      All Actions
-porter-debug    Print debug information from Porter when executing the bundle   boolean   false               false      All Actions
 region          Region to create Database and DO Space                          string    nyc3                false      All Actions
 space_name      Name for DO Space                                               string    jrrportertest       false      All Actions
 

--- a/docs/content/examine-bundles.md
+++ b/docs/content/examine-bundles.md
@@ -26,7 +26,6 @@ database_name   Name of database to create                                      
 helm_release    Helm release name                                               string    spring-music-helm   false      All Actions
 namespace       Namespace to install Spring Music app                           string    default             false      All Actions
 node_count      Number of database nodes                                        integer   1                   false      All Actions
-porter-debug    Print debug information from Porter when executing the bundle   boolean   false               false      All Actions
 region          Region to create Database and DO Space                          string    nyc3                false      All Actions
 space_name      Name for DO Space                                               string    jrrportertest       false      All Actions
 

--- a/docs/content/plugin-tutorial.md
+++ b/docs/content/plugin-tutorial.md
@@ -229,9 +229,7 @@ Credentials:
 Name       Description                                                                         Required
 password   Password for installing the world. We recommend getting this from a secret store.   true
 
-Parameters:
-Name           Description                                                     Type      Default   Required   Applies To
-porter-debug   Print debug information from Porter when executing the bundle   boolean   false     false      All Actions
+No parameters defined
 
 No outputs defined
 

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -171,10 +171,10 @@ func (p *Porter) printBundleExplain(o ExplainOpts, pb *PrintableBundle) error {
 	}
 }
 
-func checkIsInternalParam(param string) bool {
+func checkIsInternalParam(inputParam string) bool {
 	isInternalParam := false
 	for _, internalParam := range porterInternalParams {
-		if param == internalParam {
+		if inputParam == internalParam {
 			isInternalParam = true
 			break
 		}

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -114,6 +114,8 @@ func (s SortPrintableAction) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
+var porterInternalParams = []string{"porter-debug"}
+
 func (o *ExplainOpts) Validate(args []string, cxt *context.Context) error {
 	err := o.sharedOptions.Validate(args, cxt)
 	if err != nil {
@@ -169,6 +171,17 @@ func (p *Porter) printBundleExplain(o ExplainOpts, pb *PrintableBundle) error {
 	}
 }
 
+func checkIsInternalParam(param string) bool {
+	isInternalParam := false
+	for _, internalParam := range porterInternalParams {
+		if param == internalParam {
+			isInternalParam = true
+			break
+		}
+	}
+	return isInternalParam
+}
+
 func generatePrintable(bun *bundle.Bundle) (*PrintableBundle, error) {
 	if bun == nil {
 		return nil, fmt.Errorf("expected a bundle")
@@ -203,6 +216,9 @@ func generatePrintable(bun *bundle.Bundle) (*PrintableBundle, error) {
 
 	params := []PrintableParameter{}
 	for p, v := range bun.Parameters {
+		if checkIsInternalParam(p) {
+			continue
+		}
 		def, ok := bun.Definitions[v.Definition]
 		if !ok {
 			return nil, fmt.Errorf("unable to find definition %s", v.Definition)

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -114,7 +114,8 @@ func (s SortPrintableAction) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-var porterInternalParams = []string{"porter-debug"}
+// Using empty structs instead of booleans cuz empty structs occupy zero memory
+var porterInternalParams = map[string]struct{}{"porter-debug": {}}
 
 func (o *ExplainOpts) Validate(args []string, cxt *context.Context) error {
 	err := o.sharedOptions.Validate(args, cxt)
@@ -171,15 +172,9 @@ func (p *Porter) printBundleExplain(o ExplainOpts, pb *PrintableBundle) error {
 	}
 }
 
-func checkIsInternalParam(inputParam string) bool {
-	isInternalParam := false
-	for _, internalParam := range porterInternalParams {
-		if inputParam == internalParam {
-			isInternalParam = true
-			break
-		}
-	}
-	return isInternalParam
+func isInternalParam(inputParam string) bool {
+	_, ok := porterInternalParams[inputParam]
+	return ok
 }
 
 func generatePrintable(bun *bundle.Bundle) (*PrintableBundle, error) {
@@ -216,7 +211,7 @@ func generatePrintable(bun *bundle.Bundle) (*PrintableBundle, error) {
 
 	params := []PrintableParameter{}
 	for p, v := range bun.Parameters {
-		if checkIsInternalParam(p) {
+		if isInternalParam(p) {
 			continue
 		}
 		def, ok := bun.Definitions[v.Definition]

--- a/pkg/porter/testdata/explain/expected-json-output.json
+++ b/pkg/porter/testdata/explain/expected-json-output.json
@@ -4,14 +4,6 @@
   "version": "0.1.0",
   "parameters": [
     {
-      "name": "porter-debug",
-      "type": "boolean",
-      "default": false,
-      "applyTo": "All Actions",
-      "description": "Print debug information from Porter when executing the bundle",
-      "required": false
-    },
-    {
       "name": "region",
       "type": "string",
       "default": "mars",

--- a/pkg/porter/testdata/explain/expected-table-output.txt
+++ b/pkg/porter/testdata/explain/expected-table-output.txt
@@ -5,9 +5,8 @@ Version: 0.1.0
 No credentials defined
 
 Parameters:
-Name           Description                                                     Type      Default   Required   Applies To
-porter-debug   Print debug information from Porter when executing the bundle   boolean   false     false      All Actions
-region                                                                         string    mars      false      All Actions
+Name     Description   Type     Default   Required   Applies To
+region                 string   mars      false      All Actions
 
 No outputs defined
 

--- a/pkg/porter/testdata/explain/expected-yaml-output.yaml
+++ b/pkg/porter/testdata/explain/expected-yaml-output.yaml
@@ -2,12 +2,6 @@ name: HELLO
 description: An example Porter configuration
 version: 0.1.0
 parameters:
-- name: porter-debug
-  type: boolean
-  default: false
-  applyTo: All Actions
-  description: Print debug information from Porter when executing the bundle
-  required: false
 - name: region
   type: string
   default: mars


### PR DESCRIPTION
# What does this change
Don't show internal params in output of `explain`

# What issue does it fix
Closes #1091 


[1]: /CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer


# Checklist
- [x] Unit Tests
- [x] Documentation (N/A)
- [x] Schema (porter.yaml) (N/A)
