### PR TITLE
Do not hard-code version in manifest tag

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -4,7 +4,7 @@ mixins:
 
 name: mysql
 version: 0.1.2
-tag: localhost:5000/mysql:v0.1.2
+tag: localhost:5000/mysql
 
 credentials:
 - name: kubeconfig

--- a/build/testdata/bundles/wordpress/porter.yaml
+++ b/build/testdata/bundles/wordpress/porter.yaml
@@ -4,7 +4,7 @@ mixins:
 
 name: wordpress
 version: 0.1.2
-tag: localhost:5000/wordpress:v0.1.2
+tag: localhost:5000/wordpress
 
 dependencies:
   mysql:

--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -20,8 +20,8 @@ To create a new CNAB with Porter, you first run `porter create`. The generated `
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-# TODO: update the registry to your own, e.g. myregistry/porter-hello:v0.1.0
-tag: getporter/porter-hello:v0.1.0
+# TODO: update the registry to your own, e.g. myregistry/porter-hello
+tag: getporter/porter-hello
 
 # Uncomment the line below to use a template Dockerfile for your invocation image
 #dockerfile: Dockerfile.tmpl
@@ -65,7 +65,7 @@ uninstall:
 
 ```
 
-After the scaffolding is created, you may edit the _porter.yaml_ and modify the `tag: getporter/porter-hello:v0.1.0` element representing the bundle tag to include a Docker registry that you can push to. Note that the bundle is not pushed during the `porter build` workflow.
+After the scaffolding is created, you may edit the _porter.yaml_ and modify the `tag: getporter/porter-hello` element representing the bundle tag to include a Docker registry that you can push to. Note that the bundle is not pushed during the `porter build` workflow.
 
 Once you have modified the `porter.yaml`, you can run `porter build` to generate your first invocation image.  Here we add the `--verbose` flag to see all of the output:
 
@@ -219,7 +219,7 @@ mixins:
 
 name: mysql
 version: "0.1.0"
-tag: jeremyrickard/mysql:v0.1.0
+tag: jeremyrickard/mysql
 
 credentials:
 - name: kubeconfig

--- a/docs/content/distribute-bundles.md
+++ b/docs/content/distribute-bundles.md
@@ -24,7 +24,7 @@ Once you are satisfied with the bundle, the next step is to publish the bundle! 
 name: kube-example
 version: 0.1.0
 description: "An example Porter bundle using Kubernetes"
-tag: getporter/kubernetes:v0.1.0
+tag: getporter/kubernetes
 ```
 
 This YAML snippet indicates that the bundle will be built and tagged as `getporter/kubernetes:v0.1.0`. The first part of this reference, `getporter` indicates the registry that the bundle should eventually be published to. The `kubernetes` segment identifies the bundle name, while the `:v0.1.0` portion denotes a specific version. We recommend using [semantic versioning](https://semver.org/) for the bundle version.
@@ -113,7 +113,7 @@ Consider the following example:
 name: spring-music
 version: 0.5.0
 description: "Run the Spring Music Service on Kubernetes and Digital Ocean PostgreSQL"
-tag: jeremyrickard/porter-do-bundle:v0.5.0
+tag: jeremyrickard/porter-do-bundle
 
 images:
   spring-music:

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -27,7 +27,7 @@ mixins:
 
 name: mysql
 version: 0.1.0
-tag: getporter/mysql:v0.1.0
+tag: getporter/mysql
 
 credentials:
 - name: kubeconfig

--- a/docs/content/mixin-dev-guide/architecture.md
+++ b/docs/content/mixin-dev-guide/architecture.md
@@ -19,7 +19,7 @@ mixins:
 
 name: hello
 version: 0.1.0
-tag: porter-hello:v0.1.0
+tag: porter-hello
 
 install:
 - exec:

--- a/docs/content/porter-or-duffle.md
+++ b/docs/content/porter-or-duffle.md
@@ -98,7 +98,7 @@ The porter manifest and runtime handles interpreting and executing the logical p
 ```yaml
 name: wordpress
 version: 0.1.0
