### PR TITLE
fix(build): update azure pipelines to call integration test script

### DIFF
--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -91,10 +91,7 @@ jobs:
     workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Build'
 
-  - script: |
-      trap 'make -f Makefile.kind delete-kind-cluster' EXIT
-      make -f Makefile.kind install-kind create-kind-cluster
-      make start-local-docker-registry test-integration stop-local-docker-registry
+  - script: ./build/run-integration-tests.sh
     workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Integration Test'
 

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -42,10 +42,7 @@ stages:
     - script: build/azure-pipelines.setup-go-workspace.sh
       displayName: 'Set up the Go workspace'
 
-    - script: |
-        trap 'make -f Makefile.kind delete-kind-cluster' EXIT
-        make -f Makefile.kind install-kind create-kind-cluster
-        make start-local-docker-registry test-integration stop-local-docker-registry
+    - script: ./build/run-integration-tests.sh
       workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'Integration Test'
 

--- a/build/run-integration-tests.sh
+++ b/build/run-integration-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+trap 'make -f Makefile.kind delete-kind-cluster' EXIT
+make -f Makefile.kind install-kind create-kind-cluster
+make start-local-docker-registry test-integration stop-local-docker-registry


### PR DESCRIPTION

# What does this change

* Updates the test-integration steps in corresponding azure pipelines to call out to script

Follow up to https://github.com/deislabs/porter/pull/1138, per https://github.com/deislabs/porter/pull/1138/files#r456589804

# What issue does it fix

# Notes for the reviewer

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md