### PR TITLE
feat(*): add installation delete options/flags to relevant commands

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -278,7 +278,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 	f.BoolVar(&opts.Delete, "delete", false,
 		"Delete all records associated with the installation, assuming the uninstall action succeeds")
 	f.BoolVar(&opts.ForceDelete, "force-delete", false,
-		"Force delete all records associated with the installation, even if the uninstall action does not succeed")
+		"UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -249,6 +249,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
   porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
   porter bundle uninstall --driver debug
+  porter bundle uninstall --delete
+  porter bundle uninstall --force-delete
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)
@@ -273,6 +275,10 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
+	f.BoolVar(&opts.Delete, "delete", false,
+		"Delete all records associated with the installation, assuming the uninstall action succeeds")
+	f.BoolVar(&opts.ForceDelete, "force-delete", false,
+		"Force delete all records associated with the installation, even if the uninstall action does not succeed")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -60,7 +60,7 @@ func buildInstallationShowCommand(p *porter.Porter) *cobra.Command {
 		Short: "Show an installation of a bundle",
 		Long:  "Displays info relating to an installation of a bundle, including status and a listing of outputs.",
 		Example: `  porter installation show
-porter installation show another-bundle
+  porter installation show another-bundle
 
 Optional output formats include json and yaml.
 `,
@@ -87,8 +87,8 @@ func buildInstallationDeleteCommand(p *porter.Porter) *cobra.Command {
 		Short: "Delete an installation",
 		Long:  "Deletes all records and outputs associated with an installation",
 		Example: `  porter installation delete
-porter installation delete wordpress
-porter installation delete --force
+  porter installation delete wordpress
+  porter installation delete --force
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -85,9 +85,9 @@ func buildInstallationDeleteCommand(p *porter.Porter) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "delete [INSTALLATION]",
 		Short: "Delete an installation",
-		Long:  "Deletes an installation, including all claim, result and output records.",
+		Long:  "Deletes all records and outputs associated with an installation",
 		Example: `  porter installation delete
-porter installation delete another-installation
+porter installation delete wordpress
 porter installation delete --force
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -19,6 +19,7 @@ func buildInstallationCommands(p *porter.Porter) *cobra.Command {
 	cmd.AddCommand(buildInstallationsListCommand(p))
 	cmd.AddCommand(buildInstallationShowCommand(p))
 	cmd.AddCommand(buildInstallationOutputsCommands(p))
+	cmd.AddCommand(buildInstallationDeleteCommand(p))
 
 	return cmd
 }
@@ -74,6 +75,32 @@ Optional output formats include json and yaml.
 	f := cmd.Flags()
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
+
+	return &cmd
+}
+
+func buildInstallationDeleteCommand(p *porter.Porter) *cobra.Command {
+	opts := porter.DeleteOptions{}
+
+	cmd := cobra.Command{
+		Use:   "delete [INSTALLATION]",
+		Short: "Delete an installation",
+		Long:  "Deletes an installation, including all claim, result and output records.",
+		Example: `  porter installation delete
+porter installation delete another-installation
+porter installation delete --force
+`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(args, p.Context)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.DeleteInstallation(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a delete the installation, regardless of last completed action")
 
 	return &cmd
 }

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -45,7 +45,7 @@ porter bundles uninstall [INSTALLATION] [flags]
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
       --force                      Force a fresh pull of the bundle
-      --force-delete               Force delete all records associated with the installation, even if the uninstall action does not succeed
+      --force-delete               UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -30,6 +30,8 @@ porter bundles uninstall [INSTALLATION] [flags]
   porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
   porter bundle uninstall --driver debug
+  porter bundle uninstall --delete
+  porter bundle uninstall --force-delete
 
 ```
 
@@ -39,9 +41,11 @@ porter bundles uninstall [INSTALLATION] [flags]
       --allow-docker-host-access   Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://porter.sh/configuration/#allow-docker-host-access for the full implications of this flag.
       --cnab-file string           Path to the CNAB bundle.json file.
   -c, --cred strings               Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
+      --delete                     Delete all records associated with the installation, assuming the uninstall action succeeds
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
       --force                      Force a fresh pull of the bundle
+      --force-delete               Force delete all records associated with the installation, even if the uninstall action does not succeed
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.

--- a/docs/content/cli/installations.md
+++ b/docs/content/cli/installations.md
@@ -27,6 +27,7 @@ Commands for working with installations of a bundle
 ### SEE ALSO
 
 * [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter installations delete](/cli/porter_installations_delete/)	 - Delete an installation
 * [porter installations list](/cli/porter_installations_list/)	 - List installed bundles
 * [porter installations output](/cli/porter_installations_output/)	 - Output commands
 * [porter installations show](/cli/porter_installations_show/)	 - Show an installation of a bundle

--- a/docs/content/cli/installations_delete.md
+++ b/docs/content/cli/installations_delete.md
@@ -9,7 +9,7 @@ Delete an installation
 
 ### Synopsis
 
-Deletes an installation, including all claim, result and output records.
+Deletes all records and outputs associated with an installation
 
 ```
 porter installations delete [INSTALLATION] [flags]
@@ -19,7 +19,7 @@ porter installations delete [INSTALLATION] [flags]
 
 ```
   porter installation delete
-porter installation delete another-installation
+porter installation delete wordpress
 porter installation delete --force
 
 ```

--- a/docs/content/cli/installations_delete.md
+++ b/docs/content/cli/installations_delete.md
@@ -1,0 +1,44 @@
+---
+title: "porter installations delete"
+slug: porter_installations_delete
+url: /cli/porter_installations_delete/
+---
+## porter installations delete
+
+Delete an installation
+
+### Synopsis
+
+Deletes an installation, including all claim, result and output records.
+
+```
+porter installations delete [INSTALLATION] [flags]
+```
+
+### Examples
+
+```
+  porter installation delete
+porter installation delete another-installation
+porter installation delete --force
+
+```
+
+### Options
+
+```
+      --force   Force a delete the installation, regardless of last completed action
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
+```
+
+### SEE ALSO
+
+* [porter installations](/cli/porter_installations/)	 - Installation commands
+

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -30,6 +30,8 @@ porter uninstall [INSTALLATION] [flags]
   porter uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter uninstall --cred azure --cred kubernetes
   porter uninstall --driver debug
+  porter uninstall --delete
+  porter uninstall --force-delete
 
 ```
 
@@ -39,9 +41,11 @@ porter uninstall [INSTALLATION] [flags]
       --allow-docker-host-access   Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://porter.sh/configuration/#allow-docker-host-access for the full implications of this flag.
       --cnab-file string           Path to the CNAB bundle.json file.
   -c, --cred strings               Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
+      --delete                     Delete all records associated with the installation, assuming the uninstall action succeeds
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
       --force                      Force a fresh pull of the bundle
+      --force-delete               Force delete all records associated with the installation, even if the uninstall action does not succeed
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -45,7 +45,7 @@ porter uninstall [INSTALLATION] [flags]
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
       --force                      Force a fresh pull of the bundle
-      --force-delete               Force delete all records associated with the installation, even if the uninstall action does not succeed
+      --force-delete               UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.

--- a/pkg/cnab/provider/helpers.go
+++ b/pkg/cnab/provider/helpers.go
@@ -45,6 +45,8 @@ func (t *TestRuntime) LoadBundle(bundleFile string) (bundle.Bundle, error) {
 }
 
 func (t *TestRuntime) Execute(args ActionArguments) error {
-	args.Driver = debugDriver
+	if args.Driver == "" {
+		args.Driver = debugDriver
+	}
 	return t.Runtime.Execute(args)
 }

--- a/pkg/context/helpers.go
+++ b/pkg/context/helpers.go
@@ -135,6 +135,41 @@ func (c *TestContext) AddTestDirectory(srcDir, destDir string) {
 	}
 }
 
+func (c *TestContext) AddTestDriver(src, name string) string {
+	c.T.Helper()
+
+	data, err := ioutil.ReadFile(src)
+	if err != nil {
+		c.T.Fatal(err)
+	}
+
+	dirname, err := c.FileSystem.TempDir("", "porter")
+	if err != nil {
+		c.T.Fatal(err)
+	}
+
+	// filename in accordance with cnab-go's command driver expectations
+	filename := fmt.Sprintf("%s/cnab-%s", dirname, name)
+
+	newfile, err := c.FileSystem.Create(filename)
+	if err != nil {
+		c.T.Fatal(err)
+	}
+
+	if len(data) > 0 {
+		newfile.Write(data)
+	}
+
+	c.FileSystem.Chmod(newfile.Name(), os.ModePerm)
+	newfile.Close()
+	path := os.Getenv("PATH")
+	pathlist := []string{dirname, path}
+	newpath := strings.Join(pathlist, string(os.PathListSeparator))
+	os.Setenv("PATH", newpath)
+
+	return dirname
+}
+
 // GetOutput returns all text printed to stdout.
 func (c *TestContext) GetOutput() string {
 	return string(c.capturedOut.Bytes())

--- a/pkg/context/helpers.go
+++ b/pkg/context/helpers.go
@@ -157,11 +157,21 @@ func (c *TestContext) AddTestDriver(src, name string) string {
 	}
 
 	if len(data) > 0 {
-		newfile.Write(data)
+		_, err := newfile.Write(data)
+		if err != nil {
+			c.T.Fatal(err)
+		}
 	}
 
-	c.FileSystem.Chmod(newfile.Name(), os.ModePerm)
-	newfile.Close()
+	err = c.FileSystem.Chmod(newfile.Name(), os.ModePerm)
+	if err != nil {
+		c.T.Fatal(err)
+	}
+	err = newfile.Close()
+	if err != nil {
+		c.T.Fatal(err)
+	}
+
 	path := os.Getenv("PATH")
 	pathlist := []string{dirname, path}
 	newpath := strings.Join(pathlist, string(os.PathListSeparator))

--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -10,6 +10,9 @@ import (
 
 const installationDeleteTmpl = "deleting installation records for %s...\n"
 
+// ErrUnsafeInstallationDelete warns the user that deletion of an unsuccessfully uninstalled installation is unsafe
+var ErrUnsafeInstallationDelete = errors.New("it is unsafe to delete an installation when the last action wasn't a successful uninstall; if you are sure it should be deleted, retry the last command with the --force flag")
+
 // DeleteOptions represent options for Porter's installation delete command
 type DeleteOptions struct {
 	sharedOptions
@@ -45,7 +48,7 @@ func (p *Porter) DeleteInstallation(opts DeleteOptions) error {
 	result, err := p.Claims.ReadLastResult(claim.ID)
 
 	if (claim.Action != claims.ActionUninstall || result.Status != claims.StatusSucceeded) && !opts.Force {
-		return fmt.Errorf("not deleting installation as the last action was not a successful %s; use --force to override", claims.ActionUninstall)
+		return ErrUnsafeInstallationDelete
 	}
 
 	fmt.Fprintf(p.Out, installationDeleteTmpl, opts.Name)

--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -10,8 +10,13 @@ import (
 
 const installationDeleteTmpl = "deleting installation records for %s...\n"
 
-// ErrUnsafeInstallationDelete warns the user that deletion of an unsuccessfully uninstalled installation is unsafe
-var ErrUnsafeInstallationDelete = errors.New("it is unsafe to delete an installation when the last action wasn't a successful uninstall; if you are sure it should be deleted, retry the last command with the --force flag")
+var (
+	// ErrUnsafeInstallationDelete warns the user that deletion of an unsuccessfully uninstalled installation is unsafe
+	ErrUnsafeInstallationDelete = errors.New("it is unsafe to delete an installation when the last action wasn't a successful uninstall")
+
+	// ErrUnsafeInstallationDeleteRetryForce presents the ErrUnsafeInstallationDelete error and provides a retry option of --force
+	ErrUnsafeInstallationDeleteRetryForce = fmt.Errorf("%s; if you are sure it should be deleted, retry the last command with the --force flag", ErrUnsafeInstallationDelete)
+)
 
 // DeleteOptions represent options for Porter's installation delete command
 type DeleteOptions struct {
@@ -48,7 +53,7 @@ func (p *Porter) DeleteInstallation(opts DeleteOptions) error {
 	}
 
 	if (claim.Action != claims.ActionUninstall || installation.GetLastStatus() != claims.StatusSucceeded) && !opts.Force {
-		return ErrUnsafeInstallationDelete
+		return ErrUnsafeInstallationDeleteRetryForce
 	}
 
 	fmt.Fprintf(p.Out, installationDeleteTmpl, opts.Name)

--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -1,0 +1,53 @@
+package porter
+
+import (
+	"fmt"
+
+	"get.porter.sh/porter/pkg/context"
+	claims "github.com/cnabio/cnab-go/claim"
+	"github.com/pkg/errors"
+)
+
+const installationDeleteTmpl = "deleting installation records for %s...\n"
+
+// DeleteOptions represent options for Porter's installation delete command
+type DeleteOptions struct {
+	sharedOptions
+	Force bool
+}
+
+// Validate prepares for an installation delete action and validates the args/options.
+func (o *DeleteOptions) Validate(args []string, cxt *context.Context) error {
+	// Ensure only one argument exists (installation name) if args length non-zero
+	err := o.sharedOptions.validateInstallationName(args)
+	if err != nil {
+		return err
+	}
+
+	return o.sharedOptions.defaultBundleFiles(cxt)
+}
+
+// DeleteInstallation handles deletion of an installation
+func (p *Porter) DeleteInstallation(opts DeleteOptions) error {
+	err := p.applyDefaultOptions(&opts.sharedOptions)
+	if err != nil {
+		return err
+	}
+
+	// TODO: do we check to see if the installation claim has required deps
+	// declared and if so, attempt to delete them as well?
+
+	claim, err := p.Claims.ReadLastClaim(opts.Name)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read last claim for installation %s", opts.Name)
+	}
+
+	result, err := p.Claims.ReadLastResult(claim.ID)
+
+	if (claim.Action != claims.ActionUninstall || result.Status != claims.StatusSucceeded) && !opts.Force {
+		return fmt.Errorf("not deleting installation as the last action was not a successful %s; use --force to override", claims.ActionUninstall)
+	}
+
+	fmt.Fprintf(p.Out, installationDeleteTmpl, opts.Name)
+	return p.Claims.DeleteInstallation(opts.Name)
+}

--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -37,17 +37,17 @@ func (p *Porter) DeleteInstallation(opts DeleteOptions) error {
 		return err
 	}
 
-	// TODO: do we check to see if the installation claim has required deps
-	// declared and if so, attempt to delete them as well?
-
-	claim, err := p.Claims.ReadLastClaim(opts.Name)
+	installation, err := p.Claims.ReadInstallationStatus(opts.Name)
 	if err != nil {
-		return errors.Wrapf(err, "unable to read last claim for installation %s", opts.Name)
+		return errors.Wrapf(err, "unable to read status for installation %s", opts.Name)
 	}
 
-	result, err := p.Claims.ReadLastResult(claim.ID)
+	claim, err := installation.GetLastClaim()
+	if err != nil {
+		return errors.Wrapf(err, "unable to read most recent record for installation %s", opts.Name)
+	}
 
-	if (claim.Action != claims.ActionUninstall || result.Status != claims.StatusSucceeded) && !opts.Force {
+	if (claim.Action != claims.ActionUninstall || installation.GetLastStatus() != claims.StatusSucceeded) && !opts.Force {
 		return ErrUnsafeInstallationDelete
 	}
 

--- a/pkg/porter/delete_test.go
+++ b/pkg/porter/delete_test.go
@@ -17,7 +17,7 @@ func TestDeleteInstallation(t *testing.T) {
 		installationExists bool
 		wantError          string
 	}{
-		{"not yet installed", "", "", false, false, "unable to read last claim for installation test: Installation does not exist"},
+		{"not yet installed", "", "", false, false, "unable to read status for installation test: Installation does not exist"},
 		{"last action not uninstall - no force", "install", claim.StatusSucceeded, false, true, ErrUnsafeInstallationDelete.Error()},
 		{"last action failed uninstall - no force", "uninstall", claim.StatusFailed, false, true, ErrUnsafeInstallationDelete.Error()},
 		{"last action not uninstall - force", "install", claim.StatusSucceeded, true, false, ""},
@@ -34,17 +34,12 @@ func TestDeleteInstallation(t *testing.T) {
 			// Create test claim
 			if tc.lastAction != "" {
 				c := p.TestClaims.CreateClaim("test", tc.lastAction, bundle.Bundle{}, nil)
-				err := p.Claims.SaveClaim(c)
-				require.NoError(t, err, "SaveClaim failed")
 				_ = p.TestClaims.CreateResult(c, tc.lastActionStatus)
 			}
 
-			opts := DeleteOptions{
-				sharedOptions: sharedOptions{
-					Name: "test",
-				},
-				Force: tc.force,
-			}
+			opts := DeleteOptions{}
+			opts.Name = "test"
+			opts.Force = tc.force
 
 			err = p.DeleteInstallation(opts)
 			if tc.wantError != "" {

--- a/pkg/porter/delete_test.go
+++ b/pkg/porter/delete_test.go
@@ -18,8 +18,8 @@ func TestDeleteInstallation(t *testing.T) {
 		wantError          string
 	}{
 		{"not yet installed", "", "", false, false, "unable to read last claim for installation test: Installation does not exist"},
-		{"last action not uninstall - no force", "install", claim.StatusSucceeded, false, true, "not deleting installation as the last action was not a successful uninstall; use --force to override"},
-		{"last action failed uninstall - no force", "uninstall", claim.StatusFailed, false, true, "not deleting installation as the last action was not a successful uninstall; use --force to override"},
+		{"last action not uninstall - no force", "install", claim.StatusSucceeded, false, true, ErrUnsafeInstallationDelete.Error()},
+		{"last action failed uninstall - no force", "uninstall", claim.StatusFailed, false, true, ErrUnsafeInstallationDelete.Error()},
 		{"last action not uninstall - force", "install", claim.StatusSucceeded, true, false, ""},
 		{"last action failed uninstall - force", "uninstall", claim.StatusFailed, true, false, ""},
 	}

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -266,12 +266,15 @@ func (e *dependencyExecutioner) executeDependency(dep *queuedDependency, parentA
 		executeErrs = multierror.Append(executeErrs, errors.Wrapf(err, "error executing dependency %s", dep.Alias))
 
 		// Handle errors when/if the action is uninstall
+		// If uninstallOpts is an empty struct, executeErrs will pass through
 		executeErrs = uninstallOpts.handleUninstallErrs(e.Out, executeErrs)
 		if executeErrs != nil {
 			return executeErrs
 		}
 	}
 
+	// If uninstallOpts is an empty struct (i.e., action not Uninstall), this
+	// will resolve to false and thus be a no-op
 	if uninstallOpts.shouldDelete() {
 		fmt.Fprintf(e.Out, installationDeleteTmpl, depArgs.Installation)
 		return e.Claims.DeleteInstallation(depArgs.Installation)

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -258,7 +258,7 @@ func (e *dependencyExecutioner) executeDependency(dep *queuedDependency, parentA
 
 		if depArgs.Action == claim.ActionUninstall {
 			if e.parentOpts.Delete && !e.parentOpts.ForceDelete {
-				executeErrs = multierror.Append(executeErrs, fmt.Errorf("not deleting installation %s as uninstall was not successful; use --force-delete to override", depArgs.Installation))
+				executeErrs = multierror.Append(executeErrs, ErrUnsafeInstallationDeleteRetryForceDelete)
 			}
 		}
 

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -83,7 +83,7 @@ func (e *dependencyExecutioner) Execute() error {
 	}
 
 	// executeDependency the requested action against all of the dependencies
-	parentArgs := e.parentOpts.ToActionArgs(e)
+	parentArgs := e.bundleLifecycleOpts.ToActionArgs(e)
 	for _, dep := range e.deps {
 		err := e.executeDependency(dep, parentArgs)
 		if err != nil {

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -112,6 +112,19 @@ func (p *TestPorter) AddTestFile(src string, dest string) {
 	p.TestConfig.TestContext.AddTestFile(src, dest)
 }
 
+type TestDriver struct {
+	Name     string
+	Filepath string
+}
+
+func (p *TestPorter) AddTestDriver(driver TestDriver) string {
+	if !filepath.IsAbs(driver.Filepath) {
+		driver.Filepath = filepath.Join(p.TestDir, driver.Filepath)
+	}
+
+	return p.TestConfig.TestContext.AddTestDriver(driver.Filepath, driver.Name)
+}
+
 func (p *TestPorter) CreateBundleDir() string {
 	bundleDir, err := ioutil.TempDir("", "bundle")
 	require.NoError(p.T(), err)

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -7,6 +7,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var _ BundleAction = InstallOptions{}
+
 // InstallOptions that may be specified when installing a bundle.
 // Porter handles defaulting any missing values.
 type InstallOptions struct {
@@ -27,7 +29,7 @@ func (p *Porter) InstallBundle(opts InstallOptions) error {
 	}
 
 	deperator := newDependencyExecutioner(p, claim.ActionInstall)
-	err = deperator.Prepare(opts.BundleLifecycleOpts)
+	err = deperator.Prepare(opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -6,6 +6,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var _ BundleAction = InvokeOptions{}
+
 // InvokeOptions that may be specified when invoking a bundle.
 // Porter handles defaulting any missing values.
 type InvokeOptions struct {
@@ -36,7 +38,7 @@ func (p *Porter) InvokeBundle(opts InvokeOptions) error {
 	}
 
 	deperator := newDependencyExecutioner(p, opts.Action)
-	err = deperator.Prepare(opts.BundleLifecycleOpts)
+	err = deperator.Prepare(opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -5,11 +5,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+var _ BundleAction = BundleLifecycleOpts{}
+
+// BundleAction is an interface that defines methods related to constructing
+// ActionArguments and supplying BundleLifecycleOptions.  The latter is useful
+// when the implementation contains further, action-specific options beyond
+// the stock BundleLifecycleOptions.
+type BundleAction interface {
+	ToActionArgs(*dependencyExecutioner) cnabprovider.ActionArguments
+
+	GetBundleLifecycleOptions() BundleLifecycleOpts
+}
+
 type BundleLifecycleOpts struct {
 	sharedOptions
 	BundlePullOptions
 	AllowAccessToDockerHost bool
-	UninstallDeleteOptions
 }
 
 func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {
@@ -28,8 +39,12 @@ func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {
 	return nil
 }
 
+func (o BundleLifecycleOpts) GetBundleLifecycleOptions() BundleLifecycleOpts {
+	return o
+}
+
 // ToActionArgs converts this instance of user-provided action options.
-func (o *BundleLifecycleOpts) ToActionArgs(deperator *dependencyExecutioner) cnabprovider.ActionArguments {
+func (o BundleLifecycleOpts) ToActionArgs(deperator *dependencyExecutioner) cnabprovider.ActionArguments {
 	args := cnabprovider.ActionArguments{
 		Action:                deperator.Action,
 		Installation:          o.Name,

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -9,6 +9,7 @@ type BundleLifecycleOpts struct {
 	sharedOptions
 	BundlePullOptions
 	AllowAccessToDockerHost bool
+	UninstallDeleteOptions
 }
 
 func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -7,13 +7,10 @@ import (
 
 var _ BundleAction = BundleLifecycleOpts{}
 
-// BundleAction is an interface that defines methods related to constructing
-// ActionArguments and supplying BundleLifecycleOptions.  The latter is useful
-// when the implementation contains further, action-specific options beyond
-// the stock BundleLifecycleOptions.
+// BundleAction is an interface that defines a method for supplying
+// BundleLifecycleOptions.  This is useful when implementations contain
+// action-specific options beyond the stock BundleLifecycleOptions.
 type BundleAction interface {
-	ToActionArgs(*dependencyExecutioner) cnabprovider.ActionArguments
-
 	GetBundleLifecycleOptions() BundleLifecycleOpts
 }
 

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var _ BundleAction = UninstallOptions{}
+
 // ErrUnsafeInstallationDeleteRetryForceDelete presents the ErrUnsafeInstallationDelete error and provides a retry option of --force-delete
 var ErrUnsafeInstallationDeleteRetryForceDelete = fmt.Errorf("%s; if you are sure it should be deleted, retry the last command with the --force-delete flag", ErrUnsafeInstallationDelete)
 
@@ -17,6 +19,7 @@ var ErrUnsafeInstallationDeleteRetryForceDelete = fmt.Errorf("%s; if you are sur
 // Porter handles defaulting any missing values.
 type UninstallOptions struct {
 	BundleLifecycleOpts
+	UninstallDeleteOptions
 }
 
 // UninstallDeleteOptions supply options for deletion on uninstall
@@ -49,6 +52,10 @@ func (opts *UninstallDeleteOptions) handleUninstallErrs(out io.Writer, err error
 	return err
 }
 
+func (opts UninstallOptions) GetBundleLifecycleOptions() BundleLifecycleOpts {
+	return opts.BundleLifecycleOpts
+}
+
 // UninstallBundle accepts a set of pre-validated UninstallOptions and uses
 // them to uninstall a bundle.
 func (p *Porter) UninstallBundle(opts UninstallOptions) error {
@@ -63,7 +70,7 @@ func (p *Porter) UninstallBundle(opts UninstallOptions) error {
 	}
 
 	deperator := newDependencyExecutioner(p, claim.ActionUninstall)
-	err = deperator.Prepare(opts.BundleLifecycleOpts)
+	err = deperator.Prepare(opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/uninstall_test.go
+++ b/pkg/porter/uninstall_test.go
@@ -1,0 +1,55 @@
+package porter
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPorter_HandleUninstallErrs(t *testing.T) {
+	testcases := []struct {
+		name    string
+		opts    UninstallDeleteOptions
+		err     error
+		wantOut string
+		wantErr string
+	}{
+		{
+			name: "no delete; no err",
+			opts: UninstallDeleteOptions{},
+		}, {
+			name:    "no delete",
+			opts:    UninstallDeleteOptions{},
+			err:     errors.New("an error was encountered"),
+			wantErr: "an error was encountered",
+		}, {
+			name:    "--delete; no --force-delete",
+			opts:    UninstallDeleteOptions{Delete: true},
+			err:     errors.New("an error was encountered"),
+			wantErr: fmt.Sprintf("2 errors occurred:\n\t* an error was encountered\n\t* %s\n\n", ErrUnsafeInstallationDeleteRetryForceDelete),
+		}, {
+			name:    "--force-delete",
+			opts:    UninstallDeleteOptions{ForceDelete: true},
+			err:     errors.New("an error was encountered"),
+			wantOut: "ignoring the following errors as --force-delete is true:\n  an error was encountered",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := bytes.NewBufferString("")
+
+			err := tc.opts.handleUninstallErrs(out, tc.err)
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.wantOut, out.String())
+		})
+	}
+}

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -7,6 +7,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var _ BundleAction = UpgradeOptions{}
+
 // UpgradeOptions that may be specified when upgrading a bundle.
 // Porter handles defaulting any missing values.
 type UpgradeOptions struct {
@@ -27,7 +29,7 @@ func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
 	}
 
 	deperator := newDependencyExecutioner(p, claim.ActionUpgrade)
-	err = deperator.Prepare(opts.BundleLifecycleOpts)
+	err = deperator.Prepare(opts)
 	if err != nil {
 		return err
 	}

--- a/tests/dependencies_test.go
+++ b/tests/dependencies_test.go
@@ -71,6 +71,7 @@ func installWordpressBundle(p *porter.TestPorter) (namespace string) {
 		"wordpress-password=mypassword",
 		"namespace=" + namespace,
 		"wordpress-name=porter-ci-wordpress-" + namespace,
+		"mysql#namespace=" + namespace,
 		"mysql#mysql-name=porter-ci-mysql-" + namespace,
 	}
 	// Add a supplemental parameter set to vet dep param resolution
@@ -131,6 +132,7 @@ func upgradeWordpressBundle(p *porter.TestPorter, namespace string) {
 		"wordpress-password=mypassword",
 		"namespace=" + namespace,
 		"wordpress-name=porter-ci-wordpress-" + namespace,
+		"mysql#namespace=" + namespace,
 		"mysql#mysql-name=porter-ci-mysql-" + namespace,
 	}
 	err := upgradeOpts.Validate([]string{}, p.Porter)
@@ -163,6 +165,7 @@ func invokeWordpressBundle(p *porter.TestPorter, namespace string) {
 		"wordpress-password=mypassword",
 		"namespace=" + namespace,
 		"wordpress-name=porter-ci-wordpress-" + namespace,
+		"mysql#namespace=" + namespace,
 		"mysql#mysql-name=porter-ci-mysql-" + namespace,
 	}
 	err := invokeOpts.Validate([]string{}, p.Porter)

--- a/tests/testdata/drivers/exit-driver-fail.sh
+++ b/tests/testdata/drivers/exit-driver-fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# stub out support for imageType of "docker"
+if [[ "$@" == "--handles" ]]; then
+  echo "docker"
+else
+  exit 1
+fi

--- a/tests/testdata/drivers/exit-driver.sh
+++ b/tests/testdata/drivers/exit-driver.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# stub out support for imageType of "docker"
+if [[ "$@" == "--handles" ]]; then
+  echo "docker"
+else
+  exit 0
+fi

--- a/tests/uninstall_test.go
+++ b/tests/uninstall_test.go
@@ -1,0 +1,91 @@
+// +build integration
+
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"get.porter.sh/porter/pkg/porter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUninstall_DeleteInstallation(t *testing.T) {
+	testcases := []struct {
+		name               string
+		installed          bool
+		uninstallFails     bool
+		delete             bool
+		forceDelete        bool
+		installationExists bool
+		wantError          string
+	}{
+		{"not yet installed", false, false, false, false, false, "1 error occurred:\n\t* could not load installation HELLO: Installation does not exist\n\n"},
+		{"no delete", true, false, false, false, true, ""},
+		{"delete", true, false, true, false, false, ""},
+		{"uninstall fails - delete", true, true, true, false, true, "2 errors occurred:\n\t* Command driver (uninstall) failed executing bundle: exit status 1\n\t* not deleting installation HELLO as uninstall was not successful; use --force-delete to override\n\n"},
+		{"uninstall fails - force-delete", true, true, false, true, false, ""},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := porter.NewTestPorter(t)
+
+			p.SetupIntegrationTest()
+			defer p.CleanupIntegrationTest()
+			p.Debug = false
+
+			err := p.Create()
+			require.NoError(t, err)
+
+			// Install bundle
+			if tc.installed {
+				opts := porter.InstallOptions{}
+				opts.Driver = "debug"
+
+				err = opts.Validate(nil, p.Porter)
+				require.NoError(t, err, "Validate install options failed")
+
+				err = p.InstallBundle(opts)
+				require.NoError(t, err, "InstallBundle failed")
+			}
+
+			// Set up command driver
+			driver := porter.TestDriver{
+				Name:     "uninstall",
+				Filepath: "testdata/drivers/exit-driver.sh",
+			}
+			if tc.uninstallFails {
+				driver.Filepath = "testdata/drivers/exit-driver-fail.sh"
+			}
+
+			path := os.Getenv("PATH")
+			dir := p.AddTestDriver(driver)
+			defer os.Setenv("PATH", path)
+			defer p.TestConfig.TestContext.FileSystem.RemoveAll(dir)
+
+			// Uninstall bundle with custom command driver
+			opts := porter.UninstallOptions{}
+			opts.Delete = tc.delete
+			opts.ForceDelete = tc.forceDelete
+			opts.Driver = driver.Name
+
+			err = opts.Validate(nil, p.Porter)
+			require.NoError(t, err, "Validate uninstall options failed")
+
+			err = p.UninstallBundle(opts)
+			if tc.wantError != "" {
+				require.EqualError(t, err, tc.wantError)
+			} else {
+				require.NoError(t, err, "UninstallBundle failed")
+			}
+
+			_, err = p.Claims.ReadInstallation(opts.Name)
+			if tc.installationExists {
+				require.NoError(t, err, "Installation is expected to exist")
+			} else {
+				require.EqualError(t, err, "Installation does not exist")
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What does this change
* Adds logic to enable deleting an installation, either via `porter uninstall` or `porter installation delete` (as designed in https://github.com/deislabs/porter/issues/1163)

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/1163

# Notes for the reviewer
- Do we want any additional docs besides the auto-gen'd CLI docs?
- Suggestions for simplifying logic around uninstall +/- delete +/- force-delete welcome.
- Note how we are swallowing errors around the execution of the uninstall action if force-delete is true -- do we like this approach?  Or should we continue to return any/all execution errors after we force delete the installation?

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml) N/A

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md