### PR TITLE
Set PORTER_HOME in integration tests on plugins

### DIFF
--- a/pkg/plugins/pluggable/loader.go
+++ b/pkg/plugins/pluggable/loader.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -62,6 +63,16 @@ func (l *PluginLoader) Load(pluginType PluginTypeConfig) (interface{}, func(), e
 	}
 
 	pluginCommand.Stdin = configReader
+
+	// Explicitly set PORTER_HOME for the plugin
+	pluginCommand.Env = os.Environ()
+	if _, homeSet := os.LookupEnv(config.EnvHOME); !homeSet {
+		home, err := l.GetHomeDir()
+		if err != nil {
+			return nil, nil, err
+		}
+		pluginCommand.Env = append(pluginCommand.Env, home)
+	}
 
 	if l.Config.Debug {
 		fmt.Fprintf(l.Err, "Resolved %s plugin to %s\n", pluginType.Interface, l.SelectedPluginKey)

--- a/pkg/storage/filesystem/store.go
+++ b/pkg/storage/filesystem/store.go
@@ -34,6 +34,8 @@ func (s *Store) Connect() error {
 		return errors.Wrap(err, "could not determine home directory for filesystem storage")
 	}
 
+	s.logger.Debug("PORTER HOME: " + home)
+
 	s.Store = crud.NewFileSystemStore(home, "json")
 	return nil
 }


### PR DESCRIPTION
# What does this change
The integration tests don't use the PORTER_HOME env var, they programmatically set the porter home directory on the porter app. So when Porter creates a plugin, we need to explicitly set the home dir on the plugin when it's instantiated since it won't get PORTER_HOME automatically.

# What issue does it fix
Running integration tests and having it act against your real porter install. 😱 

# Notes for the reviewer
I have heartburn right now. 🚒 

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
