### PR TITLE
 Update porter.yaml template and clean up documentation and test data that use manifest template

### DIFF
--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -50,7 +50,7 @@ func TestPorter_buildBundle(t *testing.T) {
 
 	stamp, err := configadapter.LoadStamp(*bun)
 	require.NoError(t, err)
-	assert.Equal(t, "9df1079561cf9bdac892dde37d3dbd879978c37d99526224d9bab4b174007fb6", stamp.ManifestDigest)
+	assert.Equal(t, "9e0809ae4220c0f0b0c610b44e36948cfd37d56ccc181078faa24f21064c36ec", stamp.ManifestDigest)
 
 	debugParam, ok := bun.Parameters["porter-debug"]
 	require.True(t, ok, "porter-debug parameter was not defined")

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -50,7 +50,7 @@ func TestPorter_buildBundle(t *testing.T) {
 
 	stamp, err := configadapter.LoadStamp(*bun)
 	require.NoError(t, err)
-	assert.Equal(t, "ea5049721de3f31f866dfe4ec6e18b3ea0243f31a3737eace9932db88fae9aaa", stamp.ManifestDigest)
+	assert.Equal(t, "9df1079561cf9bdac892dde37d3dbd879978c37d99526224d9bab4b174007fb6", stamp.ManifestDigest)
 
 	debugParam, ok := bun.Parameters["porter-debug"]
 	require.True(t, ok, "porter-debug parameter was not defined")

--- a/pkg/templates/templates/create/porter.yaml
+++ b/pkg/templates/templates/create/porter.yaml
@@ -9,7 +9,8 @@ description: "An example Porter configuration"
 # TODO: update the registry to your own, e.g. myregistry/porter-hello
 tag: getporter/porter-hello
 
-# Uncomment the line below to customize the Dockerfile, see https://porter.sh/custom-dockerfile/
+# If you want to customize the Dockerfile in use, uncomment the line below and update the referenced file. 
+# See https://porter.sh/custom-dockerfile/
 #dockerfile: Dockerfile.tmpl
 
 mixins:
@@ -36,7 +37,7 @@ uninstall:
       arguments:
         - uninstall
 
-# Below is an example of how to defined credentials
+# Below is an example of how to define credentials
 # See https://porter.sh/author-bundles/#credentials
 #credentials:
 #  - name: kubeconfig

--- a/pkg/templates/templates/create/porter.yaml
+++ b/pkg/templates/templates/create/porter.yaml
@@ -9,7 +9,7 @@ description: "An example Porter configuration"
 # TODO: update the registry to your own, e.g. myregistry/porter-hello
 tag: getporter/porter-hello
 
-# Uncomment the line below to use a template Dockerfile for your invocation image
+# Uncomment the line below to customize the Dockerfile, see https://porter.sh/custom-dockerfile/
 #dockerfile: Dockerfile.tmpl
 
 mixins:
@@ -36,15 +36,17 @@ uninstall:
       arguments:
         - uninstall
 
-
-# See https://porter.sh/author-bundles/#dependencies
-#dependencies:
-#  mysql:
-#    tag: getporter/mysql:v0.1.2
-#    parameters:
-#      database-name: wordpress
-
-# See https://porter.sh/wiring/#credentials
+# Below is an example of how to defined credentials
+# See https://porter.sh/author-bundles/#credentials
 #credentials:
 #  - name: kubeconfig
 #    path: /root/.kube/config
+#  - name: username
+#    env: USERNAME
+
+# Below is an example of how to define parameters
+# See https://porter.sh/author-bundles/#parameters
+#parameters:
+#  - name: mysql_user
+#    type: string
+#    default: wordpress


### PR DESCRIPTION
# What does this change

This updates the porter.yaml template that is used with porter create:

* Give example for parameters and link in comments https://porter.sh/author-bundles/#parameters
* Link to documentation for customizing the dockerfile within the sample porter.yaml template
* Link to updated credentials page https://porter.sh/author-bundles/#credentials

This cleans up the testing and documentation that includes the sample template in a number of pages. This includes 

* Removing hard-coded version in the manifest tag
* Removes invocationImage from manifest examples related #1140

# What issue does it fix
None, just noticed that we could do better when reviewing #1171  💪 
Fixes Issue #1146

# Notes for the reviewer
NA

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
