### PR TITLE
Param source

### DIFF
--- a/cmd/porter/run_test.go
+++ b/cmd/porter/run_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"get.porter.sh/porter/pkg/config"
-	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/porter"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +20,7 @@ func TestRun_Validate(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFileContents(configTpl, config.Name)
 	cmd := buildRunCommand(p.Porter)
 
-	os.Setenv(config.EnvACTION, string(manifest.ActionInstall))
+	os.Setenv(config.EnvACTION, string(claim.ActionInstall))
 
 	err = cmd.PreRunE(cmd, []string{})
 	require.Nil(t, err)

--- a/pkg/claims/helpers.go
+++ b/pkg/claims/helpers.go
@@ -1,19 +1,51 @@
 package claims
 
 import (
+	"testing"
+
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/utils/crud"
+	"github.com/stretchr/testify/require"
 )
 
 var _ claim.Provider = &TestClaimProvider{}
 
 type TestClaimProvider struct {
 	claim.Store
+	t *testing.T
 }
 
-func NewTestClaimProvider() TestClaimProvider {
+func NewTestClaimProvider(t *testing.T) TestClaimProvider {
 	crud := crud.NewMockStore()
 	return TestClaimProvider{
+		t:     t,
 		Store: claim.NewClaimStore(crud, nil, nil),
 	}
+}
+
+// CreateClaim creates a new claim and saves it.
+func (p TestClaimProvider) CreateClaim(installation string, action string, bun bundle.Bundle, parameters map[string]interface{}) claim.Claim {
+	c, err := claim.New(installation, action, bun, parameters)
+	require.NoError(p.t, err, "New claim failed")
+	err = p.SaveClaim(c)
+	require.NoError(p.t, err, "SaveClaim failed")
+	return c
+}
+
+// CreateResult creates a new result from the specified claim and saves it.
+func (p TestClaimProvider) CreateResult(c claim.Claim, status string) claim.Result {
+	r, err := c.NewResult(status)
+	require.NoError(p.t, err, "NewResult failed")
+	err = p.SaveResult(r)
+	require.NoError(p.t, err, "SaveResult failed")
+	return r
+}
+
+// CreateOutput creates a new output from the specified claim and result and saves it.
+func (p TestClaimProvider) CreateOutput(c claim.Claim, r claim.Result, name string, value []byte) claim.Output {
+	o := claim.NewOutput(c, r, name, value)
+	err := p.SaveOutput(o)
+	require.NoError(p.t, err, "SaveOutput failed")
+	return o
 }

--- a/pkg/claims/helpers.go
+++ b/pkg/claims/helpers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ claim.Provider = &TestClaimProvider{}
+var _ claim.Provider = TestClaimProvider{}
 
 type TestClaimProvider struct {
 	claim.Store

--- a/pkg/cnab/extensions/dependencies.go
+++ b/pkg/cnab/extensions/dependencies.go
@@ -11,7 +11,7 @@ const (
 	// DependenciesKey represents the full key for the Dependencies Extension
 	DependenciesKey = "io.cnab.dependencies"
 	// DependenciesSchema represents the schema for the Dependencies Extension
-	DependenciesSchema = "https://cnab.io/specs/v1/dependencies.schema.json"
+	DependenciesSchema = "https://cnab.io/v1/dependencies.schema.json"
 )
 
 // DependenciesExtension represents the required extension to enable dependencies

--- a/pkg/cnab/extensions/docker_test.go
+++ b/pkg/cnab/extensions/docker_test.go
@@ -36,7 +36,7 @@ func TestProcessedExtensions_GetDockerExtension(t *testing.T) {
 		}
 
 		dockerExt, dockerRequired, err := ext.GetDockerExtension()
-		require.Error(t, err, "GetDockerExtension failed")
+		require.Error(t, err, "GetDockerExtension should have failed")
 		assert.True(t, dockerRequired, "docker should be a required extension")
 		assert.Equal(t, Docker{}, dockerExt, "Docker config should default to empty")
 	})

--- a/pkg/cnab/extensions/parameter_sources.go
+++ b/pkg/cnab/extensions/parameter_sources.go
@@ -8,11 +8,12 @@ import (
 )
 
 const (
-	// ParameterSourcesExtensionKey represents the full key for the Parameter Sources Extension
+	// ParameterSourcesExtensionKey represents the full key for the Parameter Sources Extension.
 	ParameterSourcesExtensionKey = "io.cnab.parameter-sources"
-	// DockerExtensionSchema represents the schema for the Docker Extension
-	ParameterSourcesExtensionSchema = "https://cnab.io/specs/v1/parameter-sources.schema.json"
-	ParameterSourceTypeOutput       = "output"
+	// ParameterSourcesExtensionSchema represents the schema for the Docker Extension.
+	ParameterSourcesExtensionSchema = "https://cnab.io/v1/parameter-sources.schema.json"
+	// ParameterSourceTypeOutput defines a type of parameter source that is provided by a bundle output.
+	ParameterSourceTypeOutput = "output"
 )
 
 // ParameterSourcesExtension represents a required extension that specifies how
@@ -44,7 +45,7 @@ func (ps *ParameterSources) SetParameterFromOutput(parameter string, output stri
 }
 
 type ParameterSource struct {
-	// Array of source types in the priority order that they should be used to
+	// Priority is an array of source types in the priority order that they should be used to
 	// populated the parameter.
 	Priority []string `json:"priority" mapstructure:"priority"`
 
@@ -139,7 +140,7 @@ func ParameterSourcesExtensionReader(bun bundle.Bundle) (interface{}, error) {
 	return ps, nil
 }
 
-// GetParameterSourcesExtension checks if the docker extension is present and returns its
+// GetParameterSourcesExtension checks if the parameter sources extension is present and returns its
 // extension configuration.
 func (e ProcessedExtensions) GetParameterSourcesExtension() (ParameterSources, bool, error) {
 	rawExt, required := e[ParameterSourcesExtensionKey]

--- a/pkg/cnab/extensions/parameter_sources.go
+++ b/pkg/cnab/extensions/parameter_sources.go
@@ -1,0 +1,153 @@
+package extensions
+
+import (
+	"encoding/json"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/pkg/errors"
+)
+
+const (
+	// ParameterSourcesExtensionKey represents the full key for the Parameter Sources Extension
+	ParameterSourcesExtensionKey = "io.cnab.parameter-sources"
+	// DockerExtensionSchema represents the schema for the Docker Extension
+	ParameterSourcesExtensionSchema = "https://cnab.io/specs/v1/parameter-sources.schema.json"
+	ParameterSourceTypeOutput       = "output"
+)
+
+// ParameterSourcesExtension represents a required extension that specifies how
+// to default parameter values.
+var ParameterSourcesExtension = RequiredExtension{
+	Shorthand: "parameter-sources",
+	Key:       ParameterSourcesExtensionKey,
+	Schema:    ParameterSourcesExtensionSchema,
+	Reader:    ParameterSourcesExtensionReader,
+}
+
+// ParameterSources describes the set of custom extension metadata associated
+// with the Parameter Sources extension
+type ParameterSources map[string]ParameterSource
+
+// SetParameterFromOutput creates an entry in the parameter sources section setting
+// the parameter's value using the specified output's value.
+func (ps *ParameterSources) SetParameterFromOutput(parameter string, output string) {
+	if *ps == nil {
+		*ps = ParameterSources{}
+	}
+
+	(*ps)[parameter] = ParameterSource{
+		Priority: []string{ParameterSourceTypeOutput},
+		Sources: ParameterSourceMap{
+			ParameterSourceTypeOutput: OutputParameterSource{OutputName: output},
+		},
+	}
+}
+
+type ParameterSource struct {
+	// Array of source types in the priority order that they should be used to
+	// populated the parameter.
+	Priority []string `json:"priority" mapstructure:"priority"`
+
+	// Sources is a map of key/value pairs of a source type and definition for
+	// the parameter value.
+	Sources ParameterSourceMap `json:"sources" mapstructure:"sources"`
+}
+
+// ListSourcesByPriority returns the parameter sources by the requested priority,
+// if none is specified, they are unsorted.
+func (s ParameterSource) ListSourcesByPriority() []ParameterSourceDefinition {
+	sources := make([]ParameterSourceDefinition, len(s.Sources))
+	if len(s.Priority) == 0 {
+		for _, source := range s.Sources {
+			sources = append(sources, source)
+		}
+	} else {
+		for _, sourceType := range s.Priority {
+			sources = append(sources, s.Sources[sourceType])
+		}
+	}
+	return sources
+}
+
+type ParameterSourceMap map[string]ParameterSourceDefinition
+
+func (m *ParameterSourceMap) UnmarshalJSON(data []byte) error {
+	if *m == nil {
+		*m = ParameterSourceMap{}
+	}
+
+	var rawMap map[string]interface{}
+	err := json.Unmarshal(data, &rawMap)
+	if err != nil {
+		return err
+	}
+
+	for sourceKey, sourceDef := range rawMap {
+		rawDef, err := json.Marshal(sourceDef)
+		if err != nil {
+			return errors.Wrapf(err, "error re-marshaling parameter source definition")
+		}
+
+		switch sourceKey {
+		case ParameterSourceTypeOutput:
+			var output OutputParameterSource
+			err := json.Unmarshal(rawDef, &output)
+			if err != nil {
+				return errors.Wrapf(err, "invalid parameter source definition for key output")
+			}
+			(*m)[ParameterSourceTypeOutput] = output
+		default:
+			return errors.Errorf("unsupported parameter source key %s", sourceKey)
+		}
+	}
+
+	return nil
+}
+
+type ParameterSourceDefinition interface {
+}
+
+// OutputParameterSource represents a parameter that is set using the value from
+// a bundle output.
+type OutputParameterSource struct {
+	OutputName string `json:"name" mapstructure:"name"`
+}
+
+// ParameterSourcesExtensionReader is a Reader for the ParameterSourcesExtension,
+// which reads from the applicable section in the provided bundle and
+// returns a the raw data in the form of an interface
+func ParameterSourcesExtensionReader(bun bundle.Bundle) (interface{}, error) {
+	data, ok := bun.Custom[ParameterSourcesExtensionKey]
+	if !ok {
+		return nil, errors.Errorf("no custom extension configuration found for %s",
+			ParameterSourcesExtensionKey)
+	}
+
+	dataB, err := json.Marshal(data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not marshal the untyped %q extension data %q",
+			ParameterSourcesExtensionKey, string(dataB))
+	}
+
+	ps := ParameterSources{}
+	err = json.Unmarshal(dataB, &ps)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not unmarshal the %q extension %q",
+			ParameterSourcesExtensionKey, string(dataB))
+	}
+
+	return ps, nil
+}
+
+// GetParameterSourcesExtension checks if the docker extension is present and returns its
+// extension configuration.
+func (e ProcessedExtensions) GetParameterSourcesExtension() (ParameterSources, bool, error) {
+	rawExt, required := e[ParameterSourcesExtensionKey]
+
+	ext, ok := rawExt.(ParameterSources)
+	if !ok && required {
+		return ParameterSources{}, required, errors.Errorf("unable to parse Parameter Sources extension config: %+v", rawExt)
+	}
+
+	return ext, required, nil
+}

