### PR TITLE
ref(*): remove invocation image from the Porter manifest

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -32,7 +32,6 @@ name: azure-wordpress
 description: Install Wordpress on Azure
 version: 0.1.0
 tag: getporter/azure-wordpress
-invocationImage: getporter/azure-wordpress-installer
 dockerfile: dockerfile.tmpl
 ```
 
@@ -40,12 +39,9 @@ dockerfile: dockerfile.tmpl
 * `description`: A description of the bundle
 * `version`: The version of the bundle, uses [semver](https://semver.org). Should not have a 'v' prefix.
 * `tag`: The tag to use when the bundle is published to a registry. The format is `REGISTRY/IMAGE`, or optionally `REGISTRY/IMAGE:TAG` 
-   if you do not want the default behavior of defaulting the docker image TAG portion to the version of the bundle.
-* `invocationImage`: OPTIONAL. The tag to use when the invocation image is built and published to a registry. The format is
-    `REGISTRY/IMAGE` or optionally `REGISTRY/IMAGE:TAG` if you do not want the default behavior of defaulting the docker image TAG 
-    portion to the version of the bundle. When omitted the `invocationImage` defaults to the value of `tag` with `-installer` suffixed. 
-    For example if the bundle `tag` is `getporter/porter-hello` and the `version` is `0.1.0`, then the `invocationImage` 
-    will default to `getporter/porter-hello-installer:v0.1.0`
+   if you do not want the default behavior of defaulting the docker image TAG portion to the version of the bundle. The invocation
+   image name will be based on this value.  For example, if the bundle `tag` is `getporter/porter-hello` and the `version` is `0.1.0`,
+   then the invocation image name will default to `getporter/porter-hello-installer:v0.1.0`
 * `dockerfile`: OPTIONAL. The relative path to a Dockerfile to use as a template during `porter build`. 
     See [Custom Dockerfile](/custom-dockerfile/) for details on how to use a custom Dockerfile.
 * `custom`: OPTIONAL. A map of [custom bundle metadata](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions).

--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -41,7 +41,7 @@ dockerfile: dockerfile.tmpl
 * `tag`: The tag to use when the bundle is published to a registry. The format is `REGISTRY/IMAGE`, or optionally `REGISTRY/IMAGE:TAG` 
    if you do not want the default behavior of defaulting the docker image TAG portion to the version of the bundle. The invocation
    image name will be based on this value.  For example, if the bundle `tag` is `getporter/porter-hello` and the `version` is `0.1.0`,
-   then the invocation image name will default to `getporter/porter-hello-installer:v0.1.0`
+   then the invocation image name will be `getporter/porter-hello-installer:v0.1.0`
 * `dockerfile`: OPTIONAL. The relative path to a Dockerfile to use as a template during `porter build`. 
     See [Custom Dockerfile](/custom-dockerfile/) for details on how to use a custom Dockerfile.
 * `custom`: OPTIONAL. A map of [custom bundle metadata](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions).

--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -65,7 +65,7 @@ uninstall:
 
 ```
 
-After the scaffolding is created, you may edit the _porter.yaml_ and modify the `tag: getporter/porter-hello:v0.1.0` element representing the bundle tag to include a Docker registry that you can push to. You may also uncomment and modify the `invocationImage: getporter/porter-hello:0.1.0` element representing the invocation image name to your liking. Note that the invocation image is not pushed during the `porter build` workflow.
+After the scaffolding is created, you may edit the _porter.yaml_ and modify the `tag: getporter/porter-hello:v0.1.0` element representing the bundle tag to include a Docker registry that you can push to. Note that the bundle is not pushed during the `porter build` workflow.
 
 Once you have modified the `porter.yaml`, you can run `porter build` to generate your first invocation image.  Here we add the `--verbose` flag to see all of the output:
 

--- a/docs/content/distribute-bundles.md
+++ b/docs/content/distribute-bundles.md
@@ -113,7 +113,6 @@ Consider the following example:
 name: spring-music
 version: 0.5.0
 description: "Run the Spring Music Service on Kubernetes and Digital Ocean PostgreSQL"
-invocationImage: jeremyrickard/porter-do:v0.5.0
 tag: jeremyrickard/porter-do-bundle:v0.5.0
 
 images:
