### PR TITLE
Ensure tag flags are applied consistently

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -101,11 +101,12 @@ The first argument is the name of the installation to create. This defaults to t
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle install
+  porter bundle install MyAppFromTag --tag getporter/kubernetes:v0.1.0
+  porter bundle install --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle install MyAppInDev --file myapp/bundle.json
   porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle install --cred azure --cred kubernetes
   porter bundle install --driver debug
-  porter bundle install MyAppFromTag --tag getporter/kubernetes:v0.1.0
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)
@@ -130,12 +131,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
-	f.StringVarP(&opts.Tag, "tag", "t", "",
-		"Use a bundle in an OCI registry specified by the given tag")
-	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
-		"Don't require TLS for the registry")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle and all dependencies")
+	addBundlePullFlags(f, &opts.BundlePullOptions)
 	return cmd
 }
 
@@ -151,11 +147,12 @@ The first argument is the installation name to upgrade. This defaults to the nam
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle upgrade
+  porter bundle upgrade --tag getporter/kubernetes:v0.1.0
+  porter bundle upgrade --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
   porter bundle upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle upgrade --cred azure --cred kubernetes
   porter bundle upgrade --driver debug
-  porter bundle upgrade MyAppFromTag --tag getporter/kubernetes:v0.1.0
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)
@@ -180,12 +177,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
-	f.StringVarP(&opts.Tag, "tag", "t", "",
-		"Use a bundle in an OCI registry specified by the given tag")
-	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
-		"Don't require TLS for the registry")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle and all dependencies")
+	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd
 }
@@ -202,11 +194,12 @@ The first argument is the installation name upon which to invoke the action. Thi
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle invoke --action ACTION
+  porter bundle invoke --tag getporter/kubernetes:v0.1.0
+  porter bundle invoke --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter bundle invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle invoke --action ACTION --cred azure --cred kubernetes
   porter bundle invoke --action ACTION --driver debug
-  porter bundle invoke --action ACTION MyAppFromTag --tag getporter/kubernetes:v0.1.0
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)
@@ -233,12 +226,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
-	f.StringVarP(&opts.Tag, "tag", "t", "",
-		"Use a bundle in an OCI registry specified by the given tag")
-	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
-		"Don't require TLS for the registry")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle and all dependencies")
+	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd
 }
@@ -255,12 +243,12 @@ The first argument is the installation name to uninstall. This defaults to the n
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle uninstall
+  porter bundle uninstall --tag getporter/kubernetes:v0.1.0
+  porter bundle uninstall --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
   porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
   porter bundle uninstall --driver debug
-  porter bundle uninstall MyAppFromTag --tag getporter/kubernetes:v0.1.0
-
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)
@@ -285,12 +273,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
-	f.StringVarP(&opts.Tag, "tag", "t", "",
-		"Use a bundle in an OCI registry specified by the given tag")
-	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
-		"Don't require TLS for the registry")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle and all dependencies")
+	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd
 }
@@ -316,9 +299,10 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
-	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false, "Don't require TLS for the registry.")
 	f.StringVarP(&opts.ArchiveFile, "archive", "a", "", "Path to the bundle archive in .tgz format")
-	f.StringVarP(&opts.Tag, "tag", "t", "", "Bundle tag for newly published bundle; required if --archive is supplied")
+	addTagFlag(f, &opts.BundlePullOptions)
+	addInsecureRegistryFlag(f, &opts.BundlePullOptions)
+	// We aren't using addBundlePullFlags because we don't use --force since we are pushing, and that flag isn't needed
 
 	return &cmd
 }
@@ -327,10 +311,12 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 
 	opts := porter.ArchiveOptions{}
 	cmd := cobra.Command{
-		Use:     "archive FILENAME --tag PUBLISHED_BUNDLE",
-		Short:   "Archive a bundle from a tag",
-		Long:    "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
-		Example: `  porter bundle archive mybun.tgz --tag repo/bundle:tag`,
+		Use:   "archive FILENAME --tag PUBLISHED_BUNDLE",
+		Short: "Archive a bundle from a tag",
+		Long:  "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
+		Example: `  porter bundle archive mybun.tgz --tag getporter/porter-hello:v0.1.0
+  porter bundle archive mybun.tgz --tag localhost:5000/getporter/porter-hello:v0.1.0 --force
+`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)
 		},