-tag: getporter/wordpress:v0.1.0
+tag: getporter/wordpress
 
 mixins:
   - helm
@@ -242,7 +242,7 @@ mixins:
 
 name: wordpress
 version: 0.1.0
-tag: porter/wordpress:v0.1.0
+tag: porter/wordpress
 
 parameters:
   - name: wordpress_name

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -25,7 +25,7 @@ Here is a very basic **porter.yaml** file:
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 mixins:
   - exec

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -466,8 +466,7 @@ mixins:
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-invocationImage: porter-hello:latest
-tag: deislabs/porter-hello-bundle:latest
+tag: getporter/porter-hello
 
 install:
   - exec:
@@ -760,8 +759,7 @@ Use `porter publish` to share bundles:
 name: HELLO-LLAMA
 version: 0.1.0
 description: "An example Porter configuration with moar llamas"
-invocationImage: "YOURNAME/porter-hello-llama:latest"
-tag: "YOURNAME/porter-hello-llama-bundle:latest"
+tag: "YOURNAME/porter-hello-llama"
 ```
 
 ---
@@ -808,7 +806,7 @@ If you run into trouble here, here are a few things to check:
 # Try it out: Install the bundle
 
 ```
-$ porter install --tag YOURNAME/porter-hello-llama:latest --param name=YOURNAME
+$ porter install --tag YOURNAME/porter-hello-llama:v0.1.0 --param name=YOURNAME
 ```
 
 ---
@@ -953,8 +951,7 @@ name: manifest
 name: porter-workshop-tf 
 version: 0.1.0
 description: "An example using Porter to build the from scratch bundle"
-invocationImage: porter-workshop-tf:latest
-tag: deislabs/porter-workshop-tf-bundle:latest
+tag: getporter/porter-workshop-tf
 ```
 
 ---

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -943,9 +943,8 @@ name: manifest
 
 ```yaml
 name: "azure-wordpress"
-version: "v0.1.0"
-invocationImage: "deislabs/azure-wordpress-ii:v0.1.0"
-tag: "deislabs/azure-wordpress:v0.1.0"
+version: "0.1.0"
+tag: "deislabs/azure-wordpress"
 ```
 
 ---

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -223,7 +223,7 @@ mixins:
 
 name: mysql
 version: 0.1.0
-tag: getporter/mysql:v0.1.0
+tag: getporter/mysql
 
 credentials:
 - name: kubeconfig
@@ -265,7 +265,7 @@ mixins:
 
 name: wordpress
 version: 0.1.0
-tag: getporter/wordpress:v0.1.0
+tag: getporter/wordpress
 
 dependencies:
   mysql:

--- a/examples/airgap/porter.yaml
+++ b/examples/airgap/porter.yaml
@@ -1,7 +1,7 @@
 name: whalegap
 version: 0.1.0
 description: "An example bundle that demonstrates how to sneak a whale-sized bundle through an airgap"
-tag: getporter/whalegap:v0.1.0
+tag: getporter/whalegap
 
 parameters:
   - name: release

--- a/examples/aks-spring-music/porter.yaml
+++ b/examples/aks-spring-music/porter.yaml
@@ -2,7 +2,7 @@ name: aks-spring-music
 version: 0.1.0
 description: "Spring Music Demo app with Azure Cosmos DB"
 dockerfile: Dockerfile.tmpl
-tag: getporter/aks-spring-music:v0.1.0
+tag: getporter/aks-spring-music
 
 mixins:
   - exec

--- a/examples/azure-terraform/porter.yaml
+++ b/examples/azure-terraform/porter.yaml
@@ -10,7 +10,7 @@ mixins:
 name: azure-terraform
 version: 1.0.0
 description: "An example Porter Bundle using Terraform and Azure"
