### PR TITLE
Add contributors file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,7 @@ _Put any questions or notes for the reviewer here._
 - [ ] Unit Tests
 - [ ] Documentation
 - [ ] Schema (porter.yaml)
+
+If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️
+
+[contributors]: /CONTRIBUTORS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,10 @@ Another great way to contribute is to create a mixin! You can start use the
 [Porter Skeletor][skeletor] repository as a template to start, along with the
 [Mixin Developer Guide][mixin-dev-guide].
 
+When you create your first pull request, add your name to the bottom of our 
+[Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️
+                                          
+[contributors]: /CONTRIBUTORS.md                                          
 [skeletor]: https://github.com/deislabs/porter-skeletor
 [mixin-dev-guide]: https://porter.sh/mixin-dev-guide/
 [good-first-issue]: https://porter.sh/board/good+first+issue

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,49 @@
+# Porter Contributors
+
+These are the wonderful people who have donated their time and effort to help
+make Porter better for all of us to use. We wouldn't be where we are today
+without your contributions. Thank you! 🙇‍♀️💖
+
+New contributors should add their name to the bottom of this list on their first
+pull request. If you are a contributor in other ways other than code, please
+either submit a pull request adding your name, or mention it to another maintainer
+and we will add you. **All** contributors belong here. 💯
+
+* [Carolyn Van Slyck](https://github.com/carolynvs) (Co-Creator of Porter)
+* [Jeremy Rickard](https://github.com/jeremyrickard) (Co-Creator of Porter)
+* [Vaughn Dice](https://github.com/vdice)
+* [Reddy Prasad](https://github.com/dev-drprasad)
+* [Thorsten Hans](https://github.com/ThorstenHans)
+* [Ronan Flynn-Curran](https://github.com/flynnduism)
+* [Allan Guwatudde](https://github.com/AGMETEOR)
+* [Josh Dolitsky](https://github.com/jdolitsky)
+* [Urvashi Reddy](https://github.com/youreddy)
+* [Jennifer Davis](https://github.com/iennae)
+* [Adam Reese](https://github.com/adamreese)
+* [Simon Davies](https://github.com/simongdavies)
+* [Phillip Ahereza](https://github.com/phillipahereza)
+* [Ivan Towlson](https://github.com/itowlson)
+* [Scott Coulton](https://github.com/scotty-c)
+* [Radu Matei](https://github.com/radu-matei)
+* [Raymond Kao](https://github.com/raykao)
+* [Ryan Moran](https://github.com/ryanmoran)
+* [Sean Harvey](https://github.com/halkyon)
+* [SpiLLeR](https://github.com/SpiLLeR)
+* [Weidong Feng](https://github.com/fenngwd)
+* [Y.Horie](https://github.com/u5surf)
+* [Zhaoyang Jiang](https://github.com/JiangZhaoYang)
+* [Gauri Madhok](https://github.com/gaurimadhok)
+* [Abhishek Gupta](https://github.com/abhirockzz)
+* [Anubhav Mishra](https://github.com/anubhavmishra)
+* [Aravind](https://github.com/scriptonist)
+* [Artem](https://github.com/SuddenGunter)
+* [Ben Wilkinson](https://github.com/brwilkinson)
+* [Brad](https://github.com/bradcypert)
+* [Clarence Bakirtzidis](https://github.com/clarenceb)
+* [Cory O'Daniel](https://github.com/coryodaniel)
+* [Hongchao Deng](https://github.com/hongchaodeng)
+* [John Reese](https://github.com/jpreese)
+* [Lanre Adelowo](https://github.com/adelowo)
+* [Matt Butcher](https://github.com/technosophos)
+* [Michael William Boldt](https://github.com/mboldt)
+* [Mohamed Chorfa](https://github.com/MChorfa)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ into becoming reviewers and maintainers.
 
 <p align="center">Start with our <a href="https://porter.sh/contribute/">New Contributors Guide</a>
 
+Porter wouldn't be possible without our [contributors][contributors], carrying
+the load and making it better every day! 🙇‍♀️
+
+[contributors]: /CONTRIBUTORS.md
+
 ---
 
 # Roadmap


### PR DESCRIPTION
# What does this change
This works around a bug/limitation in GitHub where you lose your contributor status to the project when you disassociate the email that you contributed with from your GitHub profile. Basically when you change jobs, it looks like you never contributed which is unacceptable to us.

So we will ensure contributors are acknowledged and thanked via a Contributors file and properly link it so people know to use it.

# What issue does it fix
INJUSTICE  ✊ 

# Notes for the reviewer
* let's make sure all my new links work

# Checklist
- [x] Unit Tests - NA
- [x] Documentation
- [x] Schema (porter.yaml) - NA
