### PR TITLE
feat(publish.go): update invocation image per bundle tag on publish

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -536,35 +536,26 @@ func UnmarshalManifest(manifestData []byte) (*Manifest, error) {
 	return manifest, nil
 }
 
+// SetDefaults updates the manifest with default values where not populated
 func (m *Manifest) SetDefaults() error {
-	bundleRef, err := reference.ParseNormalizedNamed(m.BundleTag)
+	return m.SetInvocationImageFromBundleTag(m.BundleTag, false)
+}
+
+// SetInvocationImageFromBundleTag sets the invocation image name on the manifest
+// per the provided bundle tag, setting/overriding the original image name if
+// empty or if overrideImage is true
+func (m *Manifest) SetInvocationImageFromBundleTag(bundleTag string, overrideImage bool) error {
+	bundleRef, err := reference.ParseNormalizedNamed(bundleTag)
 	if err != nil {
-		return errors.Wrapf(err, "invalid tag %s", m.BundleTag)
+		return errors.Wrapf(err, "invalid tag %s", bundleTag)
 	}
 
-	var dockerTag string
-	switch v := bundleRef.(type) {
-	case reference.Tagged:
-		dockerTag = v.Tag()
-	case reference.Named:
-		ver, err := semver.NewVersion(m.Version)
-		if err != nil {
-			return errors.Wrapf(err, "could not parse %q as a semantic version", m.Version)
-		}
-
-		// Tag is missing from the bundle, default it to use the version prefixed with v
-		// Example: bundle version is 1.0.0, so the bundle tag is v1.0.0
-		dockerTag = fmt.Sprintf("v%s", ver.String())
-		bundleRef, err = reference.WithTag(v, dockerTag)
-		if err != nil {
-			return errors.Wrapf(err, "could not set bundle tag to %q", dockerTag)
-		}
-		m.BundleTag = reference.FamiliarString(bundleRef)
-	case reference.Digested:
-		return errors.New("invalid bundle tag format %q, must be an OCI image tag")
+	dockerTag, err := m.getDockerTagFromBundleRef(bundleRef)
+	if err != nil {
+		return errors.Wrapf(err, "unable to derive docker tag from bundle tag %q", bundleTag)
 	}
 
-	if m.Image == "" {
+	if m.Image == "" || overrideImage {
 		imageName, err := reference.ParseNormalizedNamed(bundleRef.Name() + "-installer")
 		if err != err {
 			return errors.Wrapf(err, "could not set invocation image to %q", bundleRef.Name()+"-installer")
@@ -590,10 +581,39 @@ func (m *Manifest) SetDefaults() error {
 			}
 			m.Image = reference.FamiliarString(imageRef)
 		case reference.Digested:
-			return errors.New("invalid bundle tag format %q, must be an OCI image tag")
+			return errors.New("invalid bundle tag format, must be an OCI image tag")
 		}
 	}
+
 	return nil
+}
+
+// getDockerTagFromBundleRef returns the Docker tag portion of the bundle tag,
+// updating the manifest BundleTag value if it initially lacks a Docker tag
+func (m *Manifest) getDockerTagFromBundleRef(bundleRef reference.Named) (string, error) {
+	var dockerTag string
+	switch v := bundleRef.(type) {
+	case reference.Tagged:
+		dockerTag = v.Tag()
+	case reference.Named:
+		ver, err := semver.NewVersion(m.Version)
+		if err != nil {
+			return "", errors.Wrapf(err, "could not parse the bundle version %q as a semantic version", m.Version)
+		}
+		// Docker tag is missing from the provided bundle tag, so default it
+		// to use the manifest version prefixed with v
+		// Example: bundle version is 1.0.0, so the bundle tag is v1.0.0
+		dockerTag = fmt.Sprintf("v%s", ver.String())
+		bundleRef, err = reference.WithTag(v, dockerTag)
+		if err != nil {
+			return "", errors.Wrapf(err, "could not set bundle tag to %q", dockerTag)
+		}
+		m.BundleTag = reference.FamiliarString(bundleRef)
+	case reference.Digested:
+		return "", errors.New("invalid bundle tag format, must be an OCI image tag")
+	}
+
+	return dockerTag, nil
 }
 
 func readFromFile(cxt *context.Context, path string) ([]byte, error) {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -403,3 +403,29 @@ func TestLoadManifestWithRequiredExtensions(t *testing.T) {
 	assert.NotNil(t, m)
 	assert.Equal(t, expected, m.Required)
 }
+
+func TestSetInvocationImageFromBundleTag(t *testing.T) {
+	t.Run("with image override", func(t *testing.T) {
+		m := Manifest{
+			Version:   "1.2.3-beta.1",
+			BundleTag: "getporter/mybun:v1.2.3",
+			Image:     "portersh/mybun-some-installer:v1.2.3-beta.1",
+		}
+		err := m.SetInvocationImageFromBundleTag(m.BundleTag, true)
+		require.NoError(t, err)
+		assert.Equal(t, "getporter/mybun:v1.2.3", m.BundleTag)
+		assert.Equal(t, "getporter/mybun-installer:v1.2.3", m.Image)
+	})
+
+	t.Run("without image override", func(t *testing.T) {
+		m := Manifest{
+			Version:   "1.2.3-beta.1",
+			BundleTag: "getporter/mybun:v1.2.3",
+			Image:     "portersh/mybun-some-installer:v1.2.3-beta.1",
+		}
+		err := m.SetInvocationImageFromBundleTag(m.BundleTag, false)
+		require.NoError(t, err)
+		assert.Equal(t, "getporter/mybun:v1.2.3", m.BundleTag)
+		assert.Equal(t, "portersh/mybun-some-installer:v1.2.3-beta.1", m.Image)
+	})
+}

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -82,7 +82,13 @@ func (p *Porter) Publish(opts PublishOptions) error {
 
 func (p *Porter) publishFromFile(opts PublishOptions) error {
 	tag := opts.Tag
-	if tag == "" {
+	if tag != "" {
+		// If tag was supplied, update the invocation image name on the manifest
+		// per the registry, org and docker tag from the value provided
+		if err := p.Manifest.SetInvocationImageFromBundleTag(tag, true); err != nil {
+			return errors.Wrapf(err, "unable to set invocation image name from tag %q", tag)
+		}
+	} else {
 		tag = p.Manifest.BundleTag
 	}
 	if p.Manifest.BundleTag == "" {
@@ -96,7 +102,7 @@ func (p *Porter) publishFromFile(opts PublishOptions) error {
 
 	digest, err := p.Registry.PushInvocationImage(p.Manifest.Image)
 	if err != nil {
-		return errors.Wrap(err, "unable to push CNAB invocation image")
+		return errors.Wrapf(err, "unable to push CNAB invocation image %q", p.Manifest.Image)
 	}
 
 	bun, err := p.rewriteBundleWithInvocationImageDigest(digest)


### PR DESCRIPTION
# What does this change

* Updates `porter publish` logic such that the invocation image name is updated when a bundle tag value (via `--tag`) is provided.  The updated image name inherits the registry and docker tag from the provided bundle tag value.
* A bit of refactoring was introduced to consolidate this image naming logic for use by multiple areas (in this case, publish as well as setting defaults on the manifest)

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/1123

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md