### PR TITLE
Add suffix arguments to exec mixin

### DIFF
--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -29,6 +29,8 @@ exec:
     repeated-flag:
     - flag-value1
     - flag-value2
+  suffix-arguments:
+  - suffix-arg1
   suppress-output: false
   outputs:
   - name: NAME
@@ -42,7 +44,7 @@ exec:
 This is executed as:
 
 ```
-$ cmd arg1 arg2 -a flag-value --long-flag true --repeated-flag flag-value1 --repeated-flag flag-value2
+$ cmd arg1 arg2 -a flag-value --long-flag true --repeated-flag flag-value1 --repeated-flag flag-value2 suffix-arg1
 ```
 
 ### Suppress Output

--- a/pkg/exec/action.go
+++ b/pkg/exec/action.go
@@ -88,6 +88,7 @@ func (a *Actions) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+var _ builder.HasOrderedArguments = Step{}
 var _ builder.ExecutableStep = Step{}
 var _ builder.StepWithOutputs = Step{}
 
@@ -96,12 +97,13 @@ type Step struct {
 }
 
 type Instruction struct {
-	Description    string        `yaml:"description"`
-	Command        string        `yaml:"command"`
-	Arguments      []string      `yaml:"arguments,omitempty"`
-	Flags          builder.Flags `yaml:"flags,omitempty"`
-	Outputs        []Output      `yaml:"outputs,omitempty"`
-	SuppressOutput bool          `yaml:"suppress-output,omitempty"`
+	Description     string        `yaml:"description"`
+	Command         string        `yaml:"command"`
+	Arguments       []string      `yaml:"arguments,omitempty"`
+	SuffixArguments []string      `yaml:"suffix-arguments,omitempty"`
+	Flags           builder.Flags `yaml:"flags,omitempty"`
+	Outputs         []Output      `yaml:"outputs,omitempty"`
+	SuppressOutput  bool          `yaml:"suppress-output,omitempty"`
 }
 
 func (s Step) GetCommand() string {
@@ -110,6 +112,10 @@ func (s Step) GetCommand() string {
 
 func (s Step) GetArguments() []string {
 	return s.Arguments
+}
+
+func (s Step) GetSuffixArguments() []string {
+	return s.SuffixArguments
 }
 
 func (s Step) GetFlags() builder.Flags {

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -117,3 +117,21 @@ func TestMixin_Uninstall(t *testing.T) {
 	step := action.Steps[0]
 	assert.Equal(t, "bash", step.Instruction.Command)
 }
+
+func TestMixin_SuffixArgs(t *testing.T) {
+	os.Setenv(test.ExpectedCommandEnv, `docker build --tag getporter/porter-hello:latest .`)
+	defer os.Unsetenv(test.ExpectedCommandEnv)
+
+	b, err := ioutil.ReadFile("testdata/suffix-args-input.yaml")
+	require.NoError(t, err, "ReadFile failed")
+
+	var action Action
+	err = yaml.Unmarshal(b, &action)
+	require.NoError(t, err, "Unmarshal failed")
+
+	h := NewTestMixin(t)
+	h.In = bytes.NewReader(b)
+
+	err = h.Execute(ExecuteOptions{})
+	require.NoError(t, err)
+}

--- a/pkg/exec/schema/exec.json
+++ b/pkg/exec/schema/exec.json
@@ -64,6 +64,13 @@
             "type": "string"
           }
         },
+        "suffix-arguments": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minItems": 1
+          }
+        },
         "outputs": {
           "type": "array",
           "items": {

--- a/pkg/exec/testdata/suffix-args-input.yaml
+++ b/pkg/exec/testdata/suffix-args-input.yaml
@@ -1,0 +1,10 @@
+install:
+  - exec:
+      description: "Build a docker image"
+      command: docker
+      arguments:
+        - build
+      flags:
+        tag: "getporter/porter-hello:latest"
+      suffix-arguments:
+        - .

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -264,6 +264,13 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "suffix-arguments": {
+            "items": {
+              "minItems": 1,
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "required": [


### PR DESCRIPTION
# What does this change
Implement the HasOrderedArguments interface on the exec mixin supporting @Nunix's scenario of using suffix arguments with the exec mixin.

example:

```yaml
install:
  - exec:
      description: "Run uname via ssh"
      command: ssh
      arguments:
        - somehost
      flags:
        l: username
        p: port
      suffix-arguments:
        - uname
```

# What issue does it fix
Closes #806

# Notes for the reviewer
NA

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml)
