### PR TITLE
Fix listing of parameter sources in order

### DIFF
--- a/pkg/cnab/extensions/parameter_sources.go
+++ b/pkg/cnab/extensions/parameter_sources.go
@@ -57,7 +57,7 @@ type ParameterSource struct {
 // ListSourcesByPriority returns the parameter sources by the requested priority,
 // if none is specified, they are unsorted.
 func (s ParameterSource) ListSourcesByPriority() []ParameterSourceDefinition {
-	sources := make([]ParameterSourceDefinition, len(s.Sources))
+	sources := make([]ParameterSourceDefinition, 0, len(s.Sources))
 	if len(s.Priority) == 0 {
 		for _, source := range s.Sources {
 			sources = append(sources, source)

--- a/pkg/cnab/extensions/paramter_sources_test.go
+++ b/pkg/cnab/extensions/paramter_sources_test.go
@@ -58,3 +58,13 @@ func TestReadParameterSourcesProperties(t *testing.T) {
 	want.SetParameterFromOutput("tfstate", "tfstate")
 	assert.Equal(t, want, ps)
 }
+
+func TestParameterSource_ListSourcesByPriority(t *testing.T) {
+	ps := ParameterSources{}
+	ps.SetParameterFromOutput("tfstate", "tfstate")
+	got := ps["tfstate"].ListSourcesByPriority()
+	want := []ParameterSourceDefinition{
+		OutputParameterSource{OutputName: "tfstate"},
+	}
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
# What does this change
I am using append when listing parameter sources but then forget to set the array size to 0...

# What issue does it fix
I found this when helping MChorfa with the same code for dependencies.

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