--- a/pkg/cnab/extensions/paramter_sources_test.go
+++ b/pkg/cnab/extensions/paramter_sources_test.go
@@ -1,0 +1,43 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessedExtensions_GetParameterSourcesExtension(t *testing.T) {
+	t.Run("extension present", func(t *testing.T) {
+		var ps ParameterSources
+		ps.SetParameterFromOutput("tfstate", "tfstate")
+		processed := ProcessedExtensions{
+			ParameterSourcesExtensionKey: ps,
+		}
+
+		ext, required, err := processed.GetParameterSourcesExtension()
+		require.NoError(t, err, "GetParameterSourcesExtension failed")
+		assert.True(t, required, "parameter-sources should be a required extension")
+		assert.Equal(t, ps, ext, "parameter-sources was not populated properly")
+	})
+
+	t.Run("extension missing", func(t *testing.T) {
+		processed := ProcessedExtensions{}
+
+		ext, required, err := processed.GetParameterSourcesExtension()
+		require.NoError(t, err, "GetParameterSourcesExtension failed")
+		assert.False(t, required, "parameter-sources should NOT be a required extension")
+		assert.Empty(t, ext, "parameter-sources should default to empty when not required")
+	})
+
+	t.Run("extension invalid", func(t *testing.T) {
+		processed := ProcessedExtensions{
+			ParameterSourcesExtensionKey: map[string]string{"ponies": "are great"},
+		}
+
+		ext, required, err := processed.GetParameterSourcesExtension()
+		require.Error(t, err, "GetParameterSourcesExtension failed")
+		assert.True(t, required, "parameter-sources should be a required extension")
+		assert.Empty(t, ext, "parameter-sources should default to empty when not required")
+	})
+}

--- a/pkg/cnab/extensions/paramter_sources_test.go
+++ b/pkg/cnab/extensions/paramter_sources_test.go
@@ -36,7 +36,7 @@ func TestProcessedExtensions_GetParameterSourcesExtension(t *testing.T) {
 		}
 
 		ext, required, err := processed.GetParameterSourcesExtension()
-		require.Error(t, err, "GetParameterSourcesExtension failed")
+		require.Error(t, err, "GetParameterSourcesExtension should have failed")
 		assert.True(t, required, "parameter-sources should be a required extension")
 		assert.Empty(t, ext, "parameter-sources should default to empty when not required")
 	})

--- a/pkg/cnab/extensions/required.go
+++ b/pkg/cnab/extensions/required.go
@@ -18,6 +18,7 @@ type RequiredExtension struct {
 var SupportedExtensions = []RequiredExtension{
 	DependenciesExtension,
 	DockerExtension,
+	ParameterSourcesExtension,
 }
 
 // ProcessedExtensions represents a map of the extension name to the

--- a/pkg/cnab/extensions/required_test.go
+++ b/pkg/cnab/extensions/required_test.go
@@ -1,22 +1,17 @@
 package extensions
 
 import (
-	"io/ioutil"
+	"fmt"
 	"testing"
 
-	"github.com/cnabio/cnab-go/bundle"
+	"get.porter.sh/porter/pkg/cnab"
 	"github.com/stretchr/testify/require"
 )
 
 func TestProcessRequiredExtensions(t *testing.T) {
 	t.Run("supported", func(t *testing.T) {
-		data, err := ioutil.ReadFile("testdata/bundle.json")
-		require.NoError(t, err, "cannot read bundle file")
-
-		bun, err := bundle.Unmarshal(data)
-		require.NoError(t, err, "could not unmarshal the bundle")
-
-		exts, err := ProcessRequiredExtensions(*bun)
+		bun := cnab.ReadTestBundle(t, "testdata/bundle.json")
+		exts, err := ProcessRequiredExtensions(bun)
 		require.NoError(t, err, "could not process required extensions")
 
 		expected := ProcessedExtensions{
@@ -34,45 +29,45 @@ func TestProcessRequiredExtensions(t *testing.T) {
 					},
 				},
 			},
+			"io.cnab.parameter-sources": ParameterSources{
+				"tfstate": ParameterSource{
+					Priority: []string{ParameterSourceTypeOutput},
+					Sources: ParameterSourceMap{
+						ParameterSourceTypeOutput: OutputParameterSource{"tfstate"},
+					},
+				},
+			},
 		}
 		require.Equal(t, expected, exts)
 	})
 
 	t.Run("supported unprocessable", func(t *testing.T) {
-		data, err := ioutil.ReadFile("testdata/bundle-supported-unprocessable.json")
-		require.NoError(t, err, "cannot read bundle file")
-
-		bun, err := bundle.Unmarshal(data)
-		require.NoError(t, err, "could not unmarshal the bundle")
-
-		_, err = ProcessRequiredExtensions(*bun)
+		bun := cnab.ReadTestBundle(t, "testdata/bundle-supported-unprocessable.json")
+		_, err := ProcessRequiredExtensions(bun)
 		require.EqualError(t, err, "unable to process extension: io.cnab.docker: no custom extension configuration found")
 	})
 
 	t.Run("unsupported", func(t *testing.T) {
-		data, err := ioutil.ReadFile("testdata/bundle-unsupported-required.json")
-		require.NoError(t, err, "cannot read bundle file")
-
-		bun, err := bundle.Unmarshal(data)
-		require.NoError(t, err, "could not unmarshal the bundle")
-
-		_, err = ProcessRequiredExtensions(*bun)
+		bun := cnab.ReadTestBundle(t, "testdata/bundle-unsupported-required.json")
+		_, err := ProcessRequiredExtensions(bun)
 		require.EqualError(t, err, "unsupported required extension: donuts")
 	})
 }
 
 func TestGetSupportedExtension(t *testing.T) {
-	t.Run("supported via shorthand", func(t *testing.T) {
-		ext, err := GetSupportedExtension("docker")
-		require.NoError(t, err)
-		require.Equal(t, DockerExtension.Key, ext.Key)
-	})
+	for _, supported := range SupportedExtensions {
+		t.Run(fmt.Sprintf("%s - shorthand", supported.Shorthand), func(t *testing.T) {
+			ext, err := GetSupportedExtension(supported.Shorthand)
+			require.NoError(t, err)
+			require.Equal(t, supported.Key, ext.Key)
+		})
 
-	t.Run("supported via full key", func(t *testing.T) {
-		ext, err := GetSupportedExtension("io.cnab.docker")
-		require.NoError(t, err)
-		require.Equal(t, DockerExtension.Key, ext.Key)
-	})
+		t.Run(fmt.Sprintf("%s - key", supported.Key), func(t *testing.T) {
+			ext, err := GetSupportedExtension(supported.Key)
+			require.NoError(t, err)
+			require.Equal(t, supported.Key, ext.Key)
+		})
+	}
 
 	t.Run("unsupported", func(t *testing.T) {
 		_, err := GetSupportedExtension("donuts")

--- a/pkg/cnab/extensions/testdata/bundle.json
+++ b/pkg/cnab/extensions/testdata/bundle.json
@@ -43,7 +43,8 @@
     }
   },
   "requiredExtensions": [
-    "io.cnab.dependencies"
+    "io.cnab.dependencies",
+    "io.cnab.parameter-sources"
   ],
   "custom": {
     "com.example.duffle-bag": {
@@ -69,6 +70,16 @@
           }
         }
       }