@@ -338,11 +324,8 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 			return p.Archive(opts)
 		},
 	}
-	f := cmd.Flags()
-	f.StringVarP(&opts.Tag, "tag", "t", "",
-		"Use a bundle in an OCI registry specified by the given tag")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle")
+
+	addBundlePullFlags(cmd.Flags(), &opts.BundlePullOptions)
 
 	return &cmd
 }

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -62,9 +62,10 @@ When you wish to install, upgrade or delete a bundle, Porter will use the
 credential set to determine where to read the necessary information from and
 will then provide it to the bundle in the correct location. `,
 		Example: `  porter credential generate
-  porter credential generate kubecred --file myapp/porter.yaml
   porter credential generate kubecred --tag getporter/porter-hello:v0.1.0
-  porter credential generate kubecred --cnab-file myapp/bundle.json --dry-run
+  porter credential generate kubecred --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter credential generate kubecred --file myapp/porter.yaml
+  porter credential generate kubecred --cnab-file myapp/bundle.json
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)
@@ -79,10 +80,7 @@ will then provide it to the bundle in the correct location. `,
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
-	f.StringVar(&opts.Tag, "tag", "",
-		"Use a bundle in an OCI registry specified by the given tag.")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle")
+	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd
 }

--- a/cmd/porter/explain.go
+++ b/cmd/porter/explain.go
@@ -14,9 +14,10 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
 		Short: "Explain a bundle",
 		Long:  "Explain how to use a bundle by printing the parameters, credentials, outputs, actions.",
 		Example: `  porter bundle explain
+  porter bundle explain --tag getporter/porter-hello:v0.1.0
+  porter bundle explain --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle explain --file another/porter.yaml
   porter bundle explain --cnab-file some/bundle.json
-  porter bundle explain --tag getporter/porter-hello:v0.1.0
 		  `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)
@@ -28,11 +29,9 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
-	f.StringVarP(&opts.Tag, "tag", "t", "",
-		"Use a bundle in an OCI registry specified by the given tag")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
+	addBundlePullFlags(f, &opts.BundlePullOptions)
+
 	return &cmd
 }

--- a/cmd/porter/inspect.go
+++ b/cmd/porter/inspect.go
@@ -17,9 +17,10 @@ If you would like more information about the bundle, the porter explain command 
 like parameters, credentials, outputs and custom actions available.
 `,
 		Example: `  porter bundle inspect
+  porter bundle inspect --tag getporter/porter-hello:v0.1.0
+  porter bundle inspect --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle inspect --file another/porter.yaml
   porter bundle inspect --cnab-file some/bundle.json
-  porter bundle inspect --tag getporter/porter-hello:v0.1.0
 		  `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)
@@ -31,11 +32,8 @@ like parameters, credentials, outputs and custom actions available.
 	f := cmd.Flags()
 	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
-	f.StringVarP(&opts.Tag, "tag", "t", "",
-		"Use a bundle in an OCI registry specified by the given tag")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
+	addBundlePullFlags(f, &opts.BundlePullOptions)
 	return &cmd
 }

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -9,6 +9,7 @@ import (
 	"get.porter.sh/porter/pkg/porter"
 	"github.com/gobuffalo/packr/v2"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var includeDocsCommand = false
@@ -128,4 +129,25 @@ func ShouldShowUngroupedCommand(cmd *cobra.Command) bool {
 
 	_, hasGroup := cmd.Annotations["group"]
 	return !hasGroup
+}
+
+func addBundlePullFlags(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
+	addTagFlag(f, opts)
+	addInsecureRegistryFlag(f, opts)
+	addForcePullFlag(f, opts)
+}
+
+func addTagFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
+	f.StringVar(&opts.Tag, "tag", "",
+		"Use a bundle in an OCI registry specified by the given tag.")
+}
+
+func addInsecureRegistryFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
+	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
+		"Don't require TLS for the registry")
+}
+
+func addForcePullFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle")
 }

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -62,9 +62,10 @@ When you wish to install, upgrade or delete a bundle, Porter will use the
 parameter set to determine where to read the necessary information from and
 will then provide it to the bundle in the correct location. `,
 		Example: `  porter parameter generate
