### PR TITLE
fix(archive.go): return error if parent dir of dest file does not exist

### DIFF
--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -23,7 +23,7 @@ type ArchiveOptions struct {
 // Validate performs validation on the publish options
 func (o *ArchiveOptions) Validate(args []string, p *Porter) error {
 	if len(args) < 1 || args[0] == "" {
-		return errors.New("Destination File is required")
+		return errors.New("destination file is required")
 	}
 	o.ArchiveFile = args[0]
 	return o.BundleLifecycleOpts.Validate(args, p)
@@ -33,6 +33,10 @@ func (o *ArchiveOptions) Validate(args []string, p *Porter) error {
 // any referenced images locally (if needed), export them to individual layers, generate a bundle.json and
 // then generate a gzipped tar archive containing the bundle.json and the images
 func (p *Porter) Archive(opts ArchiveOptions) error {
+	dir := filepath.Dir(opts.ArchiveFile)
+	if _, err := p.Config.FileSystem.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("parent directory %q does not exist", dir)
+	}
 
 	err := p.prepullBundleByTag(&opts.BundleLifecycleOpts)
 	if err != nil {
@@ -70,9 +74,7 @@ func (p *Porter) Archive(opts ArchiveOptions) error {
 	if err := exp.export(); err != nil {
 		return err
 	}
-	// if ex.verbose {
-	// 	fmt.Fprintf(p.Out, "Export logs: %s\n", exp.Logs())
-	// }
+
 	return nil
 }
 

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -1,0 +1,19 @@
+package porter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchive_ParentDirDoesNotExist(t *testing.T) {
+	p := NewTestPorter(t)
+
+	opts := ArchiveOptions{}
+
+	err := opts.Validate([]string{"/path/to/file"}, p.Porter)
+	require.NoError(t, err, "expected no validation error to occur")
+
+	err = p.Archive(opts)
+	require.EqualError(t, err, "parent directory \"/path/to\" does not exist")
+}


### PR DESCRIPTION
# What does this change
* Adds logic to error out if the parent directory for the provided archive filepath does not exist
# What issue does it fix
Closes https://github.com/deislabs/porter/issues/1169

# Notes for the reviewer
I first placed the logic in the `Validate` function with a direct `os` call but I then remembered that we probably want to use Porter's filesystem from its config; therefore, the logic was placed in `Archive` itself.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md