### PR TITLE
Trigger build all branches

### DIFF
--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -4,8 +4,6 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/go
 
 trigger: none
-pr: 
-  - "*"
 
 pool:
   vmImage: 'Ubuntu 16.04'

--- a/tests/claim_migration_test.go
+++ b/tests/claim_migration_test.go
@@ -24,10 +24,9 @@ func TestClaimMigration_List(t *testing.T) {
 	claimsDir := filepath.Join(home, "claims")
 
 	// Remove any rando stuff copied from the dev bin, you won't find this in CI but a local dev run may have it
-	err = p.FileSystem.RemoveAll(claimsDir)
-	require.NoError(t, err, "error removing existing claims directory before test run")
-	err = p.FileSystem.Remove(filepath.Join(home, "schema.json"))
-	require.NoError(t, err, "error removing existing schema.json")
+	// Not checking for an error, since the files won't be there on CI
+	p.FileSystem.RemoveAll(claimsDir)
+	p.FileSystem.Remove(filepath.Join(home, "schema.json"))
 
 	// Create unmigrated claim data
 	p.FileSystem.Mkdir(claimsDir, 0755)


### PR DESCRIPTION
# What does this change
I messed up the syntax for triggering a build for any branch name. This should get integration tests running when the branch name has a `/` in it, e.g. `release/0.28.0`

# What issue does it fix
The broken integration test build on https://github.com/deislabs/porter/pull/1145

# Notes for the reviewer
Regex is hard

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md