-  porter parameter generate myparamset --file myapp/porter.yaml
   porter parameter generate myparamset --tag getporter/porter-hello:v0.1.0
-  porter parameter generate myparamset --cnab-file myapp/bundle.json --dry-run
+  porter parameter generate myparamset --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter parameter generate myparamset --file myapp/porter.yaml
+  porter parameter generate myparamset --cnab-file myapp/bundle.json
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)
@@ -79,10 +80,7 @@ will then provide it to the bundle in the correct location. `,
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
-	f.StringVar(&opts.Tag, "tag", "",
-		"Use a bundle in an OCI registry specified by the given tag.")
-	f.BoolVar(&opts.Force, "force", false,
-		"Force a fresh pull of the bundle")
+	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd
 }

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -18,15 +18,18 @@ porter archive FILENAME --tag PUBLISHED_BUNDLE [flags]
 ### Examples
 
 ```
-  porter archive mybun.tgz --tag repo/bundle:tag
+  porter archive mybun.tgz --tag getporter/porter-hello:v0.1.0
+  porter archive mybun.tgz --tag localhost:5000/getporter/porter-hello:v0.1.0 --force
+
 ```
 
 ### Options
 
 ```
-      --force        Force a fresh pull of the bundle
-  -h, --help         help for archive
-  -t, --tag string   Use a bundle in an OCI registry specified by the given tag
+      --force               Force a fresh pull of the bundle
+  -h, --help                help for archive
+      --insecure-registry   Don't require TLS for the registry
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -18,15 +18,18 @@ porter bundles archive FILENAME --tag PUBLISHED_BUNDLE [flags]
 ### Examples
 
 ```
-  porter bundle archive mybun.tgz --tag repo/bundle:tag
+  porter bundle archive mybun.tgz --tag getporter/porter-hello:v0.1.0
+  porter bundle archive mybun.tgz --tag localhost:5000/getporter/porter-hello:v0.1.0 --force
+
 ```
 
 ### Options
 
 ```
-      --force        Force a fresh pull of the bundle
-  -h, --help         help for archive
-  -t, --tag string   Use a bundle in an OCI registry specified by the given tag
+      --force               Force a fresh pull of the bundle
+  -h, --help                help for archive
+      --insecure-registry   Don't require TLS for the registry
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_explain.md
+++ b/docs/content/cli/bundles_explain.md
@@ -19,21 +19,23 @@ porter bundles explain [flags]
 
 ```
   porter bundle explain
+  porter bundle explain --tag getporter/porter-hello:v0.1.0
+  porter bundle explain --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle explain --file another/porter.yaml
   porter bundle explain --cnab-file some/bundle.json
-  porter bundle explain --tag getporter/porter-hello:v0.1.0
 		  
 ```
 
 ### Options
 
 ```
-      --cnab-file string   Path to the CNAB bundle.json file.
-  -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force              Force a fresh pull of the bundle
-  -h, --help               help for explain
-  -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
-  -t, --tag string         Use a bundle in an OCI registry specified by the given tag
+      --cnab-file string    Path to the CNAB bundle.json file.
+  -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force               Force a fresh pull of the bundle
+  -h, --help                help for explain
+      --insecure-registry   Don't require TLS for the registry
+  -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_inspect.md
+++ b/docs/content/cli/bundles_inspect.md
@@ -23,21 +23,23 @@ porter bundles inspect [flags]
 
 ```
   porter bundle inspect
+  porter bundle inspect --tag getporter/porter-hello:v0.1.0
+  porter bundle inspect --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle inspect --file another/porter.yaml
   porter bundle inspect --cnab-file some/bundle.json
-  porter bundle inspect --tag getporter/porter-hello:v0.1.0
 		  
 ```
 
 ### Options
 
 ```
-      --cnab-file string   Path to the CNAB bundle.json file.
-  -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force              Force a fresh pull of the bundle
-  -h, --help               help for inspect
-  -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
-  -t, --tag string         Use a bundle in an OCI registry specified by the given tag
+      --cnab-file string    Path to the CNAB bundle.json file.
+  -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force               Force a fresh pull of the bundle
+  -h, --help                help for inspect
+      --insecure-registry   Don't require TLS for the registry
+  -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -24,11 +24,12 @@ porter bundles install [INSTALLATION] [flags]
 
 ```
   porter bundle install
