### PR TITLE
Hold open plugin connection during schema migration

### DIFF
--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -40,7 +40,7 @@ Optional output formats include json and yaml.`,
 			return opts.ParseFormat()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListInstallations(opts)
+			return p.PrintInstallations(opts)
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,19 @@ module get.porter.sh/porter
 
 go 1.13
 
-replace github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
+replace (
+	// https://github.com/cnabio/cnab-go/pull/225
+	github.com/cnabio/cnab-go => github.com/carolynvs/cnab-go v0.12.1-beta1.0.20200721195107-a83b6fd3ce7a
 
-replace golang.org/x/sys => golang.org/x/sys v0.0.0-20190830141801-acfa387b8d69
+	// See https://github.com/containerd/containerd/issues/3031
+	// When I try to just use the require, go is shortening it to v2.7.1+incompatible which then fails to build...
+	github.com/docker/distribution => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
+	github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
 
-replace github.com/hashicorp/go-plugin => github.com/carolynvs/go-plugin v1.0.1-acceptstdin
+	github.com/hashicorp/go-plugin => github.com/carolynvs/go-plugin v1.0.1-acceptstdin
 
-// See https://github.com/containerd/containerd/issues/3031
-// When I try to just use the require, go is shortening it to v2.7.1+incompatible which then fails to build...
-replace github.com/docker/distribution => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
+	golang.org/x/sys => golang.org/x/sys v0.0.0-20190830141801-acfa387b8d69
+)
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -20,6 +24,7 @@ require (
 	github.com/cbroglie/mustache v1.0.1
 	github.com/cnabio/cnab-go v0.13.0-beta1
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
+	github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 // indirect
 	github.com/containerd/containerd v1.3.0
 	github.com/containerd/continuity v0.0.0-20200228182428-0f16d7a0959c // indirect
 	github.com/containerd/fifo v0.0.0-20191213151349-ff969a566b00 // indirect

--- a/pkg/claims/claimStorage.go
+++ b/pkg/claims/claimStorage.go
@@ -4,6 +4,7 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/storage/pluginstore"
 	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/utils/crud"
 )
 
 var _ claim.Provider = &ClaimStorage{}
@@ -19,6 +20,6 @@ func NewClaimStorage(c *config.Config, storagePlugin *pluginstore.Store) *ClaimS
 	migration := newMigrateClaimsWrapper(c.Context, storagePlugin)
 	return &ClaimStorage{
 		Config: c,
-		Store:  claim.NewClaimStore(migration, nil, nil),
+		Store:  claim.NewClaimStore(crud.NewBackingStore(migration), nil, nil),
 	}
 }

--- a/pkg/claims/helpers.go
+++ b/pkg/claims/helpers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/claim"
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,10 +16,9 @@ type TestClaimProvider struct {
 }
 
 func NewTestClaimProvider(t *testing.T) TestClaimProvider {
-	crud := crud.NewMockStore()
 	return TestClaimProvider{
 		t:     t,
-		Store: claim.NewClaimStore(crud, nil, nil),
+		Store: claim.NewMockStore(nil, nil),
 	}
 }
 

--- a/pkg/claims/migrateClaimsWrapper.go
+++ b/pkg/claims/migrateClaimsWrapper.go
@@ -36,7 +36,7 @@ type migrateClaimsWrapper struct {
 	schemaChecked bool
 	schema        storage.Schema
 	*context.Context
-	crud.BackingStore
+	*crud.BackingStore
 	claims claim.Store
 }
 
@@ -44,7 +44,7 @@ func newMigrateClaimsWrapper(cxt *context.Context, wrappedStore crud.Store) *mig
 	backingStore := crud.NewBackingStore(wrappedStore)
 	return &migrateClaimsWrapper{
 		Context:      cxt,
-		BackingStore: *backingStore,
+		BackingStore: backingStore,
 		claims:       claim.NewClaimStore(backingStore, nil, nil),
 	}
 }

--- a/pkg/claims/migrateClaimsWrapper.go
+++ b/pkg/claims/migrateClaimsWrapper.go
@@ -36,24 +36,29 @@ type migrateClaimsWrapper struct {
 	schemaChecked bool
 	schema        storage.Schema
 	*context.Context
-	crud.Store
+	crud.BackingStore
 	claims claim.Store
 }
 
 func newMigrateClaimsWrapper(cxt *context.Context, wrappedStore crud.Store) *migrateClaimsWrapper {
 	backingStore := crud.NewBackingStore(wrappedStore)
 	return &migrateClaimsWrapper{
-		Context: cxt,
-		Store:   backingStore,
-		claims:  claim.NewClaimStore(backingStore, nil, nil),
+		Context:      cxt,
+		BackingStore: *backingStore,
+		claims:       claim.NewClaimStore(backingStore, nil, nil),
 	}
 }
 
 func (w *migrateClaimsWrapper) Connect() error {
+	err := w.BackingStore.Connect()
+	if err != nil {
+		return err
+	}
+
 	migrate := false
 	if !w.schemaChecked {
-		w.schemaChecked = true
-		b, err := w.Store.Read("", "schema")
+		w.AutoClose = false
+		b, err := w.BackingStore.Read("", "schema")
 		if err != nil {
 			if strings.Contains(err.Error(), crud.ErrRecordDoesNotExist.Error()) {
 				// Do a migration if we don't have a schema for the current storage layout
@@ -75,6 +80,8 @@ func (w *migrateClaimsWrapper) Connect() error {
 				return err
 			}
 		}
+		w.schemaChecked = true
+		w.AutoClose = true
 	}
 
 	return nil
@@ -83,7 +90,7 @@ func (w *migrateClaimsWrapper) Connect() error {
 func (w *migrateClaimsWrapper) MigrateAll() error {
 	fmt.Fprint(w.Err, "!!! Migrating claims data to match the CNAB Claim spec https://cdn.cnab.io/schema/cnab-claim-1.0.0-DRAFT+b5ed2f3/claim.schema.json. This is a one-way migration !!!\n")
 
-	installationNames, err := w.Store.List(claim.ItemTypeClaims, "")
+	installationNames, err := w.BackingStore.List(claim.ItemTypeClaims, "")
 	if err != nil {
 		return errors.Wrapf(err, "!!! Migration failed, unable to list installation names")
 	}
@@ -114,7 +121,7 @@ func (w *migrateClaimsWrapper) MigrateAll() error {
 func (w *migrateClaimsWrapper) MigrateInstallation(name string) error {
 	fmt.Fprintf(w.Err, " - Migrating claim %s to the new claim layout...\n", name)
 
-	oldClaimData, err := w.Store.Read(claim.ItemTypeClaims, name)
+	oldClaimData, err := w.BackingStore.Read(claim.ItemTypeClaims, name)
 	if err != nil {
 		return errors.Wrap(err, "could not read claim file")
 	}

--- a/pkg/claims/migrateClaimsWrapper_test.go
+++ b/pkg/claims/migrateClaimsWrapper_test.go
@@ -100,6 +100,28 @@ func TestMigrateClaimsWrapper_List(t *testing.T) {
 	assert.Equal(t, []string{"example-exec-outputs", "mybun"}, names, "unexpected list of installation names")
 }
 
+func TestMigrateClaimsWrapper_Read(t *testing.T) {
+	config := config.NewTestConfig(t)
+	home := config.TestContext.UseFilesystem()
+	config.SetHomeDir(home)
+	defer config.TestContext.Cleanup()
+
+	claimsDir := filepath.Join(home, "claims")
+	config.FileSystem.Mkdir(claimsDir, 0755)
+	config.TestContext.AddTestFile("testdata/installed.json", filepath.Join(claimsDir, "installed.json"))
+	config.TestContext.AddTestFile("testdata/has-installation.json", filepath.Join(claimsDir, "has-installation.json"))
+
+	dataStore := filesystem.NewStore(*config.Config, hclog.NewNullLogger())
+	wrapper := newMigrateClaimsWrapper(config.Context, dataStore)
+	claimStore := claim.NewClaimStore(crud.NewBackingStore(wrapper), nil, nil)
+
+	// Validate that we can migrate and read in the same operation
+	i, err := claimStore.ReadInstallation("mybun")
+	require.NoError(t, err, "ReadInstallation failed")
+	assert.Equal(t, "mybun", i.Name)
+	assert.Equal(t, claim.StatusSucceeded, i.GetLastStatus())
+}
+
 func TestMigrateClaimsWrapper_MigrateInstall(t *testing.T) {
 	config := config.NewTestConfig(t)
 	home := config.TestContext.UseFilesystem()

--- a/pkg/claims/migrateClaimsWrapper_test.go
+++ b/pkg/claims/migrateClaimsWrapper_test.go
@@ -8,6 +8,7 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/storage/filesystem"
 	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,7 +39,7 @@ func TestMigrateClaimsWrapper_MigrateInstallation(t *testing.T) {
 
 			dataStore := filesystem.NewStore(*config.Config, hclog.NewNullLogger())
 			wrapper := newMigrateClaimsWrapper(config.Context, dataStore)
-			claimStore := claim.NewClaimStore(wrapper, nil, nil)
+			claimStore := claim.NewClaimStore(crud.NewBackingStore(wrapper), nil, nil)
 
 			c, err := claimStore.ReadLastClaim(installation)
 			require.NoError(t, err, "could not read claim")
@@ -69,7 +70,7 @@ func TestMigrateClaimsWrapper_MigrateInstallation(t *testing.T) {
 
 		dataStore := filesystem.NewStore(*config.Config, hclog.NewNullLogger())
 		wrapper := newMigrateClaimsWrapper(config.Context, dataStore)
-		claimStore := claim.NewClaimStore(wrapper, nil, nil)
+		claimStore := claim.NewClaimStore(crud.NewBackingStore(wrapper), nil, nil)
 
 		c, err := claimStore.ReadLastClaim(installation)
 		require.NoError(t, err, "could not read claim")
@@ -92,7 +93,7 @@ func TestMigrateClaimsWrapper_List(t *testing.T) {
 
 	dataStore := filesystem.NewStore(*config.Config, hclog.NewNullLogger())
 	wrapper := newMigrateClaimsWrapper(config.Context, dataStore)
-	claimStore := claim.NewClaimStore(wrapper, nil, nil)
+	claimStore := claim.NewClaimStore(crud.NewBackingStore(wrapper), nil, nil)
 
 	names, err := claimStore.ListInstallations()
 	sort.Strings(names)
@@ -130,7 +131,7 @@ func TestMigrateClaimsWrapper_MigrateInstall(t *testing.T) {
 
 	dataStore := filesystem.NewStore(*config.Config, hclog.NewNullLogger())
 	wrapper := newMigrateClaimsWrapper(config.Context, dataStore)
-	claimStore := claim.NewClaimStore(wrapper, nil, nil)
+	claimStore := claim.NewClaimStore(crud.NewBackingStore(wrapper), nil, nil)
 
 	claimsDir := filepath.Join(home, "claims")
 	config.FileSystem.Mkdir(claimsDir, 0755)
@@ -161,7 +162,7 @@ func TestMigrateClaimsWrapper_MigrateUpgrade(t *testing.T) {
 
 	dataStore := filesystem.NewStore(*config.Config, hclog.NewNullLogger())
 	wrapper := newMigrateClaimsWrapper(config.Context, dataStore)
-	claimStore := claim.NewClaimStore(wrapper, nil, nil)
+	claimStore := claim.NewClaimStore(crud.NewBackingStore(wrapper), nil, nil)
 
 	claimsDir := filepath.Join(home, "claims")
 	config.FileSystem.Mkdir(claimsDir, 0755)

--- a/pkg/credentials/credentialStorage.go
+++ b/pkg/credentials/credentialStorage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cnabio/cnab-go/credentials"
 	cnabsecrets "github.com/cnabio/cnab-go/secrets"
 	"github.com/cnabio/cnab-go/secrets/host"
+	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/cnabio/cnab-go/valuesource"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -30,8 +31,8 @@ type CredentialStorage struct {
 }
 
 func NewCredentialStorage(c *config.Config, storagePlugin *crudplugins.Store) *CredentialStorage {
-	//migration := newMigrateCredentialsWrapper(c, storagePlugin)
-	credStore := credentials.NewCredentialStore(storagePlugin)
+	backingStore := crud.NewBackingStore(storagePlugin)
+	credStore := credentials.NewCredentialStore(backingStore)
 	return &CredentialStorage{
 		Config:           c,
 		CredentialsStore: &credStore,

--- a/pkg/credentials/helpers.go
+++ b/pkg/credentials/helpers.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cnabio/cnab-go/utils/crud"
-
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/secrets"
 	inmemorysecrets "get.porter.sh/porter/pkg/secrets/in-memory"
@@ -26,8 +24,7 @@ type TestCredentialProvider struct {
 
 func NewTestCredentialProvider(t *testing.T, tc *config.TestConfig) TestCredentialProvider {
 	backingSecrets := inmemorysecrets.NewStore()
-	backingCreds := crud.NewMockStore()
-	credStore := credentials.NewCredentialStore(backingCreds)
+	credStore := credentials.NewMockStore()
 	return TestCredentialProvider{
 		T:           t,
 		TestConfig:  tc,

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -186,7 +186,7 @@ func TestGenerateNoCredentialDirectory(t *testing.T) {
 
 	// Write credentials to the real file system for this test, not sure if this test is worth keeping
 	fsStore := crud.NewFileSystemStore(home, claim.NewClaimStoreFileExtensions())
-	credStore := credentials.NewCredentialStore(fsStore)
+	credStore := credentials.NewCredentialStore(crud.NewBackingStore(fsStore))
 	p.TestCredentials.CredentialStorage.CredentialsStore = &credStore
 
 	p.TestConfig.SetupPorterHome()

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -103,6 +103,14 @@ func (p *TestPorter) SetupIntegrationTest() {
 	require.NoError(t, err, "could not save test credentials")
 }
 
+func (p *TestPorter) AddTestFile(src string, dest string) {
+	if !filepath.IsAbs(src) {
+		src = filepath.Join(p.TestDir, src)
+	}
+
+	p.TestConfig.TestContext.AddTestFile(src, dest)
+}
+
 func (p *TestPorter) CreateBundleDir() string {
 	bundleDir, err := ioutil.TempDir("", "bundle")
 	require.NoError(p.T(), err)

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -82,28 +82,38 @@ type InstallationAction struct {
 	Status    string
 }
 
-// ListInstallations lists installed bundles by their claims.
-func (p *Porter) ListInstallations(opts ListOptions) error {
+// ListInstallations lists installed bundles.
+func (p *Porter) ListInstallations() (DisplayInstallations, error) {
 	installations, err := p.Claims.ReadAllInstallationStatus()
 	if err != nil {
-		return errors.Wrap(err, "could not list installations")
+		return nil, errors.Wrap(err, "could not list installations")
 	}
 
 	var displayInstallations DisplayInstallations
 	for _, installation := range installations {
 		displayInstallation, err := NewDisplayInstallation(installation)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		displayInstallations = append(displayInstallations, displayInstallation)
 	}
 	sort.Sort(sort.Reverse(displayInstallations))
 
+	return displayInstallations, nil
+}
+
+// PrintInstallations prints installed bundles.
+func (p *Porter) PrintInstallations(opts ListOptions) error {
+	displayInstallations, err := p.ListInstallations()
+	if err != nil {
+		return err
+	}
+
 	switch opts.Format {
 	case printer.FormatJson:
-		return printer.PrintJson(p.Out, installations)
+		return printer.PrintJson(p.Out, displayInstallations)
 	case printer.FormatYaml:
-		return printer.PrintYaml(p.Out, installations)
+		return printer.PrintYaml(p.Out, displayInstallations)
 	case printer.FormatTable:
 		// have every row use the same "now" starting ... NOW!
 		now := time.Now()

--- a/tests/claim_migration_test.go
+++ b/tests/claim_migration_test.go
@@ -1,0 +1,40 @@
+// +build integration
+
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"get.porter.sh/porter/pkg/porter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Do a transparent migration. This also checks for any problems with our
+// connection handling which can result in panics :-)
+func TestClaimMigration_List(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+
+	// Make a test home
+	home, err := p.GetHomeDir()
+	require.NoError(t, err, "GetHomeDir failed")
+	claimsDir := filepath.Join(home, "claims")
+
+	// Remove any rando stuff copied from the dev bin, you won't find this in CI but a local dev run may have it
+	err = p.FileSystem.RemoveAll(claimsDir)
+	require.NoError(t, err, "error removing existing claims directory before test run")
+	err = p.FileSystem.Remove(filepath.Join(home, "schema.json"))
+	require.NoError(t, err, "error removing existing schema.json")
+
+	// Create unmigrated claim data
+	p.FileSystem.Mkdir(claimsDir, 0755)
+	p.AddTestFile(filepath.Join("../pkg/claims/testdata", "upgraded.json"), filepath.Join(home, "claims", "mybun.json"))
+
+	installations, err := p.ListInstallations()
+	require.NoError(t, err, "could not list installations")
+	require.Len(t, installations, 1, "expected one installation")
+	assert.Equal(t, "mybun", installations[0].Name, "unexpected list of installation names")
+}


### PR DESCRIPTION
# What does this change
* Make sure we don't open/close the plugin connection during the schema migration check.
* Bubble through the Connect call to the wrapped backing store.
* Use the same backing store for the manual data access and the claim store.

# What issue does it fix
Reduces unnecessary connection open/close caused by wrapping our claims data access with the migration data structure.

# Notes for the reviewer
Required a PR to cnab-go, so that will need review first. https://github.com/cnabio/cnab-go/pull/225

# Checklist
- [x] Unit Tests
- [x] Documentation - NA
- [x] Schema (porter.yaml) - NA

