### PR TITLE
fix(publish.go): fix certain cases around image name updating

### DIFF
--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -285,17 +285,9 @@ func getNewImageNameFromBundleTag(origImg, bundleTag string) (image.Name, error)
 	if err != nil {
 		return image.EmptyName, errors.Wrapf(err, "unable to parse bundle tag %q into domain/path components", bundleTag)
 	}
-	bundleHost := bundleName.Host() // e.g. docker.io
 
-	// Split up the Path portion of each to derive original image name
-	// and the bundle org/subdir values
-	origPathParts := strings.Split(origName.Path(), "/")                     // e.g. [origOrg, orgSubdir, orgImgName]
-	origImgName := strings.Join(origPathParts[len(origPathParts)-1:], "/")   // e.g. [origImgName]
-	bundlePathParts := strings.Split(bundleName.Path(), "/")                 // e.g. [bundleOrg, bundleSubdir, bundleImgname]
-	bundleOrg := strings.Join(bundlePathParts[:len(bundlePathParts)-1], "/") // e.g. [bundleOrg, bundleSubdir]
-
-	// Join for bundleHost/bundleOrg/bundleSubdir/origImgName
-	newImg := path.Join(bundleHost, bundleOrg, origImgName)
+	// Use the image name with the bundle location
+	newImg := path.Join(path.Dir(bundleName.Name()), path.Base(origName.Name()))
 
 	newImgName, err := image.NewName(newImg)
 	if err != nil {

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -70,6 +70,24 @@ func TestPublish_getNewImageNameFromBundleTag(t *testing.T) {
 		assert.Equal(t, "example.com/neworg/apache-installer", newInvImgName.String())
 	})
 
+	t.Run("has registry and org, bundle tag has subdomain", func(t *testing.T) {
+		newInvImgName, err := getNewImageNameFromBundleTag("localhost:5000/myorg/apache-installer", "example.com/neworg/bundles/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		assert.Equal(t, "example.com/neworg/bundles/apache-installer", newInvImgName.String())
+	})
+
+	t.Run("has registry, org and subdomain, bundle tag has subdomain", func(t *testing.T) {
+		newInvImgName, err := getNewImageNameFromBundleTag("localhost:5000/myorg/myimgs/apache-installer", "example.com/neworg/bundles/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		assert.Equal(t, "example.com/neworg/bundles/apache-installer", newInvImgName.String())
+	})
+
+	t.Run("has registry, no org", func(t *testing.T) {
+		newInvImgName, err := getNewImageNameFromBundleTag("localhost:5000/apache-installer", "example.com/neworg/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		assert.Equal(t, "example.com/neworg/apache-installer", newInvImgName.String())
+	})
+
 	t.Run("no registry, has org", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleTag("myorg/apache-installer", "example.com/anotherorg/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
@@ -98,6 +116,12 @@ func TestPublish_getNewImageNameFromBundleTag(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleTag("apache", "example.com/neworg/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
 		assert.Equal(t, "example.com/neworg/apache", newInvImgName.String())
+	})
+
+	t.Run("src has registry, dst has no registry (implicit docker.io)", func(t *testing.T) {
+		newInvImgName, err := getNewImageNameFromBundleTag("oldregistry.com/apache", "neworg/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		assert.Equal(t, "docker.io/neworg/apache", newInvImgName.String())
 	})
 }
 


### PR DESCRIPTION
# What does this change

When we go to update an invocation image based on a bundle tag, there were some cases when the resulting image had an incorrect or unexpected name.  This logic currently is used by `archive` but may also come in handy for `publish` if/when https://github.com/deislabs/porter/pull/1127 is merged.  As a bonus, this area of code has been simplified while implementing the fix.

One obvious case of brokenness was when the invocation image had a registry but no org:

```
	t.Run("has registry, no org", func(t *testing.T) {
		newInvImgName, err := getNewImageNameFromBundleTag("localhost:5000/apache-installer", "example.com/neworg/apache:v0.1.0")
		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
		assert.Equal(t, "example.com/neworg/apache-installer", newInvImgName.String())
	})
```
Yielded:
```
    --- FAIL: TestPublish_getNewImageNameFromBundleTag/has_registry,_no_org (0.00s)
        publish_test.go:88:
            	Error Trace:	publish_test.go:88
            	Error:      	Not equal:
            	            	expected: "example.com/neworg/apache-installer"
            	            	actual  : "docker.io/neworg/example.com/apache-installer"
```

# What issue does it fix
(No corresponding GH issue.)

# Notes for the reviewer

Note the added unit tests around the corner cases where either/both of the invocation image and bundle tag have subdomains/subdirectories in their names.  This PR currently takes the position of inheriting the subdomain from the bundle tag, but I'm not sure if this is what is desired.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md