### PR TITLE
Put release branches in a "directory" structure

### DIFF
--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -6,7 +6,9 @@
 trigger: none
 pr: 
   - main
-  - release-*
+  - release/*
+  - feature/*
+  - hotfix/*
 
 pool:
   vmImage: 'Ubuntu 16.04'

--- a/build/azure-pipelines.pr-manual.yml
+++ b/build/azure-pipelines.pr-manual.yml
@@ -6,7 +6,9 @@
 trigger: none
 pr: 
   - main
-  - release-*
+  - feature/*
+  - release/*
+  - hotfix/*
 
 pool:
   vmImage: 'Ubuntu 16.04'


### PR DESCRIPTION
# What does this change
We are using release/VERSION instead of release-VERSION, to take advantage of tooling that collapses releases.

Allow for triggering tests against other gitflow named branches as well.

# What issue does it fix
Being able to run tests against non-main branches.

# Notes for the reviewer
Reduce/Reuse/Recycle

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md