+  porter bundle install MyAppFromTag --tag getporter/kubernetes:v0.1.0
+  porter bundle install --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle install MyAppInDev --file myapp/bundle.json
   porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle install --cred azure --cred kubernetes
   porter bundle install --driver debug
-  porter bundle install MyAppFromTag --tag getporter/kubernetes:v0.1.0
 
 ```
 
@@ -40,12 +41,12 @@ porter bundles install [INSTALLATION] [flags]
   -c, --cred strings               Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                      Force a fresh pull of the bundle and all dependencies
+      --force                      Force a fresh pull of the bundle
   -h, --help                       help for install
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
+      --tag string                 Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -24,11 +24,12 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
 
 ```
   porter bundle invoke --action ACTION
+  porter bundle invoke --tag getporter/kubernetes:v0.1.0
+  porter bundle invoke --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter bundle invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle invoke --action ACTION --cred azure --cred kubernetes
   porter bundle invoke --action ACTION --driver debug
-  porter bundle invoke --action ACTION MyAppFromTag --tag getporter/kubernetes:v0.1.0
 
 ```
 
@@ -41,12 +42,12 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
   -c, --cred strings               Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                      Force a fresh pull of the bundle and all dependencies
+      --force                      Force a fresh pull of the bundle
   -h, --help                       help for invoke
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
+      --tag string                 Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -24,12 +24,12 @@ porter bundles uninstall [INSTALLATION] [flags]
 
 ```
   porter bundle uninstall
+  porter bundle uninstall --tag getporter/kubernetes:v0.1.0
+  porter bundle uninstall --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
   porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
   porter bundle uninstall --driver debug
-  porter bundle uninstall MyAppFromTag --tag getporter/kubernetes:v0.1.0
-
 
 ```
 
@@ -41,12 +41,12 @@ porter bundles uninstall [INSTALLATION] [flags]
   -c, --cred strings               Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
-      --force                      Force a fresh pull of the bundle and all dependencies
+      --force                      Force a fresh pull of the bundle
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
+      --tag string                 Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -24,11 +24,12 @@ porter bundles upgrade [INSTALLATION] [flags]
 
 ```
   porter bundle upgrade
+  porter bundle upgrade --tag getporter/kubernetes:v0.1.0
+  porter bundle upgrade --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
   porter bundle upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle upgrade --cred azure --cred kubernetes
   porter bundle upgrade --driver debug
-  porter bundle upgrade MyAppFromTag --tag getporter/kubernetes:v0.1.0
 
 ```
 
@@ -40,12 +41,12 @@ porter bundles upgrade [INSTALLATION] [flags]
   -c, --cred strings               Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                      Force a fresh pull of the bundle and all dependencies
+      --force                      Force a fresh pull of the bundle
   -h, --help                       help for upgrade
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
+      --tag string                 Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -35,20 +35,22 @@ porter credentials generate [NAME] [flags]
 
 ```
   porter credential generate
-  porter credential generate kubecred --file myapp/porter.yaml
   porter credential generate kubecred --tag getporter/porter-hello:v0.1.0
-  porter credential generate kubecred --cnab-file myapp/bundle.json --dry-run
+  porter credential generate kubecred --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter credential generate kubecred --file myapp/porter.yaml
+  porter credential generate kubecred --cnab-file myapp/bundle.json
 
 ```
 
 ### Options
 
 ```
