### PR TITLE
fix(Makefile): wire up local registry targets for cli and int tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ make test-integration
 ```
 
 If you want to know _all_ the targets that the CI runs, look at
-<build/azure-pipelines.pr-automatic.yml> and <build/azure-pipelines.pr-manual.yml>.
+<build/azure-pipelines.pr-automatic.yml>.
 
 ## How to get your pull request reviewed fast
 
@@ -215,9 +215,8 @@ Here are the most common Makefile tasks
 * `test-unit` runs the unit tests.
 * `test-integration` runs the integration tests. This requires a kubernetes
   cluster setup with credentials located at **~/.kube/config**. Expect this to
-  take 10 minutes.
-* `test-cli` runs a small test of end-to-end tests that require a kubernetes
-  cluster (same as `test-integration`).
+  take 20 minutes.
+* `test-cli` runs a small suite of end-to-end tests using the Porter CLI.
 * `docs-preview` hosts the docs site. See [Preview
   Documentation](#preview-documentation).
 * `test` runs all the tests.

--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,11 @@ test: clean-last-testrun test-unit test-integration test-cli
 test-unit:
 	$(GO) test ./...
 
-test-integration: build
+test-integration: clean-last-testrun build start-local-docker-registry
 	$(GO) build -o $(PORTER_HOME)/testplugin ./cmd/testplugin
 	PROJECT_ROOT=$(shell pwd) $(GO) test -timeout 20m -tags=integration ./...
 
-test-cli: clean-last-testrun build init-porter-home-for-ci
+test-cli: clean-last-testrun build init-porter-home-for-ci start-local-docker-registry
 	REGISTRY=$(REGISTRY) KUBECONFIG=$(KUBECONFIG) ./scripts/test/test-cli.sh
 
 init-porter-home-for-ci:
@@ -214,7 +214,7 @@ clean: clean-mixins clean-last-testrun
 clean-mixins:
 	-rm -fr bin/
 
-clean-last-testrun:
+clean-last-testrun: stop-local-docker-registry
 	-rm -fr cnab/ porter.yaml Dockerfile bundle.json
 
 clean-packr: packr2

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -110,6 +110,6 @@ jobs:
     displayName: 'Build'
 
   - script: |
-      make start-local-docker-registry test-cli stop-local-docker-registry
+      make test-cli
     workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'CLI Test'

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -59,7 +59,7 @@ stages:
       displayName: 'Build'
 
     - script: |
-        make start-local-docker-registry test-cli stop-local-docker-registry
+        make test-cli
       workingDirectory: '$(System.DefaultWorkingDirectory)'
       displayName: 'CLI Test'
 

--- a/build/brigade.js
+++ b/build/brigade.js
@@ -124,7 +124,7 @@ function testIntegration(e, p) {
     "cd /src",
     "trap 'make -f Makefile.kind delete-kind-cluster' EXIT",
     `make -f Makefile.kind create-kind-cluster`,
-    "make start-local-docker-registry test-integration stop-local-docker-registry"
+    "make test-integration"
   );
 
   return testInt;
@@ -136,7 +136,7 @@ function testCLI(e, p) {
   testCLI.enableDind();
 
   testCLI.tasks.push(
-    "make start-local-docker-registry test-cli stop-local-docker-registry"
+    "make test-cli"
   );
 
   return testCLI;

--- a/build/run-integration-tests.sh
+++ b/build/run-integration-tests.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 trap 'make -f Makefile.kind delete-kind-cluster' EXIT
 make -f Makefile.kind install-kind create-kind-cluster
-make start-local-docker-registry test-integration stop-local-docker-registry
+make test-integration


### PR DESCRIPTION

# What does this change
* Adds logic to run the necessary local registry targets when running the CLI and integration tests

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md