### PR TITLE
Improve plugin connection handling

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -59,6 +59,8 @@ func buildRootCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVar(&p.Debug, "debug", false, "Enable debug logging")
+	cmd.PersistentFlags().BoolVar(&p.DebugPlugins, "debug-plugins", false, "Enable plugin debug logging")
+
 	cmd.Flags().BoolVarP(&printVersion, "version", "v", false, "Print the application version")
 
 	cmd.AddCommand(buildVersionCommand(p))

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -38,7 +38,8 @@ porter archive FILENAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/build.md
+++ b/docs/content/cli/build.md
@@ -26,7 +26,8 @@ porter build [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles.md
+++ b/docs/content/cli/bundles.md
@@ -20,7 +20,8 @@ Commands for working with bundles. These all have shortcuts so that you can call
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -38,7 +38,8 @@ porter bundles archive FILENAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_build.md
+++ b/docs/content/cli/bundles_build.md
@@ -26,7 +26,8 @@ porter bundles build [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_copy.md
+++ b/docs/content/cli/bundles_copy.md
@@ -40,7 +40,8 @@ porter bundles copy [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_create.md
+++ b/docs/content/cli/bundles_create.md
@@ -24,7 +24,8 @@ porter bundles create [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_explain.md
+++ b/docs/content/cli/bundles_explain.md
@@ -39,7 +39,8 @@ porter bundles explain [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_inspect.md
+++ b/docs/content/cli/bundles_inspect.md
@@ -43,7 +43,8 @@ porter bundles inspect [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -51,7 +51,8 @@ porter bundles install [INSTALLATION] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -52,7 +52,8 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_lint.md
+++ b/docs/content/cli/bundles_lint.md
@@ -29,7 +29,8 @@ porter bundles lint [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -52,7 +52,8 @@ porter bundles uninstall [INSTALLATION] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -51,7 +51,8 @@ porter bundles upgrade [INSTALLATION] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/copy.md
+++ b/docs/content/cli/copy.md
@@ -40,7 +40,8 @@ porter copy [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/create.md
+++ b/docs/content/cli/create.md
@@ -24,7 +24,8 @@ porter create [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/credentials.md
+++ b/docs/content/cli/credentials.md
@@ -20,7 +20,8 @@ Credentials commands
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/credentials_delete.md
+++ b/docs/content/cli/credentials_delete.md
@@ -24,7 +24,8 @@ porter credentials delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/credentials_edit.md
+++ b/docs/content/cli/credentials_edit.md
@@ -24,7 +24,8 @@ porter credentials edit [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -54,7 +54,8 @@ porter credentials generate [NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/credentials_list.md
+++ b/docs/content/cli/credentials_list.md
@@ -31,7 +31,8 @@ porter credentials list [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/credentials_show.md
+++ b/docs/content/cli/credentials_show.md
@@ -31,7 +31,8 @@ porter credentials show [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -39,7 +39,8 @@ porter explain [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/inspect.md
+++ b/docs/content/cli/inspect.md
@@ -43,7 +43,8 @@ porter inspect [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -51,7 +51,8 @@ porter install [INSTALLATION] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/installations.md
+++ b/docs/content/cli/installations.md
@@ -20,7 +20,8 @@ Commands for working with installations of a bundle
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/installations_list.md
+++ b/docs/content/cli/installations_list.md
@@ -36,7 +36,8 @@ porter installations list [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/installations_output.md
+++ b/docs/content/cli/installations_output.md
@@ -20,7 +20,8 @@ Output commands
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/installations_output_list.md
+++ b/docs/content/cli/installations_output_list.md
@@ -34,7 +34,8 @@ porter installations output list [--installation|i INSTALLATION] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/installations_output_show.md
+++ b/docs/content/cli/installations_output_show.md
@@ -32,7 +32,8 @@ porter installations output show NAME [--installation|-i INSTALLATION] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/installations_show.md
+++ b/docs/content/cli/installations_show.md
@@ -35,7 +35,8 @@ Optional output formats include json and yaml.
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -52,7 +52,8 @@ porter invoke [INSTALLATION] --action ACTION [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/lint.md
+++ b/docs/content/cli/lint.md
@@ -29,7 +29,8 @@ porter lint [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/list.md
+++ b/docs/content/cli/list.md
@@ -36,7 +36,8 @@ porter list [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/mixins.md
+++ b/docs/content/cli/mixins.md
@@ -20,7 +20,8 @@ Mixin commands. Mixins assist with authoring bundles.
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/mixins_feed.md
+++ b/docs/content/cli/mixins_feed.md
@@ -20,7 +20,8 @@ Feed commands
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/mixins_feed_generate.md
+++ b/docs/content/cli/mixins_feed_generate.md
@@ -51,7 +51,8 @@ porter mixins feed generate [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/mixins_feed_template.md
+++ b/docs/content/cli/mixins_feed_template.md
@@ -24,7 +24,8 @@ porter mixins feed template [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/mixins_install.md
+++ b/docs/content/cli/mixins_install.md
@@ -36,7 +36,8 @@ porter mixins install NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/mixins_list.md
+++ b/docs/content/cli/mixins_list.md
@@ -25,7 +25,8 @@ porter mixins list [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/mixins_search.md
+++ b/docs/content/cli/mixins_search.md
@@ -33,7 +33,8 @@ porter mixins search [QUERY] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/mixins_uninstall.md
+++ b/docs/content/cli/mixins_uninstall.md
@@ -30,7 +30,8 @@ porter mixins uninstall NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/parameters.md
+++ b/docs/content/cli/parameters.md
@@ -20,7 +20,8 @@ Parameter set commands
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/parameters_delete.md
+++ b/docs/content/cli/parameters_delete.md
@@ -24,7 +24,8 @@ porter parameters delete NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/parameters_edit.md
+++ b/docs/content/cli/parameters_edit.md
@@ -24,7 +24,8 @@ porter parameters edit [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/parameters_generate.md
+++ b/docs/content/cli/parameters_generate.md
@@ -54,7 +54,8 @@ porter parameters generate [NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/parameters_list.md
+++ b/docs/content/cli/parameters_list.md
@@ -31,7 +31,8 @@ porter parameters list [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/parameters_show.md
+++ b/docs/content/cli/parameters_show.md
@@ -31,7 +31,8 @@ porter parameters show [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/plugins.md
+++ b/docs/content/cli/plugins.md
@@ -20,7 +20,8 @@ Plugin commands. Plugins enable Porter to work on different cloud providers and 
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/plugins_install.md
+++ b/docs/content/cli/plugins_install.md
@@ -37,7 +37,8 @@ porter plugins install NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/plugins_list.md
+++ b/docs/content/cli/plugins_list.md
@@ -25,7 +25,8 @@ porter plugins list [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/plugins_search.md
+++ b/docs/content/cli/plugins_search.md
@@ -33,7 +33,8 @@ porter plugins search [QUERY] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/plugins_show.md
+++ b/docs/content/cli/plugins_show.md
@@ -25,7 +25,8 @@ porter plugins show [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/plugins_uninstall.md
+++ b/docs/content/cli/plugins_uninstall.md
@@ -30,7 +30,8 @@ porter plugins uninstall NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/porter.md
+++ b/docs/content/cli/porter.md
@@ -27,9 +27,10 @@ porter [flags]
 ### Options
 
 ```
-      --debug     Enable debug logging
-  -h, --help      help for porter
-  -v, --version   Print the application version
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
+  -h, --help            help for porter
+  -v, --version         Print the application version
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -37,7 +37,8 @@ porter publish [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/schema.md
+++ b/docs/content/cli/schema.md
@@ -24,7 +24,8 @@ porter schema [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/show.md
+++ b/docs/content/cli/show.md
@@ -35,7 +35,8 @@ Optional output formats include json and yaml.
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -52,7 +52,8 @@ porter uninstall [INSTALLATION] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -51,7 +51,8 @@ porter upgrade [INSTALLATION] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/version.md
+++ b/docs/content/cli/version.md
@@ -26,7 +26,8 @@ porter version [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   Enable debug logging
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
 ```
 
 ### SEE ALSO

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -14,6 +14,7 @@ override it in a shell session with an environment variable and then override
 both in a particular command with a flag.
 
 * [Enable Debug Output](#debug)
+* [Debug Plugins](#debug-plugins)
 * [Output Formatting](#output)
 * [Allow Docker Host Access](#allow-docker-host-access)
 
@@ -73,8 +74,17 @@ Below is an example configuration file in TOML
 **~/.porter/config.toml**
 ```toml
 debug = true
+debug-plugins = true
 output = "json"
 allow-docker-host-access = true
+```
+
+### Debug Plugins
+
+The `debug-plugins` configuration setting controls if logs related to communication
+between porter and its plugins should be printed when debugging. This can be _very_
+verbose, so it is not turned on by default when debug is true.
+
 ```
 
 [install]: /cli/porter_install/

--- a/pkg/claims/migrateClaimsWrapper.go
+++ b/pkg/claims/migrateClaimsWrapper.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"get.porter.sh/porter/pkg/storage"
-
 	"get.porter.sh/porter/pkg/context"
+	"get.porter.sh/porter/pkg/storage"
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/schema"
 	"github.com/cnabio/cnab-go/utils/crud"
@@ -85,6 +84,10 @@ func (w *migrateClaimsWrapper) Connect() error {
 	}
 
 	return nil
+}
+
+func (w *migrateClaimsWrapper) Close() error {
+	return w.BackingStore.Close()
 }
 
 func (w *migrateClaimsWrapper) MigrateAll() error {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -20,13 +20,14 @@ const (
 type CommandBuilder func(name string, arg ...string) *exec.Cmd
 
 type Context struct {
-	Debug      bool
-	verbose    bool
-	FileSystem *afero.Afero
-	In         io.Reader
-	Out        io.Writer
-	Err        io.Writer
-	NewCommand CommandBuilder
+	Debug        bool
+	DebugPlugins bool
+	verbose      bool
+	FileSystem   *afero.Afero
+	In           io.Reader
+	Out          io.Writer
+	Err          io.Writer
+	NewCommand   CommandBuilder
 }
 
 func (c *Context) SetVerbose(value bool) {

--- a/pkg/porter/plugins.go
+++ b/pkg/porter/plugins.go
@@ -219,9 +219,10 @@ func (p *Porter) RunInternalPlugins(args []string) {
 	err := opts.Validate(args, p.Config)
 	if err != nil {
 		logger := hclog.New(&hclog.LoggerOptions{
-			Name:   "porter",
-			Output: p.Err,
-			Level:  hclog.Error,
+			Name:       "porter",
+			Output:     p.Err,
+			Level:      hclog.Error,
+			JSONFormat: true,
 		})
 		logger.Error(err.Error())
 		return

--- a/pkg/storage/filesystem/plugin.go
+++ b/pkg/storage/filesystem/plugin.go
@@ -20,9 +20,10 @@ type Plugin struct {
 func NewPlugin(c config.Config) plugin.Plugin {
 	// Create an hclog.Logger
 	logger := hclog.New(&hclog.LoggerOptions{
-		Name:   PluginKey,
-		Output: c.Err,
-		Level:  hclog.Error,
+		Name:       PluginKey,
+		Output:     c.Err,
+		Level:      hclog.Debug,
+		JSONFormat: true,
 	})
 
 	return &crudstore.Plugin{

--- a/pkg/storage/filesystem/store.go
+++ b/pkg/storage/filesystem/store.go
@@ -35,7 +35,7 @@ func (s *Store) Connect() error {
 		return errors.Wrap(err, "could not determine home directory for filesystem storage")
 	}
 
-	s.logger.Debug("PORTER HOME: " + home)
+	s.logger.Info("PORTER HOME: " + home)
 
 	s.Store = crud.NewFileSystemStore(home, NewFileExtensions())
 	return nil


### PR DESCRIPTION
# What does this change
* Use json formatted plugin logging so that we can log just the plugin message and not the raw unformatted message
* Add --debug-plugin flag so that we can selectively see the logs from the plugin

# What issue does it fix
Honestly I demo'd this to Vaughn weeks ago and then somehow lost this change and had to fish it out of my reflog... 😂 

# Notes for the reviewer
NA

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