-      --cnab-file string   Path to the CNAB bundle.json file.
-  -f, --file string        Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force              Force a fresh pull of the bundle
-  -h, --help               help for generate
-      --tag string         Use a bundle in an OCI registry specified by the given tag.
+      --cnab-file string    Path to the CNAB bundle.json file.
+  -f, --file string         Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force               Force a fresh pull of the bundle
+  -h, --help                help for generate
+      --insecure-registry   Don't require TLS for the registry
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -19,21 +19,23 @@ porter explain [flags]
 
 ```
   porter explain
+  porter explain --tag getporter/porter-hello:v0.1.0
+  porter explain --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter explain --file another/porter.yaml
   porter explain --cnab-file some/bundle.json
-  porter explain --tag getporter/porter-hello:v0.1.0
 		  
 ```
 
 ### Options
 
 ```
-      --cnab-file string   Path to the CNAB bundle.json file.
-  -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force              Force a fresh pull of the bundle
-  -h, --help               help for explain
-  -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
-  -t, --tag string         Use a bundle in an OCI registry specified by the given tag
+      --cnab-file string    Path to the CNAB bundle.json file.
+  -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force               Force a fresh pull of the bundle
+  -h, --help                help for explain
+      --insecure-registry   Don't require TLS for the registry
+  -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/inspect.md
+++ b/docs/content/cli/inspect.md
@@ -23,21 +23,23 @@ porter inspect [flags]
 
 ```
   porter inspect
+  porter inspect --tag getporter/porter-hello:v0.1.0
+  porter inspect --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter inspect --file another/porter.yaml
   porter inspect --cnab-file some/bundle.json
-  porter inspect --tag getporter/porter-hello:v0.1.0
 		  
 ```
 
 ### Options
 
 ```
-      --cnab-file string   Path to the CNAB bundle.json file.
-  -f, --file porter.yaml   Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force              Force a fresh pull of the bundle
-  -h, --help               help for inspect
-  -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
-  -t, --tag string         Use a bundle in an OCI registry specified by the given tag
+      --cnab-file string    Path to the CNAB bundle.json file.
+  -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force               Force a fresh pull of the bundle
+  -h, --help                help for inspect
+      --insecure-registry   Don't require TLS for the registry
+  -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -24,11 +24,12 @@ porter install [INSTALLATION] [flags]
 
 ```
   porter install
+  porter install MyAppFromTag --tag getporter/kubernetes:v0.1.0
+  porter install --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter install MyAppInDev --file myapp/bundle.json
   porter install --parameter-set azure --param test-mode=true --param header-color=blue
   porter install --cred azure --cred kubernetes
   porter install --driver debug
-  porter install MyAppFromTag --tag getporter/kubernetes:v0.1.0
 
 ```
 
@@ -40,12 +41,12 @@ porter install [INSTALLATION] [flags]
   -c, --cred strings               Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                      Force a fresh pull of the bundle and all dependencies
+      --force                      Force a fresh pull of the bundle
   -h, --help                       help for install
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
+      --tag string                 Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -24,11 +24,12 @@ porter invoke [INSTALLATION] --action ACTION [flags]
 
 ```
   porter invoke --action ACTION
+  porter invoke --tag getporter/kubernetes:v0.1.0
+  porter invoke --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter invoke --action ACTION --cred azure --cred kubernetes
   porter invoke --action ACTION --driver debug
-  porter invoke --action ACTION MyAppFromTag --tag getporter/kubernetes:v0.1.0
 
 ```
 
@@ -41,12 +42,12 @@ porter invoke [INSTALLATION] --action ACTION [flags]
   -c, --cred strings               Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                      Force a fresh pull of the bundle and all dependencies
