### PR TITLE
feat(stamp.go): add image name to manifest digest

### DIFF
--- a/pkg/cnab/config-adapter/stamp.go
+++ b/pkg/cnab/config-adapter/stamp.go
@@ -102,6 +102,10 @@ func (c *ManifestConverter) DigestManifest() (string, error) {
 	v := pkg.Version
 	data = append(data, v...)
 
+	// Porter may update the invocation image name on-the-fly
+	// (for instance, during publish), so add this to the data
+	data = append(data, []byte(c.Manifest.Image)...)
+
 	for _, m := range c.Mixins {
 		data = append(append(data, m.Name...), m.Version...)
 	}

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -3,6 +3,7 @@ package configadapter
 import (
 	"testing"
 
+	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/manifest"
 
 	"get.porter.sh/porter/pkg/config"
@@ -11,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var simpleManifestDigest = "6154be0570d30a2b654d02258d9fa3004a72df9d5b70dafc0efce73c6818dc8f"
+var simpleManifestDigest = "a50e89710dfa2b30a999f8bb7b2801f0a2b97053eb368b01de448f71e712d0ae"
 
 func TestConfig_GenerateStamp(t *testing.T) {
 	c := config.NewTestConfig(t)
@@ -105,4 +106,37 @@ func TestStamp_DecodeManifest(t *testing.T) {
 		assert.Nil(t, data, "No manifest data should be returned")
 	})
 
+}
+
+func TestConfig_DigestManifest(t *testing.T) {
+	c := config.NewTestConfig(t)
+	c.TestContext.AddTestFile("../../manifest/testdata/simple.porter.yaml", config.Name)
+
+	t.Run("updated invocation image", func(t *testing.T) {
+		m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+		require.NoError(t, err, "could not load manifest")
+
+		a := NewManifestConverter(c.Context, m, nil, nil)
+		digest, err := a.DigestManifest()
+		require.NoError(t, err, "DigestManifest failed")
+
+		m.Image = "newpublishregistry/porter-hello:v0.1.0"
+		newDigest, err := a.DigestManifest()
+		require.NoError(t, err, "DigestManifest failed")
+		assert.NotEqual(t, newDigest, digest, "expected the digest to be different due to the updated image")
+	})
+
+	t.Run("updated version", func(t *testing.T) {
+		m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+		require.NoError(t, err, "could not load manifest")
+
+		a := NewManifestConverter(c.Context, m, nil, nil)
+		digest, err := a.DigestManifest()
+		require.NoError(t, err, "DigestManifest failed")
+
+		pkg.Version = "foo"
+		newDigest, err := a.DigestManifest()
+		require.NoError(t, err, "DigestManifest failed")
+		assert.NotEqual(t, newDigest, digest, "expected the digest to be different due to the updated pkg version")
+	})
 }

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -50,7 +50,7 @@ func TestPorter_buildBundle(t *testing.T) {
 
 	stamp, err := configadapter.LoadStamp(*bun)
 	require.NoError(t, err)
-	assert.Equal(t, "262ed16849e1b2321c26624224cb5666a80a60dc6c92a2e469c83b159537652b", stamp.ManifestDigest)
+	assert.Equal(t, "98132d568b085858935dae13910cae08fdf405e317482898ecff6631e042a8f5", stamp.ManifestDigest)
 
 	debugParam, ok := bun.Parameters["porter-debug"]
 	require.True(t, ok, "porter-debug parameter was not defined")


### PR DESCRIPTION
# What does this change
* Adds the in-memory manifest image name to the data to digest

A bit of a follow-up to https://github.com/deislabs/porter/pull/1127.  We now update the image name on-the-fly on `porter publish` if/when a different bundle tag is supplied.  However, to properly trigger a rebuild prior to publishing, we need to capture this update which doesn't exist in the manifest file itself (and won't be saved there, either).

# What issue does it fix
N/A; described above

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md