### PR TITLE
Add new contributors to Porter team

### DIFF
--- a/.github/invite-contributors.yml
+++ b/.github/invite-contributors.yml
@@ -1,0 +1,3 @@
+# See https://probot.github.io/apps/invite-contributors/
+
+team: porters

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,9 +156,13 @@ request comment so that we don't collectively forget.
    your commits. If you prefer to rebase your own commits, at any time leave a
    comment on the pull request to let them know that.
 
-At this point your changes are available in the [canary][canary] release of Porter!
+At this point your changes are available in the [canary][canary] release of
+Porter! After your first pull request is merged, you will be invited to the
+[Porters team] which you may choose to accept (or not). Joining the team lets
+you have issues in GitHub assigned to you.
 
 [canary]: https://porter.sh/install/#canary
+[Porters team]: https://github.com/orgs/deislabs/teams/porters
 
 ### Follow-on PR
 


### PR DESCRIPTION
# What does this change
Automatically add new contributors to our Porters team so that they can have issues assigned to them and generally interact with our repos/org later. Right now I do this by hand and sometimes miss people.

This uses the https://github.com/erickzhao/invite-contributors GitHub app.

# What issue does it fix
Me missing people...

# Notes for the reviewer
NA

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