-tag: getporter/azure-terraform:v1.0.0
+tag: getporter/azure-terraform
 
 ## This section defines what credentials are used for the bundle. In this case, we are operating
 ## against Azure, so we need some Azure Service Principal information.

--- a/examples/azure-wordpress/porter.yaml
+++ b/examples/azure-wordpress/porter.yaml
@@ -4,7 +4,7 @@ mixins:
  
 name: azure-wordpress
 version: 0.1.0
-tag: getporter/azure-wordpress:v0.1.0
+tag: getporter/azure-wordpress
 
 credentials:
 - name: SUBSCRIPTION_ID

--- a/examples/docker/porter.yaml
+++ b/examples/docker/porter.yaml
@@ -1,7 +1,7 @@
 name: whalesay
 version: 0.1.1
 description: "An example bundle that uses docker through the magic of whalespeak"
-tag: getporter/whalesay:v0.1.1
+tag: getporter/whalesay
 
 dockerfile: Dockerfile.tmpl
 

--- a/examples/exec-outputs/porter.yaml
+++ b/examples/exec-outputs/porter.yaml
@@ -1,7 +1,7 @@
 name: exec-outputs
 version: 0.1.0
 description: "An example Porter bundle demonstrating exec mixin outputs"
-tag: getporter/exec-outputs:v0.1.0
+tag: getporter/exec-outputs
 dockerfile: Dockerfile.tmpl
 
 mixins:

--- a/examples/gke-example/porter.yaml
+++ b/examples/gke-example/porter.yaml
@@ -1,7 +1,7 @@
 name: gke-example
 version: 0.1.0
 description: "An example Porter bundle with Kubernetes"
-tag: getporter/gke-example:v0.1.0
+tag: getporter/gke-example
 dockerfile: Dockerfile.tmpl
 
 credentials:

--- a/examples/kubernetes/porter.yaml
+++ b/examples/kubernetes/porter.yaml
@@ -9,7 +9,7 @@ credentials:
 name: kubernetes 
 version: 0.1.0
 description: "An example Porter bundle with Kubernetes"
-tag: getporter/kubernetes:v0.1.0
+tag: getporter/kubernetes
 
 install:
   - kubernetes:

--- a/examples/plugins-tutorial/porter.yaml
+++ b/examples/plugins-tutorial/porter.yaml
@@ -2,7 +2,7 @@ name: plugins-tutorial
 version: 0.1.0
 description: "Example of porter resolving credentials from a secrets store using
 a plugin. This bundle is a companion for the plugin tutorial at https://porter.sh/plugins/tutorial/."
-tag: getporter/plugins-tutorial:v0.1.0
+tag: getporter/plugins-tutorial
 
 credentials:
 - name: password

--- a/examples/service-fabric-cli/porter.yaml
+++ b/examples/service-fabric-cli/porter.yaml
@@ -6,7 +6,7 @@
 name: service-fabric-cli
 version: 0.1.0
 description: "An example Porter bundle that uses the service fabric cli"
