### PR TITLE
ref(archive): update archive command to require --tag

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -327,14 +327,10 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 
 	opts := porter.ArchiveOptions{}
 	cmd := cobra.Command{
-		Use:   "archive FILENAME",
-		Short: "Archive a bundle",
-		Long:  "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
-		Example: `  porter bundle archive mybun.tgz
-  porter bundle archive mybun.tgz --file another/porter.yaml
-  porter bundle archive mybun.tgz --cnab-file some/bundle.json
-  porter bundle archive mybun.tgz --tag repo/bundle:tag
-		  `,
+		Use:     "archive FILENAME --tag PUBLISHED_BUNDLE",
+		Short:   "Archive a bundle from a tag",
+		Long:    "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
+		Example: `  porter bundle archive mybun.tgz --tag repo/bundle:tag`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)
 		},
@@ -343,8 +339,6 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 		},
 	}
 	f := cmd.Flags()
-	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
 	f.StringVarP(&opts.Tag, "tag", "t", "",
 		"Use a bundle in an OCI registry specified by the given tag")
 	f.BoolVar(&opts.Force, "force", false,

--- a/docs/content/archive-bundles.md
+++ b/docs/content/archive-bundles.md
@@ -7,21 +7,19 @@ Porter allows you to share bundles by [publishing](/distribute-bundles) them to 
 
 ## Generating a Bundle Archive With Porter
 
-To generate the archive, you run the `porter archive` command. For example, assume you are working with a local bundle. To generate the archive, you would run the following command:
+In order to generate the archive, all of the images in the bundle **must** have been published to a registry. For this reason, you must first `publish` your bundle to a registry:
 
 ```
-porter archive bundle-archive-file-name.tgz
+porter publish --tag jeremyrickard/porter-do-bundle:v0.5.0
 ```
 
-NOTE: In order to generate the archive, all of the images in the bundle **must** have been published to a registry. For this reason, it is best to first `publish` your bundle to a registry.
-
-This will generate a file in the directory named `bundle-archive-file-name.tgz`.
-
-Porter can generate a bundle archive from a local `porter.yaml` manifest, a local `bundle.json` or a published bundle via a bundle reference, like `deislabs/kubundle:1.5.0`. The recommended way to produce an archive is to first publish the bundle. This will ensure that the invocation image has been pushed to a registry. Once a bundle has been published, to `jeremyrickard/porter-do-bundle:v0.5.0` for example, you can archive it using the following command:
+Now you can run the `porter archive` command and designate the archive file name and bundle tag to use:
 
 ```
 porter archive --tag jeremyrickard/porter-do-bundle:v0.5.0 do-porter.tgz
 ```
+
+This will generate a file in the directory named `do-porter.tgz`.
 
 ## Bundle Archive Format
 

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -5,34 +5,28 @@ url: /cli/porter_archive/
 ---
 ## porter archive
 
-Archive a bundle
+Archive a bundle from a tag
 
 ### Synopsis
 
 Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.
 
 ```
-porter archive FILENAME [flags]
+porter archive FILENAME --tag PUBLISHED_BUNDLE [flags]
 ```
 
 ### Examples
 
 ```
-  porter archive mybun.tgz
-  porter archive mybun.tgz --file another/porter.yaml
-  porter archive mybun.tgz --cnab-file some/bundle.json
   porter archive mybun.tgz --tag repo/bundle:tag
-		  
 ```
 
 ### Options
 
 ```
-      --cnab-file string   Path to the CNAB bundle.json file.
-  -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force              Force a fresh pull of the bundle
-  -h, --help               help for archive
-  -t, --tag string         Use a bundle in an OCI registry specified by the given tag
+      --force        Force a fresh pull of the bundle
+  -h, --help         help for archive
+  -t, --tag string   Use a bundle in an OCI registry specified by the given tag
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles.md
+++ b/docs/content/cli/bundles.md
@@ -27,7 +27,7 @@ Commands for working with bundles. These all have shortcuts so that you can call
 ### SEE ALSO
 
 * [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
-* [porter bundles archive](/cli/porter_bundles_archive/)	 - Archive a bundle
+* [porter bundles archive](/cli/porter_bundles_archive/)	 - Archive a bundle from a tag
 * [porter bundles build](/cli/porter_bundles_build/)	 - Build a bundle
 * [porter bundles copy](/cli/porter_bundles_copy/)	 - Copy a bundle
 * [porter bundles create](/cli/porter_bundles_create/)	 - Create a bundle

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -5,34 +5,28 @@ url: /cli/porter_bundles_archive/
 ---
 ## porter bundles archive
 
-Archive a bundle
+Archive a bundle from a tag
 
 ### Synopsis
 
 Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.
 
 ```
-porter bundles archive FILENAME [flags]
+porter bundles archive FILENAME --tag PUBLISHED_BUNDLE [flags]
 ```
 
 ### Examples
 
 ```
-  porter bundle archive mybun.tgz
-  porter bundle archive mybun.tgz --file another/porter.yaml
-  porter bundle archive mybun.tgz --cnab-file some/bundle.json
   porter bundle archive mybun.tgz --tag repo/bundle:tag
-		  
 ```
 
 ### Options
 
 ```
-      --cnab-file string   Path to the CNAB bundle.json file.
-  -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force              Force a fresh pull of the bundle
-  -h, --help               help for archive
-  -t, --tag string         Use a bundle in an OCI registry specified by the given tag
+      --force        Force a fresh pull of the bundle
+  -h, --help         help for archive
+  -t, --tag string   Use a bundle in an OCI registry specified by the given tag
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/porter.md
+++ b/docs/content/cli/porter.md
@@ -35,7 +35,7 @@ porter [flags]
 
 ### SEE ALSO
 
-* [porter archive](/cli/porter_archive/)	 - Archive a bundle
+* [porter archive](/cli/porter_archive/)	 - Archive a bundle from a tag
 * [porter build](/cli/porter_build/)	 - Build a bundle
 * [porter bundles](/cli/porter_bundles/)	 - Bundle commands
 * [porter copy](/cli/porter_copy/)	 - Copy a bundle

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -25,7 +25,14 @@ func (o *ArchiveOptions) Validate(args []string, p *Porter) error {
 	if len(args) < 1 || args[0] == "" {
 		return errors.New("destination file is required")
 	}
+	if len(args) > 1 {
+		return errors.Errorf("only one positional argument may be specified, the archive file name, but multiple were received: %s", args)
+	}
 	o.ArchiveFile = args[0]
+
+	if o.Tag == "" {
+		return errors.New("must provide a value for --tag of the form REGISTRY/bundle:tag")
+	}
 	return o.BundleLifecycleOpts.Validate(args, p)
 }
 
@@ -56,7 +63,7 @@ func (p *Porter) Archive(opts ArchiveOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "couldn't open bundle for archiving")
 	}