+    },
+    "io.cnab.parameter-sources": {
+      "tfstate": {
+        "priority": ["output"],
+        "sources": {
+          "output": {
+            "name": "tfstate"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -89,6 +100,10 @@
       "required": [
         "port"
       ]
+    },
+    "tfstate": {
+      "contentEncoding": "base64",
+      "type": "string"
     }
   },
   "parameters": {
@@ -97,6 +112,18 @@
       "destination": {
         "path": "/cnab/is/go"
       }
+    },
+    "tfstate": {
+      "applyTo": [ "upgrade", "uninstall" ],
+      "definition": "tfstate",
+      "required": true
+    }
+  },
+  "outputs": {
+    "tfstate": {
+      "applyTo": [ "install", "upgrade", "uninstall" ],
+      "definition": "tfstate",
+      "path": "/cnab/app/outputs/tfstate"
     }
   }
 }

--- a/pkg/cnab/helpers.go
+++ b/pkg/cnab/helpers.go
@@ -1,0 +1,19 @@
+package cnab
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/stretchr/testify/require"
+)
+
+func ReadTestBundle(t *testing.T, path string) bundle.Bundle {
+	bunD, err := ioutil.ReadFile(path)
+	require.NoError(t, err, "ReadFile failed for %s", path)
+
+	bun, err := bundle.Unmarshal(bunD)
+	require.NoError(t, err, "Unmarshal failed for bundle at %s", path)
+
+	return *bun
+}

--- a/pkg/cnab/provider/bundle.go
+++ b/pkg/cnab/provider/bundle.go
@@ -14,8 +14,6 @@ func (r *Runtime) LoadBundle(bundleFile string) (bundle.Bundle, error) {
 		return bundle.Bundle{}, errors.Wrapf(err, "cannot read bundle at %s", bundleFile)
 	}
 
