### PR TITLE
fix(manifest): update applyTo on a param, if needed

### DIFF
--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -141,6 +141,9 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 	params := make(map[string]bundle.Parameter, len(c.Manifest.Parameters))
 
 	addParam := func(param manifest.ParameterDefinition) {
+		// Update ApplyTo per parameter definition and manifest
+		param.UpdateApplyTo(c.Manifest)
+
 		p := bundle.Parameter{
 			Definition:  param.Name,
 			ApplyTo:     param.ApplyTo,

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -405,6 +405,9 @@ func (m *RuntimeManifest) Prepare() error {
 	// For parameters of type "file", we may need to decode files on the filesystem
 	// before execution of the step/action
 	for _, param := range m.Parameters {
+		// Update ApplyTo per parameter definition and manifest
+		param.UpdateApplyTo(m.Manifest)
+
 		if !param.AppliesTo(string(m.Action)) {
 			continue
 		}


### PR DESCRIPTION
# What does this change
* Adds logic to update a parameter's `applyTo` section under certain conditions, as described in https://github.com/deislabs/porter/issues/1159

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/1159

# Notes for the reviewer
I'm not entirely happy with the approach of needing to explicitly call `UpdateApplyTo` both when converting a manifest to a bundle and when converting a manifest to its runtime variant when running an action.  (Basically, on build and during runtime).  But it does appear that the manifest is loaded anew in each place, hence the two places to update.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md