### PR TITLE
Fix TestDependencySolver_ResolveDependencies Flake

### DIFF
--- a/pkg/cnab/extensions/solver_test.go
+++ b/pkg/cnab/extensions/solver_test.go
@@ -29,15 +29,20 @@ func TestDependencySolver_ResolveDependencies(t *testing.T) {
 	s := DependencySolver{}
 	locks, err := s.ResolveDependencies(bun)
 	require.NoError(t, err)
-
 	require.Len(t, locks, 2)
 
-	mysql := locks[0]
-	assert.Equal(t, "mysql", mysql.Alias)
-	assert.Equal(t, "getporter/mysql:5.7", mysql.Tag)
+	var mysql DependencyLock
+	var nginx DependencyLock
+	for _, lock := range locks {
+		switch lock.Alias {
+		case "mysql":
+			mysql = lock
+		case "nginx":
+			nginx = lock
+		}
+	}
 
-	nginx := locks[1]
-	assert.Equal(t, "nginx", nginx.Alias)
+	assert.Equal(t, "getporter/mysql:5.7", mysql.Tag)
 	assert.Equal(t, "localhost:5000/nginx:1.19", nginx.Tag)
 }
 


### PR DESCRIPTION
# What does this change
We were relying on an array order that was generated from iterating upon a map. So it was unreliable in our tests. This ensures that we are looking at the correct elements when evaluating the test results.

# What issue does it fix
Closes #1119

# Notes for the reviewer
Oops, sorry I wrote this test. 🤦‍♀️ 

# Checklist
- [x] Unit Tests
- [x] Documentation - NA
- [x] Schema (porter.yaml) - NA