-	// This allows you to export thin or thick bundles, we only support generting "thick" archives
+	// This allows you to export thin or thick bundles, we only support generating "thick" archives
 	ctor, err := construction.NewConstructor(false)
 	if err != nil {
 		return err

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -10,10 +10,41 @@ func TestArchive_ParentDirDoesNotExist(t *testing.T) {
 	p := NewTestPorter(t)
 
 	opts := ArchiveOptions{}
+	opts.Tag = "myreg/mybuns:v0.1.0"
 
 	err := opts.Validate([]string{"/path/to/file"}, p.Porter)
 	require.NoError(t, err, "expected no validation error to occur")
 
 	err = p.Archive(opts)
 	require.EqualError(t, err, "parent directory \"/path/to\" does not exist")
+}
+
+func TestArchive_Validate(t *testing.T) {
+	p := NewTestPorter(t)
+
+	testcases := []struct {
+		name      string
+		args      []string
+		tag       string
+		wantError string
+	}{
+		{"no arg", nil, "", "destination file is required"},
+		{"no tag", []string{"/path/to/file"}, "", "must provide a value for --tag of the form REGISTRY/bundle:tag"},
+		{"too many args", []string{"/path/to/file", "moar args!"}, "myreg/mybuns:v0.1.0", "only one positional argument may be specified, the archive file name, but multiple were received: [/path/to/file moar args!]"},
+		{"just right", []string{"/path/to/file"}, "myreg/mybuns:v0.1.0", ""},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := ArchiveOptions{}
+			opts.Tag = tc.tag
+
+			err := opts.Validate(tc.args, p.Porter)
+			if tc.wantError != "" {
+				require.EqualError(t, err, tc.wantError)
+			} else {
+				require.NoError(t, err, "expected no validation error to occur")
+			}
+		})
+	}
 }

--- a/tests/archive_test.go
+++ b/tests/archive_test.go
@@ -32,6 +32,7 @@ func TestArchive(t *testing.T) {
 
 	// Archive bundle
 	archiveOpts := porter.ArchiveOptions{}
+	archiveOpts.Tag = "localhost:5000/mysql:v0.1.2"
 	err = archiveOpts.Validate([]string{"mybuns.tgz"}, p.Porter)
 	require.NoError(p.T(), err, "validation of archive opts for bundle failed")
 


### PR DESCRIPTION
# What does this change
* Updates the archive command to require a bundle tag (and remove the local options)

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/1100
Closes https://github.com/deislabs/porter/issues/697

# Notes for the reviewer
* Do we want to add further color in the documentation around why publishing is required first?  (e.g. CNAB Spec requires contentDigests for all images)

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml) N/A

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md