-tag: getporter/service-fabric-cli:v0.1.0
+tag: getporter/service-fabric-cli
 
 # Use a custom Dockerfile for our invocation image
 dockerfile: Dockerfile.tmpl

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var simpleManifestDigest = "a50e89710dfa2b30a999f8bb7b2801f0a2b97053eb368b01de448f71e712d0ae"
+var simpleManifestDigest = "d48add363709b186e39d25515dcb724871adc93591e0876210809d875d419867"
 
 func TestConfig_GenerateStamp(t *testing.T) {
 	c := config.NewTestConfig(t)

--- a/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
@@ -1,7 +1,7 @@
 name: hello
 description: "An example Porter configuration"
 version: 0.1.0
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 custom:
   foo: bar

--- a/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
@@ -1,7 +1,7 @@
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 dependencies:
   mysql:

--- a/pkg/cnab/config-adapter/testdata/porter-with-parameters.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-parameters.yaml
@@ -1,7 +1,7 @@
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 parameters:
   - name: ainteger

--- a/pkg/cnab/config-adapter/testdata/porter-with-required-extensions.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-required-extensions.yaml
@@ -1,7 +1,7 @@
 name: hello
 description: "An example Porter configuration"
 version: 0.1.0
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 required:
   - requiredExtension1

--- a/pkg/cnab/config-adapter/testdata/porter.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter.yaml
@@ -1,7 +1,7 @@
 name: hello
 description: "An example Porter configuration"
 version: 0.1.0
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 dependencies:
   mysql:

--- a/pkg/manifest/testdata/bundles/mysql/porter.yaml
+++ b/pkg/manifest/testdata/bundles/mysql/porter.yaml
@@ -3,7 +3,7 @@ mixins:
 
 name: mysql
 version: 0.1.0
-tag: getporter/mysql:v0.1.0
+tag: getporter/mysql
 
 credentials:
 - name: kubeconfig

--- a/pkg/manifest/testdata/porter-with-image.yaml
+++ b/pkg/manifest/testdata/porter-with-image.yaml
@@ -4,8 +4,8 @@ mixins:
 name: hello
 description: "An example Porter configuration"
 version: 0.1.0
-tag: getporter/porter-hello:v0.1.0
-invocationImage: getporter/porter-hello-invocation-image.v0.1.0
+tag: getporter/porter-hello
+invocationImage: getporter/porter-hello-invocation-image
 
 install:
 - exec:

--- a/pkg/manifest/testdata/simple.porter.yaml
+++ b/pkg/manifest/testdata/simple.porter.yaml
@@ -4,7 +4,7 @@ mixins:
 name: hello
 description: "An example Porter configuration"
 version: 0.1.0
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 install:
 - exec:

--- a/pkg/manifest/testdata/with-credentials.yaml
+++ b/pkg/manifest/testdata/with-credentials.yaml
@@ -4,7 +4,7 @@ mixins:
 name: hello
 description: "An example Porter configuration"
 version: 0.1.0
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 credentials:
 - name: SUBSCRIPTION_ID

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -50,7 +50,7 @@ func TestPorter_buildBundle(t *testing.T) {
 
 	stamp, err := configadapter.LoadStamp(*bun)
 	require.NoError(t, err)
-	assert.Equal(t, "98132d568b085858935dae13910cae08fdf405e317482898ecff6631e042a8f5", stamp.ManifestDigest)
+	assert.Equal(t, "ea5049721de3f31f866dfe4ec6e18b3ea0243f31a3737eace9932db88fae9aaa", stamp.ManifestDigest)
 
 	debugParam, ok := bun.Parameters["porter-debug"]
 	require.True(t, ok, "porter-debug parameter was not defined")

--- a/pkg/porter/testdata/paramafest.yaml
+++ b/pkg/porter/testdata/paramafest.yaml
@@ -4,7 +4,7 @@ mixins:
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-tag: jeremyrickard/porter-hello:v0.1.0
+tag: jeremyrickard/porter-hello
 
 parameters:
   - name: command 

--- a/pkg/porter/testdata/porter-with-file-param.yaml
+++ b/pkg/porter/testdata/porter-with-file-param.yaml
@@ -1,7 +1,7 @@
 name: HELLO_CUSTOM
 version: 0.1.0
 description: "A bundle with a custom action"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 parameters:
   - name: my-file-param

--- a/pkg/porter/testdata/porter.yaml
+++ b/pkg/porter/testdata/porter.yaml
@@ -1,7 +1,7 @@
 name: HELLO_CUSTOM
 version: 0.1.0
 description: "A bundle with a custom action"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 credentials:
   - name: my-first-cred

--- a/pkg/runtime/testdata/dep-metadata-substitution.yaml
+++ b/pkg/runtime/testdata/dep-metadata-substitution.yaml
@@ -1,7 +1,7 @@
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-tag: jeremyrickard/porter-hello:v0.1.0
+tag: jeremyrickard/porter-hello
 
 mixins:
   - exec

--- a/pkg/runtime/testdata/metadata-substitution.yaml
+++ b/pkg/runtime/testdata/metadata-substitution.yaml
@@ -4,7 +4,7 @@ mixins:
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-tag: jeremyrickard/porter-hello:v0.1.0
+tag: jeremyrickard/porter-hello
 
 parameters:
   - name: command

--- a/pkg/runtime/testdata/outputs/bundle-outputs-error.yaml
+++ b/pkg/runtime/testdata/outputs/bundle-outputs-error.yaml
@@ -3,7 +3,7 @@ mixins:
 
 name: outputs
 version: 0.1.0
-tag: getporter/outputs-example:v0.1.0
+tag: getporter/outputs-example
 
 credentials:
 - name: kubeconfig

--- a/pkg/runtime/testdata/outputs/bundle-outputs.yaml
+++ b/pkg/runtime/testdata/outputs/bundle-outputs.yaml
@@ -3,7 +3,7 @@ mixins:
 
 name: outputs
 version: 0.1.0
-tag: getporter/outputs-example:v0.1.0
+tag: getporter/outputs-example
 
 credentials:
 - name: kubeconfig

--- a/pkg/runtime/testdata/param-test-in-block.yaml
+++ b/pkg/runtime/testdata/param-test-in-block.yaml
@@ -4,7 +4,7 @@ mixins:
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-tag: jeremyrickard/porter-hello:v0.1.0
+tag: jeremyrickard/porter-hello
 
 parameters:
   - name: command 

--- a/pkg/runtime/testdata/porter-images.yaml
+++ b/pkg/runtime/testdata/porter-images.yaml
@@ -1,7 +1,7 @@
 name: some-test
 version: 0.3.11
 description: "Test some things"
-tag: getporter/test:v0.3.11
+tag: getporter/test
 
 images:
   something:

--- a/pkg/runtime/testdata/slice-test.yaml
+++ b/pkg/runtime/testdata/slice-test.yaml
@@ -4,7 +4,7 @@ mixins:
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-tag: jeremyrickard/porter-hello:v0.1.0
+tag: jeremyrickard/porter-hello
 
 parameters:
   - name: command 

--- a/pkg/templates/templates/create/porter.yaml
+++ b/pkg/templates/templates/create/porter.yaml
@@ -6,8 +6,8 @@
 name: HELLO
 version: 0.1.0
 description: "An example Porter configuration"
-# TODO: update the registry to your own, e.g. myregistry/porter-hello:v0.1.0
-tag: getporter/porter-hello:v0.1.0
+# TODO: update the registry to your own, e.g. myregistry/porter-hello
+tag: getporter/porter-hello
 
 # Uncomment the line below to use a template Dockerfile for your invocation image
 #dockerfile: Dockerfile.tmpl

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -15,7 +15,7 @@ func TestTemplates_GetManifest(t *testing.T) {
 	require.NoError(t, err)
 
 	wantTmpl, _ := ioutil.ReadFile("./templates/create/porter.yaml")
-	assert.Equal(t, wantTmpl, gotTmpl)
+	assert.Equal(t, string(wantTmpl), string(gotTmpl))
 }
 
 func TestTemplates_GetRunScript(t *testing.T) {

--- a/tests/testdata/bundle-with-credentials.yaml
+++ b/tests/testdata/bundle-with-credentials.yaml
@@ -1,7 +1,7 @@
 name: mybun
 version: 0.1.0
 description: "An example Porter configuration"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 credentials:
   - name: kubeconfig

--- a/tests/testdata/bundle-with-custom-action.yaml
+++ b/tests/testdata/bundle-with-custom-action.yaml
@@ -1,7 +1,7 @@
 name: HELLO_CUSTOM
 version: 0.1.0
 description: "A bundle with a custom action"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 mixins:
   - exec

--- a/tests/testdata/bundle-with-file-params.yaml
+++ b/tests/testdata/bundle-with-file-params.yaml
@@ -1,7 +1,7 @@
 name: mybun
 version: 0.1.0
 description: "An example Porter configuration"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 mixins:
   - exec

--- a/tests/testdata/bundles/outputs-example/porter.yaml
+++ b/tests/testdata/bundles/outputs-example/porter.yaml
@@ -1,7 +1,7 @@
 name: mybun
 version: 0.1.0
 description: "An example Porter configuration"
-tag: getporterci/outputs-example:v0.1.0
+tag: getporterci/outputs-example
 
 mixins:
   - exec

--- a/tests/testdata/bundles/suppressed-output-example/porter.yaml
+++ b/tests/testdata/bundles/suppressed-output-example/porter.yaml
@@ -1,7 +1,7 @@
 name: mybun
 version: 0.1.0
 description: "An example Porter configuration"
-tag: getporter/porter-hello:v0.1.0
+tag: getporter/porter-hello
 
 mixins:
   - exec

--- a/workshop/asciiart/porter.yaml
+++ b/workshop/asciiart/porter.yaml
@@ -1,11 +1,11 @@
-mixins:
-  - exec
-
 name: asciiart
 version: 0.1.0
 description: "A bundle that turns pictures into ascii art"
-invocationImage: porter-ascii-art:latest
+tag: getporter/porter-ascii-art
 dockerfile: Dockerfile.tmpl
+
+mixins:
+  - exec
 
 install:
   - exec:

--- a/workshop/aws-bucket/porter.yaml
+++ b/workshop/aws-bucket/porter.yaml
@@ -1,8 +1,7 @@
 name: porter-aws-bucket
 version: 0.1.0
 description: "An example Porter AWS bundle that plays with buckets"
-invocationImage: deislabs/porter-aws-bucket-installer:latest
-tag: deislabs/porter-aws-bucket:latest
+tag: getporter/porter-aws-bucket
 
 mixins:
   - aws

--- a/workshop/azure-cli/porter.yaml
+++ b/workshop/azure-cli/porter.yaml
@@ -1,10 +1,10 @@
-mixins:
-  - exec
-
 name: azure-cli
 version: 0.1.0
 description: "Print the azure cli help text"
-invocationImage: porter-azure-cli:0.1.0
+tag: getporter/porter-azure-cli
+
+mixins:
+  - exec
 
 # Uncomment out the line below to use a template Dockerfile for your invocation image
 dockerfile: Dockerfile.tmpl

--- a/workshop/etcd-operator/porter.yaml
+++ b/workshop/etcd-operator/porter.yaml
@@ -1,10 +1,10 @@
-mixins:
-  - helm
-
 name: etcd-operator
 version: 0.1.0
 description: "An etcd-operator bundle"
-invocationImage: porter-etcd-operator:latest
+tag: getporter/porter-etcd-operator
+
+mixins:
+  - helm
 
 credentials:
 - name: kubeconfig

--- a/workshop/gcloud-compute/porter.yaml
+++ b/workshop/gcloud-compute/porter.yaml
@@ -1,8 +1,7 @@
 name: porter-gcloud-compute
 version: 0.1.0
 description: "An example Porter gcloud compute bundle"
-invocationImage: deislabs/porter-gcloud-compute-installer:v0.1.0
-tag: deislabs/porter-gcloud-compute:v0.1.0
+tag: getporter/porter-gcloud-compute
 
 mixins:
   - gcloud

--- a/workshop/hello-llama/porter.yaml
+++ b/workshop/hello-llama/porter.yaml
@@ -1,11 +1,10 @@
-mixins:
-  - exec
-
 name: HELLO-LLAMA
 version: 0.1.0
 description: "An example Porter configuration with moar llamas"
-invocationImage: "deislabs/porter-hello-llama:latest"
-tag: "deislabs/porter-hello-llama-bundle:latest"
+tag: deislabs/porter-hello-llama-bundle
+
+mixins:
+  - exec
 
 parameters:
 - name: name

--- a/workshop/porter-tf-aci/azure/README.md
+++ b/workshop/porter-tf-aci/azure/README.md
@@ -27,13 +27,13 @@ Finally, the `porter.yaml` also defines an `imageMap`. In this section, you can 
 Now, update the `porter.yaml` and change the following value:
 
 ```
-tag: getporter/workshop-tf-aci:v0.1.0
+tag: getporter/workshop-tf-aci
 ```
 
 Change the Docker-like reference to point to your own Docker registry. For example, if my Docker user name is `jeremyrickard`, I'd change that these lines to:
 
 ```
-tag: jeremyrickard/workshop-tf-aci:v0.1.0
+tag: jeremyrickard/workshop-tf-aci
 ```
 
 ## Build The Bundle!

--- a/workshop/porter-tf-aci/azure/bundle/porter.yaml
+++ b/workshop/porter-tf-aci/azure/bundle/porter.yaml
@@ -1,12 +1,12 @@
-mixins:
-  - arm
-  - exec
-  - terraform 
-
 name: workshop-tf-aci
 version: 0.1.0
 description: "An example using Porter to build a TF bundle and use ACI"
-tag: getporter/workshop-tf-aci:v0.1.0
+tag: getporter/workshop-tf-aci
+
+mixins:
+  - arm
+  - exec
+  - terraform
 
 ## This section defines what credentials are used for the bundle. In this case, we are operating
 ## against Azure, so we need some Azure Service Principal information.

--- a/workshop/porter-tf/azure/README.md
+++ b/workshop/porter-tf/azure/README.md
@@ -25,13 +25,13 @@ Review the `porter.yaml` to see what each of these sections looks like.
 Now, update the `porter.yaml` and change the following value:
 
 ```
-tag: getporter/orkshop-tf:v0.1.0
+tag: getporter/orkshop-tf
 ```
 
 Change the Docker-like reference to point to your own Docker registry. For example, if my Docker user name is `jeremyrickard`, I'd change that these lines to:
 
 ```
-tag: jeremyrickard/workshop-tf:v0.1.0
+tag: jeremyrickard/workshop-tf
 ```
 
 ## Build The Bundle!

--- a/workshop/porter-tf/azure/porter.yaml
+++ b/workshop/porter-tf/azure/porter.yaml
@@ -1,12 +1,12 @@
+name: workshop-tf
+version: 0.1.0
+description: "An example using Porter to build the from scratch bundle"
+tag: getporter/workshop-tf
+
 mixins:
   - azure
   - exec
-  - terraform 
-
-name: workshop-tf 
-version: 0.1.0
-description: "An example using Porter to build the from scratch bundle"
-tag: getporter/workshop-tf:v0.1.0
+  - terraform
 
 ## This section defines what credentials are used for the bundle. In this case, we are operating
 ## against Azure, so we need some Azure Service Principal information.

--- a/workshop/wordpress/porter.yaml
+++ b/workshop/wordpress/porter.yaml
@@ -1,9 +1,9 @@
+name: wordpress
+version: 0.1.0
+tag: getporter/porter-workshop-wordpress
+
 mixins:
   - helm
- 
-name: wordpress 
-version: 0.1.0
-invocationImage: porter-workshop-wordpress:v0.1.0
 
 credentials:
 - name: kubeconfig


### PR DESCRIPTION
# What does this change
Take advantage of the defaulting, don't give people a bad example and make it easier to maintain the bundle.

# What issue does it fix
Just a follow-up to Vaughn's good work on defaulting the tag and removing the invocation image.

# Notes for the reviewer
NA

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
