### PR TITLE
feat(pkg/cnab): docker driver support using host network

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -357,6 +357,7 @@ When the bundle is executed, this elevated privilege must be explicitly granted 
 **Configuration:**
 
   * `privileged: BOOLEAN` - OPTIONAL. Whether or not the `--privileged` flag should be set when the bundle's invocation image runs. Defaults to false.
+  * `useHostNetwork: BOOLEAN` - OPTIONAL. Whether or not host networking should be used when the bundle's invocation image runs. Defaults to false.
 
 Example:
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -38,9 +38,10 @@ combination of: `table`, `json` and `yaml`.
 `--allow-docker-host-access` controls whether or not the local Docker daemon
 should be made available to executing bundles. This flag is available for the
 following commands: [install], [upgrade], [invoke] and [uninstall]. When this
-value is set to true, bundles are executed in a privileged container with the
-docker socket mounted. This allows you to use Docker from within your bundle,
-such as `docker push`, `docker-compose`, or docker-in-docker.
+value is set to true, bundles will be executed with the docker socket mounted.
+This allows you to use Docker from within your bundle, such as `docker push`,
+`docker-compose`, or docker-in-docker. In addition, configuration may include
+running the container in privileged mode and/or with host networking enabled. 
 
 🚨 **There are security implications to enabling access! You should trust any
 bundles that you execute with this setting enabled as it gives them elevated 

--- a/pkg/cnab/extensions/docker.go
+++ b/pkg/cnab/extensions/docker.go
@@ -26,6 +26,9 @@ var DockerExtension = RequiredExtension{
 type Docker struct {
 	// Privileged represents whether or not the Docker container should run as --privileged
 	Privileged bool `json:"privileged,omitempty"`
+
+	// UseHostNetwork is set to true if the Docker container should use the host network
+	UseHostNetwork bool `json:"useHostNetwork,omitempty"`
 }
 
 // DockerExtensionReader is a Reader for the DockerExtension,

--- a/pkg/cnab/extensions/docker_test.go
+++ b/pkg/cnab/extensions/docker_test.go
@@ -11,14 +11,15 @@ func TestProcessedExtensions_GetDockerExtension(t *testing.T) {
 	t.Run("extension present", func(t *testing.T) {
 		ext := ProcessedExtensions{
 			DockerExtensionKey: Docker{
-				Privileged: true,
+				Privileged:     true,
+				UseHostNetwork: true,
 			},
 		}
 
 		dockerExt, dockerRequired, err := ext.GetDockerExtension()
 		require.NoError(t, err, "GetDockerExtension failed")
 		assert.True(t, dockerRequired, "docker should be a required extension")
-		assert.Equal(t, Docker{Privileged: true}, dockerExt, "docker config was not populated properly")
+		assert.Equal(t, Docker{Privileged: true, UseHostNetwork: true}, dockerExt, "docker config was not populated properly")
 	})
 
 	t.Run("extension missing", func(t *testing.T) {

--- a/pkg/cnab/provider/driver.go
+++ b/pkg/cnab/provider/driver.go
@@ -72,6 +72,10 @@ func (r *Runtime) dockerDriverWithHostAccess(config extensions.Docker) (driver.D
 	d := &docker.Driver{}
 	d.AddConfigurationOptions(func(cfg *container.Config, hostCfg *container.HostConfig) error {
 
+		if config.UseHostNetwork {
+			hostCfg.NetworkMode = "host"
+		}
+
 		// Equivalent of using: --privileged
 		// Required for DinD, or "Docker-in-Docker"
 		hostCfg.Privileged = config.Privileged


### PR DESCRIPTION
# What does this change
 * Adds option to use host network to docker extension configuration

# What issue does it fix
Related to https://github.com/deislabs/porter/issues/1079.  Lays the groundwork for using Porter with KinD k8s clusters.

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml) N/A

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md