@@ -136,7 +135,7 @@ Version: 0.5.0
 
 Invocation Images:
 Image                                            Type     Digest            Original Image
-jeremyrickard/porter-do-bundle@sha256:74b86...   docker   sha256:74b86...   jeremyrickard/porter-do:v0.5.0
+jeremyrickard/porter-do-bundle@sha256:74b86...   docker   sha256:74b86...   jeremyrickard/porter-do-bundle-installer:v0.5.0
 
 Images:
 Name           Type     Image                                            Digest            Original Image

--- a/docs/content/mixin-dev-guide/architecture.md
+++ b/docs/content/mixin-dev-guide/architecture.md
@@ -19,7 +19,7 @@ mixins:
 
 name: hello
 version: 0.1.0
-invocationImage: porter-hello:latest
+tag: porter-hello:v0.1.0
 
 install:
 - exec:

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -70,6 +70,8 @@ func TestConfig_LoadStamp_Invalid(t *testing.T) {
 }
 
 func TestStamp_DecodeManifest(t *testing.T) {
+	c := config.NewTestConfig(t)
+
 	t.Run("manifest populated", func(t *testing.T) {
 		s := Stamp{
 			EncodedManifest: "bmFtZTogaGVsbG8=", // name: hello
@@ -78,7 +80,7 @@ func TestStamp_DecodeManifest(t *testing.T) {
 		data, err := s.DecodeManifest()
 		require.NoError(t, err, "DecodeManifest failed")
 
-		m, err := manifest.UnmarshalManifest(data)
+		m, err := manifest.UnmarshalManifest(c.TestContext.Context, data)
 		require.NoError(t, err, "UnmarshalManifest failed")
 
 		require.NotNil(t, m, "expected manifest to be populated")

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -482,7 +482,7 @@ func (s *Step) GetMixinName() string {
 	return mixinName
 }
 
-func UnmarshalManifest(manifestData []byte) (*Manifest, error) {
+func UnmarshalManifest(cxt *context.Context, manifestData []byte) (*Manifest, error) {
 	// Unmarshal the manifest into the normal struct
 	manifest := &Manifest{}
 	err := yaml.Unmarshal(manifestData, &manifest)
@@ -515,9 +515,10 @@ func UnmarshalManifest(manifestData []byte) (*Manifest, error) {
 		if _, found := knownFields[key]; found {
 			delete(unmappedData, key)
 		}
-		// Explicitly error out if deprecated invocationImage is supplied
+		// Print deprecation notice for this field
 		if key == "invocationImage" {
-			return nil, errors.New("the invocationImage field has been deprecated and can no longer be user-specified")
+			fmt.Fprintln(cxt.Out, "WARNING: The invocationImage field has been deprecated and can no longer be user-specified; ignoring.")
+			delete(unmappedData, key)
 		}
 	}
 
@@ -643,7 +644,7 @@ func ReadManifest(cxt *context.Context, path string) (*Manifest, error) {
 		return nil, err
 	}
 
-	m, err := UnmarshalManifest(data)
+	m, err := UnmarshalManifest(cxt, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -47,14 +47,14 @@ func TestLoadManifest(t *testing.T) {
 	assert.Equal(t, "exec", mixin, "unexpected status step mixin")
 }
 
-func TestLoadManifest_VerifyImageNotSpecifiable(t *testing.T) {
+func TestLoadManifest_DeprecatedFields(t *testing.T) {
 	cxt := context.NewTestContext(t)
 
 	cxt.AddTestFile("testdata/porter-with-image.yaml", config.Name)
 
 	m, err := LoadManifestFrom(cxt.Context, config.Name)
-	require.EqualError(t, err, "the invocationImage field has been deprecated and can no longer be user-specified")
-	require.Nil(t, m, "manifest wasn't nil")
+	require.NoError(t, err, "expected no error")
+	require.NotNil(t, m, "manifest was nil")
 }
 
 func TestLoadManifestWithDependencies(t *testing.T) {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -21,6 +21,11 @@ func TestLoadManifest(t *testing.T) {
 	require.NoError(t, err, "could not load manifest")
 
 	require.NotNil(t, m, "manifest was nil")
+	require.Equal(t, m.Name, "hello", "manifest has incorrect name")
+	require.Equal(t, m.Description, "An example Porter configuration", "manifest has incorrect description")
+	require.Equal(t, m.Version, "0.1.0", "manifest has incorrect version")
+	require.Equal(t, m.BundleTag, "getporter/porter-hello:v0.1.0", "manifest has incorrect bundle tag")
+
 	assert.Equal(t, []MixinDeclaration{{Name: "exec"}}, m.Mixins, "expected manifest to declare the exec mixin")
 	require.Len(t, m.Install, 1, "expected 1 install step")
 
@@ -40,6 +45,16 @@ func TestLoadManifest(t *testing.T) {
 
 	mixin = statusStep.GetMixinName()
 	assert.Equal(t, "exec", mixin, "unexpected status step mixin")
+}
+
+func TestLoadManifest_VerifyImageNotSpecifiable(t *testing.T) {
+	cxt := context.NewTestContext(t)
+
+	cxt.AddTestFile("testdata/porter-with-image.yaml", config.Name)
+
+	m, err := LoadManifestFrom(cxt.Context, config.Name)
+	require.EqualError(t, err, "the invocationImage field has been deprecated and can no longer be user-specified")
+	require.Nil(t, m, "manifest wasn't nil")
 }
 
 func TestLoadManifestWithDependencies(t *testing.T) {
@@ -134,7 +149,7 @@ func TestManifest_Validate_Dockerfile(t *testing.T) {
 
 func TestReadManifest_URL(t *testing.T) {
 	cxt := context.NewTestContext(t)
-	url := "https://raw.githubusercontent.com/deislabs/porter/v0.17.0-beta.1/pkg/config/testdata/simple.porter.yaml"
+	url := "https://raw.githubusercontent.com/deislabs/porter/v0.27.1/pkg/manifest/testdata/simple.porter.yaml"
 	m, err := ReadManifest(cxt.Context, url)
 
 	require.NoError(t, err)
@@ -159,31 +174,7 @@ func TestReadManifest_File(t *testing.T) {
 }
 
 func TestSetDefault(t *testing.T) {
-	t.Run("bundle and invocation image tags set", func(t *testing.T) {
-		m := Manifest{
-			Version:   "1.2.3-beta.1",
-			BundleTag: "getporter/mybun:v1.2.3",
-			Image:     "getporter/mybun-some-installer:v1.2.3-beta.1",
-		}
-		err := m.SetDefaults()
-		require.NoError(t, err)
-		assert.Equal(t, "getporter/mybun:v1.2.3", m.BundleTag)
-		assert.Equal(t, "getporter/mybun-some-installer:v1.2.3-beta.1", m.Image)
-	})
-
-	t.Run("invocation image missing docker tag", func(t *testing.T) {
-		m := Manifest{
-			Version:   "1.2.3-beta.1",
-			BundleTag: "getporter/mybun:v1.2.3",
-			Image:     "getporter/mybun-some-installer",
-		}
-		err := m.SetDefaults()
-		require.NoError(t, err)
-		assert.Equal(t, "getporter/mybun:v1.2.3", m.BundleTag)
-		assert.Equal(t, "getporter/mybun-some-installer:v1.2.3", m.Image)
-	})
-
-	t.Run("invocation image missing", func(t *testing.T) {
+	t.Run("bundle docker tag set", func(t *testing.T) {
 		m := Manifest{
 			Version:   "1.2.3-beta.1",
 			BundleTag: "getporter/mybun:v1.2.3",
@@ -205,7 +196,7 @@ func TestSetDefault(t *testing.T) {
 		assert.Equal(t, "getporter/mybun-installer:v1.2.3-beta.1", m.Image)
 	})
 
-	t.Run("missing invocation image; tag includes registry with port", func(t *testing.T) {
+	t.Run("bundle tag includes registry with port", func(t *testing.T) {
 		m := Manifest{
 			Version:   "0.1.0",
 			BundleTag: "localhost:5000/missing-invocation-image",
@@ -402,30 +393,4 @@ func TestLoadManifestWithRequiredExtensions(t *testing.T) {
 
 	assert.NotNil(t, m)
 	assert.Equal(t, expected, m.Required)
-}
-
-func TestSetInvocationImageFromBundleTag(t *testing.T) {
-	t.Run("with image override", func(t *testing.T) {
-		m := Manifest{
-			Version:   "1.2.3-beta.1",
-			BundleTag: "getporter/mybun:v1.2.3",
-			Image:     "portersh/mybun-some-installer:v1.2.3-beta.1",
-		}
-		err := m.SetInvocationImageFromBundleTag(m.BundleTag, true)
-		require.NoError(t, err)
-		assert.Equal(t, "getporter/mybun:v1.2.3", m.BundleTag)
-		assert.Equal(t, "getporter/mybun-installer:v1.2.3", m.Image)
-	})
-
-	t.Run("without image override", func(t *testing.T) {
-		m := Manifest{
-			Version:   "1.2.3-beta.1",
-			BundleTag: "getporter/mybun:v1.2.3",
-			Image:     "portersh/mybun-some-installer:v1.2.3-beta.1",
-		}
-		err := m.SetInvocationImageFromBundleTag(m.BundleTag, false)
-		require.NoError(t, err)
-		assert.Equal(t, "getporter/mybun:v1.2.3", m.BundleTag)
-		assert.Equal(t, "portersh/mybun-some-installer:v1.2.3-beta.1", m.Image)
-	})
 }

--- a/pkg/manifest/testdata/porter-with-image.yaml
+++ b/pkg/manifest/testdata/porter-with-image.yaml
@@ -1,0 +1,29 @@
+mixins:
+- exec
+
+name: hello
+description: "An example Porter configuration"
+version: 0.1.0
+tag: getporter/porter-hello:v0.1.0
+invocationImage: getporter/porter-hello-invocation-image.v0.1.0
+
+install:
+- exec:
+    description: "Say Hello"
+    command: bash
+    flags:
+      c: echo Hello World
+
+status:
+- exec:
+    description: "Get World Status"
+    command: bash
+    flags:
+        c: echo The world is on fire
+
+uninstall:
+- exec:
+    description: "Say Goodbye"
+    command: bash
+    flags:
+        c: echo Goodbye World

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -85,7 +85,7 @@ func (p *Porter) publishFromFile(opts PublishOptions) error {
 	if tag != "" {
 		// If tag was supplied, update the invocation image name on the manifest
 		// per the registry, org and docker tag from the value provided
-		if err := p.Manifest.SetInvocationImageFromBundleTag(tag, true); err != nil {
+		if err := p.Manifest.SetInvocationImageFromBundleTag(tag); err != nil {
 			return errors.Wrapf(err, "unable to set invocation image name from tag %q", tag)
 		}
 	} else {

--- a/pkg/porter/testdata/porter.yaml
+++ b/pkg/porter/testdata/porter.yaml
@@ -2,7 +2,6 @@ name: HELLO_CUSTOM
 version: 0.1.0
 description: "A bundle with a custom action"
 tag: getporter/porter-hello:v0.1.0
-invocationImage: getporter/porter-hello-installer:0.1.0
 
 credentials:
   - name: my-first-cred

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -388,10 +388,6 @@
       },
       "type": "array"
     },
-    "invocationImage": {
-      "description": "The name of the container image to tag the invocation image with when it is built",
-      "type": "string"
-    },
     "mixins": {
       "items": {
         "enum": [

--- a/pkg/templates/templates/schema.json
+++ b/pkg/templates/templates/schema.json
@@ -193,10 +193,6 @@
         "anyOf": []
       }
     },
-    "invocationImage": {
-      "type": "string",
-      "description": "The name of the container image to tag the invocation image with when it is built"
-    },
     "tag": {
       "type": "string",
       "description": "The tag to use when the bundle is published to an OCI registry"


### PR DESCRIPTION

# What does this change
* Removes ability to specify an invocation image name in the Porter manifest

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/1132

# Notes for the reviewer

A couple questions:
 - The current approach explicitly errors out if the `invocationImage` is present in the manifest.  What do we think?
 - Did I visit all of the known places where logic can be simplified now that this value can't be user-specified?

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md