### PR TITLE
Show installation history

### DIFF
--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -67,7 +67,7 @@ Optional output formats include json and yaml.
 			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ShowInstallations(opts)
+			return p.ShowInstallation(opts)
 		},
 	}
 

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -26,6 +26,7 @@ type DisplayInstallation struct {
 	Status   string
 
 	Outputs DisplayOutputs
+	History []InstallationAction
 }
 
 func NewDisplayInstallation(installation claim.Installation) (DisplayInstallation, error) {
@@ -42,12 +43,22 @@ func NewDisplayInstallation(installation claim.Installation) (DisplayInstallatio
 		installTime = c.Created
 	}
 
+	history := make([]InstallationAction, len(installation.Claims))
+	for i, hc := range installation.Claims {
+		history[i] = InstallationAction{
+			Action:    hc.Action,
+			Timestamp: hc.Created,
+			Status:    hc.GetStatus(),
+		}
+	}
+
 	return DisplayInstallation{
 		Name:     installation.Name,
 		Created:  installTime,
 		Modified: c.Created,
 		Action:   c.Action,
 		Status:   installation.GetLastStatus(),
+		History:  history,
 	}, nil
 }
 
@@ -63,6 +74,12 @@ func (l DisplayInstallations) Swap(i, j int) {
 
 func (l DisplayInstallations) Less(i, j int) bool {
 	return l[i].Modified.Before(l[j].Modified)
+}
+
+type InstallationAction struct {
+	Action    string
+	Timestamp time.Time
+	Status    string
 }
 
 // ListInstallations lists installed bundles by their claims.

--- a/pkg/printer/table.go
+++ b/pkg/printer/table.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"text/tabwriter"
 
+	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 )
 
@@ -41,4 +42,34 @@ func tabify(untabified []interface{}) []interface{} {
 		}
 	}
 	return tabified
+}
+
+func NewTableSection(out io.Writer) *tablewriter.Table {
+	table := tablewriter.NewWriter(out)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetBorders(tablewriter.Border{Left: false, Right: false, Bottom: false, Top: true})
+	table.SetAutoFormatHeaders(false)
+	return table
+}
+
+func PrintTableSection(out io.Writer, v interface{}, getRow func(row interface{}) []string, headers ...string) error {
+	if reflect.TypeOf(v).Kind() != reflect.Slice {
+		return errors.Errorf("invalid data passed to PrintTableSection, must be a slice but got %T", v)
+	}
+
+	rows := reflect.ValueOf(v)
+
+	table := NewTableSection(out)
+
+	// Print the outputs table
+	table.SetHeader(headers)
+	for i := 0; i < rows.Len(); i++ {
+		table.Append(getRow(rows.Index(i).Interface()))
+	}
+
+	table.Render()
+	return nil
 }


### PR DESCRIPTION
# What does this change
* Show installation history
  Print out the history of what has happened to a bundle installation, instead of just the last action when you run `porter show`. I've added a new printer method that prints out a table section and I'll follow up and redo other sections so that they use it too.
*  Hold open plugin connection during schema migration
    Make sure we don't open/close the plugin connection during the schema migration check. Then Bubble through the Connect call to the wrapped backing store.

# What issue does it fix
Closes #1064

# Notes for the reviewer
I removed the "last action" and "last status" from the show fields since we now display that data in the History table.

# Checklist
- [x] Unit Tests
- [x] Documentation - NA
- [x] Schema (porter.yaml) - NA