-	// Issue #439: Errors that come back from the loader can be
-	// pretty opaque.
 	bun, err := l.LoadData(bunD)
 	if err != nil {
 		return bundle.Bundle{}, errors.Wrapf(err, "cannot load bundle")

--- a/pkg/cnab/provider/helpers.go
+++ b/pkg/cnab/provider/helpers.go
@@ -24,7 +24,7 @@ type TestRuntime struct {
 
 func NewTestRuntime(t *testing.T) *TestRuntime {
 	tc := config.NewTestConfig(t)
-	claimStorage := claims.NewTestClaimProvider()
+	claimStorage := claims.NewTestClaimProvider(t)
 	credentialStorage := credentials.NewTestCredentialProvider(t, tc)
 	parameterStorage := parameters.NewTestParameterProvider(t, tc)
 	return NewTestRuntimeWithConfig(tc, &claimStorage, credentialStorage, parameterStorage)

--- a/pkg/cnab/provider/helpers.go
+++ b/pkg/cnab/provider/helpers.go
@@ -8,7 +8,6 @@ import (
 	"get.porter.sh/porter/pkg/credentials"
 	"get.porter.sh/porter/pkg/parameters"
 	"github.com/cnabio/cnab-go/bundle"
-	"github.com/cnabio/cnab-go/claim"
 )
 
 const debugDriver = "debug"
@@ -17,6 +16,7 @@ var _ CNABProvider = &TestRuntime{}
 
 type TestRuntime struct {
 	*Runtime
+	TestClaims      claims.TestClaimProvider
 	TestCredentials credentials.TestCredentialProvider
 	TestParameters  *parameters.TestParameterProvider
 	TestConfig      *config.TestConfig
@@ -27,12 +27,13 @@ func NewTestRuntime(t *testing.T) *TestRuntime {
 	claimStorage := claims.NewTestClaimProvider(t)
 	credentialStorage := credentials.NewTestCredentialProvider(t, tc)
 	parameterStorage := parameters.NewTestParameterProvider(t, tc)
-	return NewTestRuntimeWithConfig(tc, &claimStorage, credentialStorage, parameterStorage)
+	return NewTestRuntimeWithConfig(tc, claimStorage, credentialStorage, parameterStorage)
 }
 
-func NewTestRuntimeWithConfig(tc *config.TestConfig, testClaims claim.Provider, testCredentials credentials.TestCredentialProvider, testParameters parameters.TestParameterProvider) *TestRuntime {
+func NewTestRuntimeWithConfig(tc *config.TestConfig, testClaims claims.TestClaimProvider, testCredentials credentials.TestCredentialProvider, testParameters parameters.TestParameterProvider) *TestRuntime {
 	return &TestRuntime{
 		TestConfig:      tc,
+		TestClaims:      testClaims,
 		TestCredentials: testCredentials,
 		TestParameters:  &testParameters,
 		Runtime:         NewRuntime(tc.Config, testClaims, testCredentials, testParameters),

--- a/pkg/cnab/provider/helpers.go
+++ b/pkg/cnab/provider/helpers.go
@@ -43,22 +43,7 @@ func (t *TestRuntime) LoadBundle(bundleFile string) (bundle.Bundle, error) {
 	return t.Runtime.LoadBundle(bundleFile)
 }
 
-func (t *TestRuntime) Install(args ActionArguments) error {
+func (t *TestRuntime) Execute(args ActionArguments) error {
 	args.Driver = debugDriver
-	return t.Runtime.Install(args)
-}
-
-func (t *TestRuntime) Upgrade(args ActionArguments) error {
-	args.Driver = debugDriver
-	return t.Runtime.Upgrade(args)
-}
-
-func (t *TestRuntime) Invoke(action string, args ActionArguments) error {
-	args.Driver = debugDriver
-	return t.Runtime.Invoke(action, args)
-}
-
-func (t *TestRuntime) Uninstall(args ActionArguments) error {
-	args.Driver = debugDriver
-	return t.Runtime.Uninstall(args)
+	return t.Runtime.Execute(args)
 }

--- a/pkg/cnab/provider/install.go
+++ b/pkg/cnab/provider/install.go
@@ -1,9 +1,0 @@
-package cnabprovider
-
-import (
-	"github.com/cnabio/cnab-go/claim"
-)
-
-func (r *Runtime) Install(args ActionArguments) error {
-	return r.ExecuteAction(claim.ActionInstall, args)
-}

--- a/pkg/cnab/provider/install_test.go
+++ b/pkg/cnab/provider/install_test.go
@@ -13,10 +13,11 @@ func TestRuntime_Install(t *testing.T) {
 	r.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "bundle.json")
 
 	args := ActionArguments{
+		Action:       claim.ActionInstall,
 		Installation: "mybuns",
 		BundlePath:   "bundle.json",
 	}
-	err := r.Install(args)
+	err := r.Execute(args)
 	require.NoError(t, err, "Install failed")
 
 	c, err := r.claims.ReadLastClaim(args.Installation)

--- a/pkg/cnab/provider/invoke.go
+++ b/pkg/cnab/provider/invoke.go
@@ -1,5 +1,0 @@
-package cnabprovider
-
-func (r *Runtime) Invoke(action string, args ActionArguments) error {
-	return r.ExecuteAction(action, args)
-}

--- a/pkg/cnab/provider/invoke_test.go
+++ b/pkg/cnab/provider/invoke_test.go
@@ -120,10 +120,11 @@ func TestRuntime_ClaimPersistence(t *testing.T) {
 			require.NoError(t, err, "could not write to bundle.json")
 
 			args := ActionArguments{
+				Action:       in.action,
 				Installation: in.installation,
 				BundlePath:   "bundle.json",
 			}
-			runErr := d.Invoke(in.action, args)
+			runErr := d.Execute(args)
 			c, claimErr := d.claims.ReadLastClaim(in.installation)
 
 			if want.err == nil {
@@ -145,8 +146,9 @@ func TestInvoke_NoClaimBubblesUpError(t *testing.T) {
 	r := NewTestRuntime(t)
 
 	args := ActionArguments{
+		Action:       "custom-action",
 		Installation: "mybuns",
 	}
-	err := r.Invoke("custom-action", args)
+	err := r.Execute(args)
 	require.EqualError(t, err, "could not load installation mybuns: Installation does not exist")
 }

--- a/pkg/cnab/provider/invoke_test.go
+++ b/pkg/cnab/provider/invoke_test.go
@@ -43,13 +43,8 @@ func TestRuntime_ClaimPersistence(t *testing.T) {
 		},
 	}
 
-	eClaim, err := claim.New("exists", claim.ActionInstall, bun, nil)
-	require.NoError(t, err)
-
 	d := NewTestRuntime(t)
-
-	err = d.claims.SaveClaim(eClaim)
-	require.NoError(t, err)
+	eClaim := d.TestClaims.CreateClaim("exists", claim.ActionInstall, bun, nil)
 
 	tests := []test{
 		{

--- a/pkg/cnab/provider/parameters_test.go
+++ b/pkg/cnab/provider/parameters_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"get.porter.sh/porter/pkg/claims"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-go/claim"
@@ -239,10 +238,9 @@ func Test_loadParameters_ParameterSourcePrecedence(t *testing.T) {
 	})
 
 	t.Run("only parameter source present", func(t *testing.T) {
-		tc := r.claims.(*claims.TestClaimProvider)
-		c := tc.CreateClaim("mybun", claim.ActionInstall, b, nil)
-		cr := tc.CreateResult(c, claim.StatusSucceeded)
-		tc.CreateOutput(c, cr, "foo", []byte("foo_source"))
+		c := r.TestClaims.CreateClaim("mybun", claim.ActionInstall, b, nil)
+		cr := r.TestClaims.CreateResult(c, claim.StatusSucceeded)
+		r.TestClaims.CreateOutput(c, cr, "foo", []byte("foo_source"))
 
 		args := ActionArguments{
 			Installation: "mybun",
@@ -255,10 +253,9 @@ func Test_loadParameters_ParameterSourcePrecedence(t *testing.T) {
 	})
 
 	t.Run("override > parameter source", func(t *testing.T) {
-		tc := r.claims.(*claims.TestClaimProvider)
-		c := tc.CreateClaim("mybun", claim.ActionInstall, b, nil)
-		cr := tc.CreateResult(c, claim.StatusSucceeded)
-		tc.CreateOutput(c, cr, "foo", []byte("foo_source"))
+		c := r.TestClaims.CreateClaim("mybun", claim.ActionInstall, b, nil)
+		cr := r.TestClaims.CreateResult(c, claim.StatusSucceeded)
+		r.TestClaims.CreateOutput(c, cr, "foo", []byte("foo_source"))
 
 		args := ActionArguments{
 			Installation: "mybun",
@@ -275,12 +272,11 @@ func Test_loadParameters_ParameterSourcePrecedence(t *testing.T) {
 		// foo is set by a the user
 		// baz is set by a parameter source
 		// bar is set by the bundle default
-		tc := r.claims.(*claims.TestClaimProvider)
-		c := tc.CreateClaim("mybun", claim.ActionInstall, b, nil)
-		cr := tc.CreateResult(c, claim.StatusSucceeded)
-		tc.CreateOutput(c, cr, "foo", []byte("foo_source"))
-		tc.CreateOutput(c, cr, "bar", []byte("bar_source"))
-		tc.CreateOutput(c, cr, "baz", []byte("baz_source"))
+		c := r.TestClaims.CreateClaim("mybun", claim.ActionInstall, b, nil)
+		cr := r.TestClaims.CreateResult(c, claim.StatusSucceeded)
+		r.TestClaims.CreateOutput(c, cr, "foo", []byte("foo_source"))
+		r.TestClaims.CreateOutput(c, cr, "bar", []byte("bar_source"))
+		r.TestClaims.CreateOutput(c, cr, "baz", []byte("baz_source"))
 
 		args := ActionArguments{
 			Installation: "mybun",
@@ -472,10 +468,9 @@ func TestRuntime_ResolveParameterSources(t *testing.T) {
 	bun, err := r.ProcessBundle("bundle.json")
 	require.NoError(t, err, "ProcessBundle failed")
 
-	tc := r.claims.(*claims.TestClaimProvider)
-	c := tc.CreateClaim("mybun", claim.ActionInstall, bun, nil)
-	cr := tc.CreateResult(c, claim.StatusSucceeded)
-	tc.CreateOutput(c, cr, "foo", []byte("abc123"))
+	c := r.TestClaims.CreateClaim("mybun", claim.ActionInstall, bun, nil)
+	cr := r.TestClaims.CreateResult(c, claim.StatusSucceeded)
+	r.TestClaims.CreateOutput(c, cr, "foo", []byte("abc123"))
 
 	args := ActionArguments{
 		Installation: "mybun",

--- a/pkg/cnab/provider/parameters_test.go
+++ b/pkg/cnab/provider/parameters_test.go
@@ -270,8 +270,8 @@ func Test_loadParameters_ParameterSourcePrecedence(t *testing.T) {
 
 	t.Run("merge parameter values", func(t *testing.T) {
 		// foo is set by a the user
-		// baz is set by a parameter source
-		// bar is set by the bundle default
+		// bar is set by a parameter source
+		// baz is set by the bundle default
 		c := r.TestClaims.CreateClaim("mybun", claim.ActionInstall, b, nil)
 		cr := r.TestClaims.CreateResult(c, claim.StatusSucceeded)
 		r.TestClaims.CreateOutput(c, cr, "foo", []byte("foo_source"))

--- a/pkg/cnab/provider/provider.go
+++ b/pkg/cnab/provider/provider.go
@@ -7,8 +7,5 @@ import (
 // CNABProvider is the interface Porter uses to communicate with the CNAB runtime
 type CNABProvider interface {
 	LoadBundle(bundleFile string) (bundle.Bundle, error)
-	Install(arguments ActionArguments) error
-	Upgrade(arguments ActionArguments) error
-	Invoke(action string, arguments ActionArguments) error
-	Uninstall(arguments ActionArguments) error
+	Execute(arguments ActionArguments) error
 }

--- a/pkg/cnab/provider/testdata/bundle-with-param-sources.json
+++ b/pkg/cnab/provider/testdata/bundle-with-param-sources.json
@@ -1,0 +1,104 @@
+{
+  "requiredExtensions": [
+    "io.cnab.parameter-sources"
+  ],
+  "custom": {
+    "io.cnab.parameter-sources": {
+      "foo": {
+        "priority": [
+          "output"
+        ],
+        "sources": {
+          "output": {
+            "name": "foo"
+          }
+        }
+      },
+      "bar": {
+        "priority": [
+          "output"
+        ],
+        "sources": {
+          "output": {
+            "name": "bar"
+          }
+        }
+      }
+    }
+  },
+  "outputs": {
+    "bar": {
+      "definition": "bar"
+    },
+    "baz": {
+      "definition": "baz"
+    },
+    "foo": {
+      "applyTo": [
+        "install",
+        "upgrade",
+        "uninstall"
+      ],
+      "definition": "foo",
+      "path": "/cnab/app/outputs/foo"
+    }
+  },
+  "parameters": {
+    "bar": {
+      "definition": "bar",
+      "destination": {
+        "env": "BAR"
+      }
+    },
+    "baz": {
+      "definition": "baz",
+      "destination": {
+        "env": "BAZ"
+      }
+    },
+    "foo": {
+      "applyTo": [
+        "upgrade",
+        "uninstall"
+      ],
+      "definition": "foo",
+      "destination": {
+        "env": "FOO"
+      }
+    },
+    "qux": {
+      "definition": "qux",
+      "destination": {
+        "env": "QUX"
+      }
+    }
+  },
+  "definitions": {
+    "foo": {
+      "type": "string",
+      "default": "foo_default"
+    },
+    "bar": {
+      "type": "string",
+      "default": "bar_default"
+    },
+    "baz": {
+      "type": "string",
+      "default": "baz_default"
+    },
+    "qux": {
+      "type": "string",
+      "default": "qux_default"
+    }
+  },
+  "description": "A bundle with a parameter sources",
+  "invocationImages": [
+    {
+      "image": "getporter/porter-parameter-sources-installer:0.1.0",
+      "imageType": "docker"
+    }
+  ],
+  "name": "porter-parameter-sources",
+  "schemaVersion": "v1.0.0",
+  "version": "0.1.0"
+}

--- a/pkg/cnab/provider/uninstall.go
+++ b/pkg/cnab/provider/uninstall.go
@@ -1,9 +1,0 @@
-package cnabprovider
-
-import (
-	"github.com/cnabio/cnab-go/claim"
-)
-
-func (r *Runtime) Uninstall(args ActionArguments) error {
-	return r.ExecuteAction(claim.ActionUninstall, args)
-}

--- a/pkg/cnab/provider/uninstall_test.go
+++ b/pkg/cnab/provider/uninstall_test.go
@@ -21,10 +21,11 @@ func TestRuntime_Uninstall(t *testing.T) {
 		require.NoError(t, err, "SaveClaim failed")
 
 		args := ActionArguments{
+			Action:       claim.ActionUninstall,
 			Installation: "mybuns",
 			BundlePath:   "bundle.json",
 		}
-		err = r.Uninstall(args)
+		err = r.Execute(args)
 		require.NoError(t, err, "Uninstall failed")
 
 		c, err := r.claims.ReadLastClaim(args.Installation)
@@ -39,10 +40,11 @@ func TestRuntime_Uninstall(t *testing.T) {
 		r.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "bundle.json")
 
 		args := ActionArguments{
+			Action:       claim.ActionUninstall,
 			Installation: "mybuns",
 			BundlePath:   "bundle.json",
 		}
-		err := r.Uninstall(args)
+		err := r.Execute(args)
 		require.Error(t, err, "Uninstall should have failed")
 		assert.Contains(t, err.Error(), "Installation does not exist")
 	})

--- a/pkg/cnab/provider/upgrade.go
+++ b/pkg/cnab/provider/upgrade.go
@@ -1,7 +1,0 @@
-package cnabprovider
-
-import "github.com/cnabio/cnab-go/claim"
-
-func (r *Runtime) Upgrade(args ActionArguments) error {
-	return r.ExecuteAction(claim.ActionUpgrade, args)
-}

--- a/pkg/cnab/provider/upgrade_test.go
+++ b/pkg/cnab/provider/upgrade_test.go
@@ -21,10 +21,11 @@ func TestRuntime_Upgrade(t *testing.T) {
 		require.NoError(t, err, "SaveClaim failed")
 
 		args := ActionArguments{
+			Action:       claim.ActionUpgrade,
 			Installation: "mybuns",
 			BundlePath:   "bundle.json",
 		}
-		err = r.Upgrade(args)
+		err = r.Execute(args)
 		require.NoError(t, err, "Upgrade failed")
 
 		c, err := r.claims.ReadLastClaim(args.Installation)
@@ -39,10 +40,11 @@ func TestRuntime_Upgrade(t *testing.T) {
 		r.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "bundle.json")
 
 		args := ActionArguments{
+			Action:       claim.ActionUpgrade,
 			Installation: "mybuns",
 			BundlePath:   "bundle.json",
 		}
-		err := r.Upgrade(args)
+		err := r.Execute(args)
 		require.Error(t, err, "Upgrade should have failed")
 		assert.Contains(t, err.Error(), "Installation does not exist")
 	})

--- a/pkg/manifest/actions.go
+++ b/pkg/manifest/actions.go
@@ -1,15 +1,11 @@
 package manifest
 
-type Action string
-
-const (
-	ActionInstall   Action = "install"
-	ActionUpgrade   Action = "upgrade"
-	ActionUninstall Action = "uninstall"
+import (
+	"github.com/cnabio/cnab-go/claim"
 )
 
 // IsCoreAction determines if the value is a core action from the CNAB spec.
-func IsCoreAction(value Action) bool {
+func IsCoreAction(value string) bool {
 	for _, a := range GetCoreActions() {
 		if value == a {
 			return true
@@ -18,6 +14,6 @@ func IsCoreAction(value Action) bool {
 	return false
 }
 
-func GetCoreActions() []Action {
-	return []Action{ActionInstall, ActionUpgrade, ActionUninstall}
+func GetCoreActions() []string {
+	return []string{claim.ActionInstall, claim.ActionUpgrade, claim.ActionUninstall}
 }

--- a/pkg/manifest/actions_test.go
+++ b/pkg/manifest/actions_test.go
@@ -13,7 +13,7 @@ func TestIsCoreAction(t *testing.T) {
 
 	for action, want := range testcases {
 		t.Run(action, func(t *testing.T) {
-			got := IsCoreAction(Action(action))
+			got := IsCoreAction(action)
 			if want != got {
 				t.Fatalf("IsCoreAction(%q) failed, want %t, got %t", action, want, got)
 			}

--- a/pkg/mixin/query/manifest_generator.go
+++ b/pkg/mixin/query/manifest_generator.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"get.porter.sh/porter/pkg/manifest"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -44,7 +45,7 @@ func (g ManifestGenerator) buildInputForMixin(mixinName string) BuildInput {
 		}
 	}
 
-	filterSteps := func(action manifest.Action, steps manifest.Steps) {
+	filterSteps := func(action string, steps manifest.Steps) {
 		mixinSteps := manifest.Steps{}
 		for _, step := range steps {
 			if step.GetMixinName() != mixinName {
@@ -52,14 +53,14 @@ func (g ManifestGenerator) buildInputForMixin(mixinName string) BuildInput {
 			}
 			mixinSteps = append(mixinSteps, step)
 		}
-		input.Actions[string(action)] = mixinSteps
+		input.Actions[action] = mixinSteps
 	}
-	filterSteps(manifest.ActionInstall, g.Manifest.Install)
-	filterSteps(manifest.ActionUpgrade, g.Manifest.Upgrade)
-	filterSteps(manifest.ActionUninstall, g.Manifest.Uninstall)
+	filterSteps(claim.ActionInstall, g.Manifest.Install)
+	filterSteps(claim.ActionUpgrade, g.Manifest.Upgrade)
+	filterSteps(claim.ActionUninstall, g.Manifest.Uninstall)
 
 	for action, steps := range g.Manifest.CustomActions {
-		filterSteps(manifest.Action(action), steps)
+		filterSteps(action, steps)
 	}
 
 	return input

--- a/pkg/porter/dependencies_test.go
+++ b/pkg/porter/dependencies_test.go
@@ -3,8 +3,7 @@ package porter
 import (
 	"testing"
 
-	cnabprovider "get.porter.sh/porter/pkg/cnab/provider"
-	"get.porter.sh/porter/pkg/manifest"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,10 +14,10 @@ func TestDependencyExecutioner_ExecuteBeforePrepare(t *testing.T) {
 	err := p.LoadManifestFrom("/porter.yaml")
 	require.NoError(t, err)
 
-	e := newDependencyExecutioner(p.Porter)
+	e := newDependencyExecutioner(p.Porter, claim.ActionInstall)
 
 	// Try to call execute without prepare
-	err = e.Execute(manifest.ActionInstall)
+	err = e.Execute()
 	require.Error(t, err, "execute before prepare should return an error")
 	assert.EqualError(t, err, "Prepare must be called before Execute")
 
@@ -27,10 +26,8 @@ func TestDependencyExecutioner_ExecuteBeforePrepare(t *testing.T) {
 	opts.File = "/porter.yaml"
 	err = opts.Validate([]string{}, p.Porter)
 	require.NoError(t, err, "opts validate failed")
-	err = e.Prepare(opts.BundleLifecycleOpts, func(args cnabprovider.ActionArguments) error {
-		return nil
-	})
+	err = e.Prepare(opts.BundleLifecycleOpts)
 	require.NoError(t, err, "prepare should have succeeded")
-	err = e.Execute(manifest.ActionInstall)
+	err = e.Execute()
 	require.NoError(t, err, "execute should not fail when we have called prepare")
 }

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -28,6 +28,7 @@ import (
 type TestPorter struct {
 	*Porter
 	TestConfig      *config.TestConfig
+	TestClaims      claims.TestClaimProvider
 	TestCredentials *credentials.TestCredentialProvider
 	TestParameters  *parameters.TestParameterProvider
 	TestCache       *cache.TestCache
@@ -53,14 +54,15 @@ func NewTestPorter(t *testing.T) *TestPorter {
 	p.Plugins = plugins.NewTestPluginProvider()
 	p.Cache = testCache
 	p.Builder = NewTestBuildProvider()
-	p.Claims = &testClaims
+	p.Claims = testClaims
 	p.Credentials = testCredentials
 	p.Parameters = testParameters
-	p.CNAB = cnabprovider.NewTestRuntimeWithConfig(tc, &testClaims, testCredentials, testParameters)
+	p.CNAB = cnabprovider.NewTestRuntimeWithConfig(tc, testClaims, testCredentials, testParameters)
 
 	return &TestPorter{
 		Porter:          p,
 		TestConfig:      tc,
+		TestClaims:      testClaims,
 		TestCredentials: &testCredentials,
 		TestParameters:  &testParameters,
 		TestCache:       testCache,

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -18,6 +18,7 @@ import (
 	"get.porter.sh/porter/pkg/parameters"
 	"get.porter.sh/porter/pkg/plugins"
 	"get.porter.sh/porter/pkg/secrets"
+	"github.com/cnabio/cnab-go/bundle"
 	cnabcreds "github.com/cnabio/cnab-go/credentials"
 	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/stretchr/testify/require"
@@ -44,7 +45,7 @@ func NewTestPorter(t *testing.T) *TestPorter {
 	testCredentials := credentials.NewTestCredentialProvider(t, tc)
 	testParameters := parameters.NewTestParameterProvider(t, tc)
 	testCache := cache.NewTestCache(cache.New(tc.Config))
-	testClaims := claims.NewTestClaimProvider()
+	testClaims := claims.NewTestClaimProvider(t)
 
 	p := New()
 	p.Config = tc.Config
@@ -122,11 +123,22 @@ func (p *TestPorter) CleanupIntegrationTest() {
 	os.Chdir(p.TestDir)
 }
 
+func (p *TestPorter) ReadBundle(path string) bundle.Bundle {
+	bunD, err := ioutil.ReadFile(path)
+	require.NoError(p.T(), err, "ReadFile failed for %s", path)
+
+	bun, err := bundle.Unmarshal(bunD)
+	require.NoError(p.T(), err, "Unmarshal failed for bundle at %s", path)
+
+	return *bun
+}
+
 type TestBuildProvider struct{}
 
 func NewTestBuildProvider() *TestBuildProvider {
 	return &TestBuildProvider{}
 }
+
 func (t *TestBuildProvider) BuildInvocationImage(manifest *manifest.Manifest) error {
 	return nil
 }

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -3,8 +3,7 @@ package porter
 import (
 	"fmt"
 
-	"get.porter.sh/porter/pkg/manifest"
-
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/pkg/errors"
 )
 
@@ -32,17 +31,17 @@ func (p *Porter) InstallBundle(opts InstallOptions) error {
 		return err
 	}
 
-	deperator := newDependencyExecutioner(p)
-	err = deperator.Prepare(opts.BundleLifecycleOpts, p.CNAB.Install)
+	deperator := newDependencyExecutioner(p, claim.ActionInstall)
+	err = deperator.Prepare(opts.BundleLifecycleOpts)
 	if err != nil {
 		return err
 	}
 
-	err = deperator.Execute(manifest.ActionInstall)
+	err = deperator.Execute()
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(p.Out, "installing %s...\n", opts.Name)
-	return p.CNAB.Install(opts.ToActionArgs(deperator))
+	return p.CNAB.Execute(opts.ToActionArgs(deperator))
 }

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -3,8 +3,6 @@ package porter
 import (
 	"fmt"
 
-	cnabprovider "get.porter.sh/porter/pkg/cnab/provider"
-	"get.porter.sh/porter/pkg/manifest"
 	"github.com/pkg/errors"
 )
 
@@ -42,19 +40,17 @@ func (p *Porter) InvokeBundle(opts InvokeOptions) error {
 		return err
 	}
 
-	deperator := newDependencyExecutioner(p)
-	err = deperator.Prepare(opts.BundleLifecycleOpts, func(args cnabprovider.ActionArguments) error {
-		return p.CNAB.Invoke(opts.Action, args)
-	})
+	deperator := newDependencyExecutioner(p, opts.Action)
+	err = deperator.Prepare(opts.BundleLifecycleOpts)
 	if err != nil {
 		return err
 	}
 
-	err = deperator.Execute(manifest.Action(opts.Action))
+	err = deperator.Execute()
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(p.Out, "invoking custom action %s on %s...\n", opts.Action, opts.Name)
-	return p.CNAB.Invoke(opts.Action, opts.ToActionArgs(deperator))
+	return p.CNAB.Execute(opts.ToActionArgs(deperator))
 }

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -30,7 +30,8 @@ func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {
 // ToActionArgs converts this instance of user-provided action options.
 func (o *BundleLifecycleOpts) ToActionArgs(deperator *dependencyExecutioner) cnabprovider.ActionArguments {
 	args := cnabprovider.ActionArguments{
-		Installation:                 o.Name,
+		Action:                deperator.Action,
+		Installation:          o.Name,
 		BundlePath:            o.CNABFile,
 		Params:                make(map[string]string, len(o.combinedParameters)),
 		CredentialIdentifiers: make([]string, len(o.CredentialIdentifiers)),

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -3,9 +3,9 @@ package porter
 import (
 	"testing"
 
+	"get.porter.sh/porter/pkg/claims"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/claim"
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,25 +13,12 @@ func TestNewDisplayInstallation(t *testing.T) {
 	bun := bundle.Bundle{Name: "wordpress"}
 
 	t.Run("install exists", func(t *testing.T) {
-		install, err := claim.New("wordpress", claim.ActionInstall, bun, nil)
-		require.NoError(t, err, "New claim failed")
-		installResult, err := install.NewResult(claim.StatusSucceeded)
-		require.NoError(t, err, "NewResult failed")
+		cp := claims.NewTestClaimProvider(t)
+		install := cp.CreateClaim("wordpress", claim.ActionInstall, bun, nil)
+		cp.CreateResult(install, claim.StatusSucceeded)
 
-		upgrade, err := claim.New("wordpress", claim.ActionUpgrade, bun, nil)
-		require.NoError(t, err, "New claim failed")
-		upgradeResult, err := upgrade.NewResult(claim.StatusRunning)
-		require.NoError(t, err, "NewResult failed")
-
-		cp := claim.NewClaimStore(crud.NewMockStore(), nil, nil)
-		err = cp.SaveClaim(install)
-		require.NoError(t, err, "SaveClaim failed")
-		err = cp.SaveResult(installResult)
-		require.NoError(t, err, "SaveResult failed")
-		err = cp.SaveClaim(upgrade)
-		require.NoError(t, err, "SaveClaim failed")
-		err = cp.SaveResult(upgradeResult)
-		require.NoError(t, err, "SaveResult failed")
+		upgrade := cp.CreateClaim("wordpress", claim.ActionUpgrade, bun, nil)
+		cp.CreateResult(upgrade, claim.StatusRunning)
 
 		i, err := cp.ReadInstallation("wordpress")
 		require.NoError(t, err, "ReadInstallation failed")
@@ -47,16 +34,9 @@ func TestNewDisplayInstallation(t *testing.T) {
 	})
 
 	t.Run("install does not exist", func(t *testing.T) {
-		dryRun, err := claim.New("wordpress", "dry-run", bun, nil)
-		require.NoError(t, err, "New claim failed")
-		dryRunResult, err := dryRun.NewResult(claim.StatusSucceeded)
-		require.NoError(t, err, "NewResult failed")
-
-		cp := claim.NewClaimStore(crud.NewMockStore(), nil, nil)
-		err = cp.SaveClaim(dryRun)
-		require.NoError(t, err, "SaveClaim failed")
-		err = cp.SaveResult(dryRunResult)
-		require.NoError(t, err, "SaveResult failed")
+		cp := claims.NewTestClaimProvider(t)
+		dryRun := cp.CreateClaim("wordpress", "dry-run", bun, nil)
+		cp.CreateResult(dryRun, claim.StatusSucceeded)
 
 		i, err := cp.ReadInstallation("wordpress")
 		require.NoError(t, err, "ReadInstallation failed")

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -57,24 +57,16 @@ func TestPorter_printDisplayOutput_JSON(t *testing.T) {
 			},
 		},
 	}
-	c, err := claim.New("test", claim.ActionInstall, b, nil)
-	require.NoError(t, err, "NewClaim failed")
+
+	c := p.TestClaims.CreateClaim("test", claim.ActionInstall, b, nil)
+	r := p.TestClaims.CreateResult(c, claim.StatusSucceeded)
+	p.TestClaims.CreateOutput(c, r, "foo", []byte("foo-output"))
+	p.TestClaims.CreateOutput(c, r, "bar", []byte("bar-output"))
+
+	// Hard code the date so we can compare the command output easily
 	c.Created = time.Date(1983, time.April, 18, 1, 2, 3, 4, time.UTC)
-	err = p.Claims.SaveClaim(c)
+	err := p.TestClaims.SaveClaim(c)
 	require.NoError(t, err, "could not store claim")
-
-	r, err := c.NewResult(claim.StatusSucceeded)
-	require.NoError(t, err, "NewResult failed")
-	err = p.Claims.SaveResult(r)
-	require.NoError(t, err, "SaveResult failed")
-
-	foo := claim.NewOutput(c, r, "foo", []byte("foo-output"))
-	err = p.Claims.SaveOutput(foo)
-	require.NoError(t, err, "SaveOutput failed")
-
-	bar := claim.NewOutput(c, r, "bar", []byte("bar-output"))
-	err = p.Claims.SaveOutput(bar)
-	require.NoError(t, err, "SaveOutput failed")
 
 	opts := OutputListOptions{
 		sharedOptions: sharedOptions{

--- a/pkg/porter/run.go
+++ b/pkg/porter/run.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"get.porter.sh/porter/pkg/config"
-	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/runtime"
 	"github.com/pkg/errors"
 )
@@ -14,9 +13,8 @@ import (
 type RunOptions struct {
 	config *config.Config
 
-	File         string
-	Action       string
-	parsedAction manifest.Action
+	File   string
+	Action string
 }
 
 func NewRunOptions(c *config.Config) RunOptions {
@@ -47,7 +45,6 @@ func (o *RunOptions) validateAction() error {
 		}
 	}
 
-	o.parsedAction = manifest.Action(o.Action)
 	return nil
 }
 
@@ -81,7 +78,7 @@ func (p *Porter) Run(opts RunOptions) error {
 		return err
 	}
 
-	runtimeManifest := runtime.NewRuntimeManifest(p.Context, opts.parsedAction, p.Manifest)
+	runtimeManifest := runtime.NewRuntimeManifest(p.Context, opts.Action, p.Manifest)
 	r := runtime.NewPorterRuntime(p.Context, p.Mixins)
 	return r.Execute(runtimeManifest)
 }

--- a/pkg/porter/run_test.go
+++ b/pkg/porter/run_test.go
@@ -4,12 +4,11 @@ import (
 	"os"
 	"testing"
 
-	"get.porter.sh/porter/pkg/mixin"
-
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/context"
-	"get.porter.sh/porter/pkg/manifest"
+	"get.porter.sh/porter/pkg/mixin"
 	"get.porter.sh/porter/pkg/pkgmgmt"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +29,7 @@ func TestPorter_Run(t *testing.T) {
 	p.FileSystem.Create("/root/.kube/config")
 
 	opts := NewRunOptions(p.Config)
-	opts.Action = string(manifest.ActionInstall)
+	opts.Action = claim.ActionInstall
 	opts.File = "porter.yaml"
 
 	err := opts.Validate()

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -3,8 +3,7 @@ package porter
 import (
 	"fmt"
 
-	"get.porter.sh/porter/pkg/manifest"
-
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/pkg/errors"
 )
 
@@ -32,14 +31,14 @@ func (p *Porter) UninstallBundle(opts UninstallOptions) error {
 		return err
 	}
 
-	deperator := newDependencyExecutioner(p)
-	err = deperator.Prepare(opts.BundleLifecycleOpts, p.CNAB.Uninstall)
+	deperator := newDependencyExecutioner(p, claim.ActionUninstall)
+	err = deperator.Prepare(opts.BundleLifecycleOpts)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(p.Out, "uninstalling %s...\n", opts.Name)
-	err = p.CNAB.Uninstall(opts.ToActionArgs(deperator))
+	err = p.CNAB.Execute(opts.ToActionArgs(deperator))
 	if err != nil {
 		if len(deperator.deps) > 0 {
 			return errors.Wrapf(err, "failed to uninstall the %s bundle, the remaining dependencies were not uninstalled", opts.Name)
@@ -49,5 +48,5 @@ func (p *Porter) UninstallBundle(opts UninstallOptions) error {
 	}
 
 	// TODO: See https://github.com/deislabs/porter/issues/465 for flag to allow keeping around the dependencies
-	return deperator.Execute(manifest.ActionUninstall)
+	return deperator.Execute()
 }

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -3,8 +3,7 @@ package porter
 import (
 	"fmt"
 
-	"get.porter.sh/porter/pkg/manifest"
-
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/pkg/errors"
 )
 
@@ -32,17 +31,17 @@ func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
 		return err
 	}
 
-	deperator := newDependencyExecutioner(p)
-	err = deperator.Prepare(opts.BundleLifecycleOpts, p.CNAB.Upgrade)
+	deperator := newDependencyExecutioner(p, claim.ActionUpgrade)
+	err = deperator.Prepare(opts.BundleLifecycleOpts)
 	if err != nil {
 		return err
 	}
 
-	err = deperator.Execute(manifest.ActionUpgrade)
+	err = deperator.Execute()
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(p.Out, "upgrading %s...\n", opts.Name)
-	return p.CNAB.Upgrade(opts.ToActionArgs(deperator))
+	return p.CNAB.Execute(opts.ToActionArgs(deperator))
 }

--- a/pkg/runtime/actionInput.go
+++ b/pkg/runtime/actionInput.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ActionInput struct {
-	action manifest.Action
+	action string
 	Steps  []*manifest.Step `yaml:"steps"`
 }
 

--- a/pkg/runtime/actionInput_test.go
+++ b/pkg/runtime/actionInput_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"get.porter.sh/porter/pkg/manifest"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -19,7 +20,7 @@ func TestActionInput_MarshalYAML(t *testing.T) {
 	}
 
 	input := &ActionInput{
-		action: manifest.ActionInstall,
+		action: claim.ActionInstall,
 		Steps:  []*manifest.Step{s},
 	}
 

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -11,6 +11,7 @@ import (
 	"get.porter.sh/porter/pkg/manifest"
 	"github.com/cbroglie/mustache"
 	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-to-oci/relocation"
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -21,7 +22,7 @@ type RuntimeManifest struct {
 	*context.Context
 	*manifest.Manifest
 
-	Action manifest.Action
+	Action string
 
 	// bundles is map of the dependencies bundle definitions, keyed by the alias used in the root manifest
 	bundles map[string]bundle.Bundle
@@ -31,7 +32,7 @@ type RuntimeManifest struct {
 	sensitiveValues []string
 }
 
-func NewRuntimeManifest(cxt *context.Context, action manifest.Action, manifest *manifest.Manifest) *RuntimeManifest {
+func NewRuntimeManifest(cxt *context.Context, action string, manifest *manifest.Manifest) *RuntimeManifest {
 	return &RuntimeManifest{
 		Context:  cxt,
 		Action:   action,
@@ -142,11 +143,11 @@ func (m *RuntimeManifest) GetOutputs() map[string]string {
 
 func (m *RuntimeManifest) setStepsByAction() error {
 	switch m.Action {
-	case manifest.ActionInstall:
+	case claim.ActionInstall:
 		m.steps = m.Install
-	case manifest.ActionUninstall:
+	case claim.ActionUninstall:
 		m.steps = m.Uninstall
-	case manifest.ActionUpgrade:
+	case claim.ActionUpgrade:
 		m.steps = m.Upgrade
 	default:
 		customAction, ok := m.CustomActions[string(m.Action)]
@@ -265,7 +266,7 @@ func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 		depOutputs := make(map[string]interface{})
 		depBundle["outputs"] = depOutputs
 
-		if bun.Outputs == nil || m.Action == manifest.ActionUninstall {
+		if bun.Outputs == nil || m.Action == claim.ActionUninstall {
 			// uninstalls are done backwards, so we don't have outputs available from dependencies
 			// TODO: validate that they weren't trying to use them at build time so they don't find out at uninstall time
 			continue

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -10,6 +10,7 @@ import (
 	"get.porter.sh/porter/pkg/manifest"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-to-oci/relocation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,11 +29,11 @@ func TestResolveMapParam(t *testing.T) {
 			},
 			{
 				Name:    "place",
-				ApplyTo: []string{string(manifest.ActionInstall)},
+				ApplyTo: []string{claim.ActionInstall},
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	s := &manifest.Step{
 		Data: map[string]interface{}{
 			"description": "a test step",
@@ -77,7 +78,7 @@ func TestResolvePathParam(t *testing.T) {
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	s := &manifest.Step{
 		Data: map[string]interface{}{
 			"description": "a test step",
@@ -111,7 +112,7 @@ func TestMetadataAvailableForTemplating(t *testing.T) {
 
 	cxt.AddTestFile("testdata/metadata-substitution.yaml", config.Name)
 	m, _ := manifest.LoadManifestFrom(cxt.Context, config.Name)
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	before, _ := yaml.Marshal(m.Install[0])
 	t.Logf("Before:\n %s", before)
@@ -135,7 +136,7 @@ func TestDependencyMetadataAvailableForTemplating(t *testing.T) {
 
 	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "LoadManifestFrom failed")
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	rm.bundles = map[string]bundle.Bundle{
 		"mysql": {
 			Name:        "Azure MySQL",
@@ -165,7 +166,7 @@ func TestResolveMapParamUnknown(t *testing.T) {
 	m := &manifest.Manifest{
 		Parameters: []manifest.ParameterDefinition{},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	s := &manifest.Step{
 		Data: map[string]interface{}{
@@ -199,7 +200,7 @@ func TestPrepare_fileParam(t *testing.T) {
 			},
 			{
 				Name:    "upgrade-file-param",
-				ApplyTo: []string{string(manifest.ActionUpgrade)},
+				ApplyTo: []string{string(claim.ActionUpgrade)},
 				Destination: manifest.Location{
 					Path: "/cnab/app/upgrade",
 				},
@@ -209,7 +210,7 @@ func TestPrepare_fileParam(t *testing.T) {
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	s := &manifest.Step{
 		Data: map[string]interface{}{
 			"description": "a test step",
@@ -257,7 +258,7 @@ func TestResolveArrayUnknown(t *testing.T) {
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	s := &manifest.Step{
 		Data: map[string]interface{}{
@@ -285,7 +286,7 @@ func TestResolveArray(t *testing.T) {
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	s := &manifest.Step{
 		Data: map[string]interface{}{
@@ -321,7 +322,7 @@ func TestResolveSensitiveParameter(t *testing.T) {
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	s := &manifest.Step{
 		Data: map[string]interface{}{
@@ -361,7 +362,7 @@ func TestResolveCredential(t *testing.T) {
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	s := &manifest.Step{
 		Data: map[string]interface{}{
@@ -396,7 +397,7 @@ func TestResolveStepOutputs_Install_NoPreexistingClaiml(t *testing.T) {
 		},
 	}
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	rm.bundles = map[string]bundle.Bundle{
 		"dep": {
 			Outputs: map[string]bundle.Output{
@@ -443,7 +444,7 @@ func TestResolveInMainDict(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	installStep := rm.Install[0]
 
@@ -470,7 +471,7 @@ func TestResolveSliceWithAMap(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	installStep := rm.Install[0]
 
@@ -508,7 +509,7 @@ func TestResolveMissingStepOutputs(t *testing.T) {
 			s,
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	err := rm.ResolveStep(s)
 	require.Error(t, err)
@@ -541,7 +542,7 @@ func TestResolveDependencyParam(t *testing.T) {
 			s,
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	os.Setenv("DATABASE", "wordpress")
 	err := rm.ResolveStep(s)
@@ -579,7 +580,7 @@ func TestResolveMissingDependencyParam(t *testing.T) {
 			s,
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	os.Setenv("DATABASE", "wordpress")
 	err := rm.ResolveStep(s)
@@ -592,7 +593,7 @@ func TestManifest_ResolveBundleName(t *testing.T) {
 	m := &manifest.Manifest{
 		Name: "mybundle",
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	s := &manifest.Step{
 		Data: map[string]interface{}{
@@ -683,7 +684,7 @@ func TestManifest_ApplyStepOutputs(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 
 	depStep := rm.Install[0]
 	err = rm.ApplyStepOutputs(depStep, map[string]string{"foo": "bar"})
@@ -704,7 +705,7 @@ func TestManifest_ResolveImageMap(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	expectedImage, ok := m.ImageMap["something"]
 	require.True(t, ok, "couldn't get expected image")
 	expectedRef := fmt.Sprintf("%s@%s", expectedImage.Repository, expectedImage.Digest)
@@ -746,7 +747,7 @@ func TestManifest_ResolveImageMapMissingKey(t *testing.T) {
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	s := &manifest.Step{
 		Data: map[string]interface{}{
 			"description": "a test step exercising bundle image interpolation",
@@ -771,7 +772,7 @@ func TestManifest_ResolveImageMapMissingImage(t *testing.T) {
 			},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	s := &manifest.Step{
 		Data: map[string]interface{}{
 			"description": "a test step exercising bundle image interpolation",
@@ -913,7 +914,7 @@ func TestResolveImageWithUpdatedBundle(t *testing.T) {
 
 	reloMap := relocation.ImageRelocationMap{}
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	err := rm.ResolveImages(bun, reloMap)
 	assert.NoError(t, err)
 	mi := rm.ImageMap["machine"]
@@ -943,7 +944,7 @@ func TestResolveImageWithUpdatedMismatchedBundle(t *testing.T) {
 
 	reloMap := relocation.ImageRelocationMap{}
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	err := rm.ResolveImages(bun, reloMap)
 	assert.Error(t, err)
 	assert.EqualError(t, err, fmt.Sprintf("unable to find image in porter manifest: %s", "ghost"))
@@ -975,7 +976,7 @@ func TestResolveImageWithRelo(t *testing.T) {
 		"gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687": "my.registry/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
 	}
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	err := rm.ResolveImages(bun, reloMap)
 	assert.NoError(t, err)
 	mi := rm.ImageMap["machine"]
@@ -1007,7 +1008,7 @@ func TestResolveImageRelocationNoMatch(t *testing.T) {
 		"deislabs/nogood:latest": "cnabio/ghost:latest",
 	}
 
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	err := rm.ResolveImages(bun, reloMap)
 	assert.NoError(t, err)
 	assert.Equal(t, "deislabs/ghost", rm.ImageMap["machine"].Repository)
@@ -1024,7 +1025,7 @@ func TestResolveStepEncoding(t *testing.T) {
 			{Name: "test"},
 		},
 	}
-	rm := NewRuntimeManifest(cxt.Context, manifest.ActionInstall, m)
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	s := &manifest.Step{
 		Data: map[string]interface{}{
 			"description": "a test step",

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"get.porter.sh/porter/pkg/context"
 	"get.porter.sh/porter/pkg/manifest"
 	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +62,7 @@ BAZ`,
 func TestPorterRuntime_ApplyStepOutputsToBundle_None(t *testing.T) {
 	r := NewTestPorterRuntime(t)
 	m := &manifest.Manifest{Name: "mybun"}
-	r.RuntimeManifest = NewRuntimeManifest(r.Context, manifest.ActionInstall, m)
+	r.RuntimeManifest = NewRuntimeManifest(r.Context, claim.ActionInstall, m)
 
 	outputs := map[string]string{
 		"foo": "bar",
@@ -93,7 +94,7 @@ func TestPorterRuntime_ApplyStepOutputsToBundle_Some_Match(t *testing.T) {
 			},
 		},
 	}
-	r.RuntimeManifest = NewRuntimeManifest(r.Context, manifest.ActionInstall, m)
+	r.RuntimeManifest = NewRuntimeManifest(r.Context, claim.ActionInstall, m)
 
 	outputs := map[string]string{
 		"foo": "bar",
@@ -129,7 +130,7 @@ func TestPorterRuntime_ApplyStepOutputsToBundle_Some_NoMatch(t *testing.T) {
 			},
 		},
 	}
-	r.RuntimeManifest = NewRuntimeManifest(r.Context, manifest.ActionInstall, m)
+	r.RuntimeManifest = NewRuntimeManifest(r.Context, claim.ActionInstall, m)
 
 	outputs := map[string]string{
 		"foo": "bar",
@@ -170,7 +171,7 @@ func TestPorterRuntime_ApplyStepOutputsToBundle_ApplyTo_True(t *testing.T) {
 			},
 		},
 	}
-	r.RuntimeManifest = NewRuntimeManifest(r.Context, manifest.ActionInstall, m)
+	r.RuntimeManifest = NewRuntimeManifest(r.Context, claim.ActionInstall, m)
 
 	outputs := map[string]string{
 		"foo": "bar",
@@ -255,7 +256,7 @@ func TestPorterRuntime_ApplyUnboundBundleOutputs_File(t *testing.T) {
 					tc.def,
 				},
 			}
-			r.RuntimeManifest = NewRuntimeManifest(r.Context, manifest.ActionInstall, m)
+			r.RuntimeManifest = NewRuntimeManifest(r.Context, claim.ActionInstall, m)
 
 			_, err := r.FileSystem.Create(srcPath)
 			require.NoError(t, err)


### PR DESCRIPTION
# What does this change
Support the parameter source extension at runtime. See https://github.com/cnabio/cnab-spec/blob/master/810-well-known-custom-extensions.md#parameter-sources for the CNAB spec definition of how that extension works.

I decided that if we can't resolve the requested output, perhaps because the output wasn't generated, or the action it relies upon hasn't been run yet, we skip over it and let porter's general parameter resolution kick in. So if there's a default, that's applied, otherwise the user is told it's a required parameter that they need to set the value for.

# What issue does it fix
Closes #1066 

# Notes for the reviewer
* This doesn't support generating bundles with parameter-source extension data, just handles running bundles with it defined. That part comes next.
* I did some refactoring to prep for this change, so I recommend reviewing this commit by commit.

# Checklist
- [x] Unit Tests
- [x] Documentation - N/A
- [x] Schema (porter.yaml) - N/A
