### PR TITLE
fix(Makefile): update sed command for compat w/ Mac/BSD sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-cli: clean-last-testrun build init-porter-home-for-ci
 
 init-porter-home-for-ci:
 	cp -R build/testdata/credentials $(PORTER_HOME)
-	sed -i 's|KUBECONFIGPATH|$(KUBECONFIG)|g' $(PORTER_HOME)/credentials/ci.json
+	sed -i.bak 's|KUBECONFIGPATH|$(KUBECONFIG)|g' $(PORTER_HOME)/credentials/ci.json
 	cp -R build/testdata/bundles $(PORTER_HOME)
 
 .PHONY: docs


### PR DESCRIPTION
# What does this change
* Updates the `sed` command (used by the `init-porter-home-for-ci` make target) to be Mac OSX/BSD-friendly

# What issue does it fix
N/A

# Notes for the reviewer
Hoping for confirmation that this works by @donmstewart when convenient :)

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md