+      --force                      Force a fresh pull of the bundle
   -h, --help                       help for invoke
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
+      --tag string                 Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/parameters_generate.md
+++ b/docs/content/cli/parameters_generate.md
@@ -35,20 +35,22 @@ porter parameters generate [NAME] [flags]
 
 ```
   porter parameter generate
-  porter parameter generate myparamset --file myapp/porter.yaml
   porter parameter generate myparamset --tag getporter/porter-hello:v0.1.0
-  porter parameter generate myparamset --cnab-file myapp/bundle.json --dry-run
+  porter parameter generate myparamset --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter parameter generate myparamset --file myapp/porter.yaml
+  porter parameter generate myparamset --cnab-file myapp/bundle.json
 
 ```
 
 ### Options
 
 ```
-      --cnab-file string   Path to the CNAB bundle.json file.
-  -f, --file string        Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force              Force a fresh pull of the bundle
-  -h, --help               help for generate
-      --tag string         Use a bundle in an OCI registry specified by the given tag.
+      --cnab-file string    Path to the CNAB bundle.json file.
+  -f, --file string         Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force               Force a fresh pull of the bundle
+  -h, --help                help for generate
+      --insecure-registry   Don't require TLS for the registry
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -30,8 +30,8 @@ porter publish [flags]
   -a, --archive string      Path to the bundle archive in .tgz format
   -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
   -h, --help                help for publish
-      --insecure-registry   Don't require TLS for the registry.
-  -t, --tag string          Bundle tag for newly published bundle; required if --archive is supplied
+      --insecure-registry   Don't require TLS for the registry
+      --tag string          Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -24,12 +24,12 @@ porter uninstall [INSTALLATION] [flags]
 
 ```
   porter uninstall
+  porter uninstall --tag getporter/kubernetes:v0.1.0
+  porter uninstall --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter uninstall MyAppInDev --file myapp/bundle.json
   porter uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter uninstall --cred azure --cred kubernetes
   porter uninstall --driver debug
-  porter uninstall MyAppFromTag --tag getporter/kubernetes:v0.1.0
-
 
 ```
 
@@ -41,12 +41,12 @@ porter uninstall [INSTALLATION] [flags]
   -c, --cred strings               Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
-      --force                      Force a fresh pull of the bundle and all dependencies
+      --force                      Force a fresh pull of the bundle
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
+      --tag string                 Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -24,11 +24,12 @@ porter upgrade [INSTALLATION] [flags]
 
 ```
   porter upgrade
+  porter upgrade --tag getporter/kubernetes:v0.1.0
+  porter upgrade --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter upgrade MyAppInDev --file myapp/bundle.json
   porter upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter upgrade --cred azure --cred kubernetes
   porter upgrade --driver debug
-  porter upgrade MyAppFromTag --tag getporter/kubernetes:v0.1.0
 
 ```
 
@@ -40,12 +41,12 @@ porter upgrade [INSTALLATION] [flags]
   -c, --cred strings               Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
   -d, --driver string              Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file string                Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                      Force a fresh pull of the bundle and all dependencies
+      --force                      Force a fresh pull of the bundle
   -h, --help                       help for upgrade
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -t, --tag string                 Use a bundle in an OCI registry specified by the given tag
+      --tag string                 Use a bundle in an OCI registry specified by the given tag.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -48,6 +48,16 @@ func (r *Registry) PullBundle(tag string, insecureRegistry bool) (bundle.Bundle,
 		insecureRegistries = append(insecureRegistries, reg)
 	}
 
+	if r.Debug {
+		msg := strings.Builder{}
+		msg.WriteString("Pulling bundle ")
+		msg.WriteString(ref.String())
+		if insecureRegistry {
+			msg.WriteString(" with --insecure-registry")
+		}
+		fmt.Fprintln(r.Err, msg.String())
+	}
+
 	bun, reloMap, err := remotes.Pull(context.Background(), ref, r.createResolver(insecureRegistries))
 	if err != nil {
 		return bundle.Bundle{}, nil, errors.Wrap(err, "unable to pull remote bundle")


### PR DESCRIPTION
# What does this change
All commands that have --tag should also have --force and --insecure-registry (except publish which doesn't have --force because it's not pulling). Define the flags in a single location so that we can make sure they are consistntly applied to commands that support --tag.

# What issue does it fix
Closes #1092 

# Notes for the reviewer
I updated the examples to move the --tag examples higher up since that's much more common than --file or --cnab-file and demo how to use --insecure-registry and --force.

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
