### PR TITLE
Add --version flag to porter

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -22,6 +22,7 @@ func main() {
 
 func buildRootCommand() *cobra.Command {
 	p := porter.New()
+	var printVersion bool
 
 	cmd := &cobra.Command{
 		Use:   "porter",
@@ -43,10 +44,22 @@ func buildRootCommand() *cobra.Command {
 
 			return nil
 		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if printVersion {
+				versionCmd := buildVersionCommand(p)
+				err := versionCmd.PreRunE(cmd, args)
+				if err != nil {
+					return err
+				}
+				return versionCmd.RunE(cmd, args)
+			}
+			return nil
+		},
 		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().BoolVar(&p.Debug, "debug", false, "Enable debug logging")
+	cmd.Flags().BoolVarP(&printVersion, "version", "v", false, "Print the application version")
 
 	cmd.AddCommand(buildVersionCommand(p))
 	cmd.AddCommand(buildSchemaCommand(p))

--- a/cmd/porter/version_test.go
+++ b/cmd/porter/version_test.go
@@ -29,7 +29,7 @@ func TestVersion(t *testing.T) {
 		assert.Contains(t, out.String(), "porter v1.0.0 (abc123)")
 	})
 
-	t.Run("command", func(t *testing.T) {
+	t.Run("flag", func(t *testing.T) {
 		p := buildRootCommand()
 
 		// Capture output

--- a/cmd/porter/version_test.go
+++ b/cmd/porter/version_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"get.porter.sh/porter/pkg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion(t *testing.T) {
+	pkg.Version = "v1.0.0"
+	pkg.Commit = "abc123"
+
+	t.Run("command", func(t *testing.T) {
+		p := buildRootCommand()
+
+		// Capture output
+		var out bytes.Buffer
+		p.SetOut(&out)
+
+		// Set the command to run
+		os.Args = []string{"porter", "version"}
+
+		err := p.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, out.String(), "porter v1.0.0 (abc123)")
+	})
+
+	t.Run("command", func(t *testing.T) {
+		p := buildRootCommand()
+
+		// Capture output
+		var out bytes.Buffer
+		p.SetOut(&out)
+
+		// Set the command to run
+		os.Args = []string{"porter", "--version"}
+
+		err := p.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, out.String(), "porter v1.0.0 (abc123)")
+	})
+}

--- a/docs/content/cli/porter.md
+++ b/docs/content/cli/porter.md
@@ -11,6 +11,10 @@ I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
 
 I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
 
+```
+porter [flags]
+```
+
 ### Examples
 
 ```
@@ -23,8 +27,9 @@ I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
 ### Options
 
 ```
-      --debug   Enable debug logging
-  -h, --help    help for porter
+      --debug     Enable debug logging
+  -h, --help      help for porter
+  -v, --version   Print the application version
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
# What does this change
People never know if a CLI supports --version or a version command. So let's just support both so whatever they try will work. MAGIC!

# What issue does it fix
Fighting muscle memory

# Notes for the reviewer
Inspired by https://twitter.com/michellenoorali/status/1280517451550199808

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml) - NA
