### PR TITLE
Adds support for debugging plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,6 +232,20 @@ installed into your bin directory in the root of the repository. You can use
 
 \* canary = most recent successful build of the "main" branch
 
+## Plugin Debugging
+
+If you are developing a [plugin](https://porter.sh/plugins/) and you want to debug it follow these steps:
+
+The plugin to be debugged should be compiled and placed in porters plugin path (e.g. in the Azure plugin case the plugin would be copied to $PORTER_HOME/plugins/azure/.
+
+The following environment variables should be set:
+
+`PORTER_RUN_PLUGIN_IN_DEBUGGER` should be set to the name of the plugin to be debugged (e.g. secrets.azure.keyvault to debug the azure secrets plugin)  
+`PORTER_DEBUGGER_PORT` should be set to the port number where the delve API will listen, if not set it defaults to 2345  
+`PORTER_PLUGIN_WORKING_DIRECTORY` should be the path to the directory containing *source code* for the plugin being executed.  
+
+When porter is run it will start delve and attach it to the plugin process, this exposes the delve API so that any delve client can connect to the server and debug the plugin.
+
 ## Preview documentation
 
 We use [Hugo](gohugo.io) to build our documentation site, and it is hosted on

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -21,14 +21,17 @@ const (
 type CommandBuilder func(name string, arg ...string) *exec.Cmd
 
 type Context struct {
-	Debug        bool
-	DebugPlugins bool
-	verbose      bool
-	FileSystem   *afero.Afero
-	In           io.Reader
-	Out          io.Writer
-	Err          io.Writer
-	NewCommand   CommandBuilder
+	Debug                  bool
+	DebugPlugins           bool
+	RunPlugInInDebugger    string
+	PlugInWorkingDirectory string
+	DebuggerPort           string
+	verbose                bool
+	FileSystem             *afero.Afero
+	In                     io.Reader
+	Out                    io.Writer
+	Err                    io.Writer
+	NewCommand             CommandBuilder
 }
 
 func (c *Context) SetVerbose(value bool) {
@@ -69,19 +72,29 @@ func (cw *CensoredWriter) Write(b []byte) (int, error) {
 }
 
 func New() *Context {
-	c := &Context{
-		FileSystem: &afero.Afero{Fs: afero.NewOsFs()},
-		In:         os.Stdin,
-		Out:        NewCensoredWriter(os.Stdout),
-		Err:        NewCensoredWriter(os.Stderr),
-		NewCommand: exec.Command,
-	}
-
 	// Default to respecting the PORTER_DEBUG env variable, the cli will override if --debug is set otherwise
 	debug, _ := strconv.ParseBool(os.Getenv("PORTER_DEBUG"))
-	c.Debug = debug
 
-	return c
+	runPlugInInDebugger := os.Getenv("PORTER_RUN_PLUGIN_IN_DEBUGGER")
+	debuggerPort := os.Getenv("PORTER_DEBUGGER_PORT")
+	debugWorkingDirectory := os.Getenv("PORTER_PLUGIN_WORKING_DIRECTORY")
+
+	port := "2345"
+	if _, err := strconv.ParseInt(debuggerPort, 10, 16); err != nil {
+		port = debuggerPort
+	}
+
+	return &Context{
+		Debug:                  debug,
+		RunPlugInInDebugger:    runPlugInInDebugger,
+		DebuggerPort:           port,
+		PlugInWorkingDirectory: debugWorkingDirectory,
+		FileSystem:             &afero.Afero{Fs: afero.NewOsFs()},
+		In:                     os.Stdin,
+		Out:                    NewCensoredWriter(os.Stdout),
+		Err:                    NewCensoredWriter(os.Stderr),
+		NewCommand:             exec.Command,
+	}
 }
 
 func (c *Context) CopyDirectory(srcDir, destDir string, includeBaseDir bool) error {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -21,17 +21,15 @@ const (
 type CommandBuilder func(name string, arg ...string) *exec.Cmd
 
 type Context struct {
-	Debug                  bool
-	DebugPlugins           bool
-	RunPlugInInDebugger    string
-	PlugInWorkingDirectory string
-	DebuggerPort           string
-	verbose                bool
-	FileSystem             *afero.Afero
-	In                     io.Reader
-	Out                    io.Writer
-	Err                    io.Writer
-	NewCommand             CommandBuilder
+	Debug              bool
+	DebugPlugins       bool
+	verbose            bool
+	FileSystem         *afero.Afero
+	In                 io.Reader
+	Out                io.Writer
+	Err                io.Writer
+	NewCommand         CommandBuilder
+	PlugInDebugContext *PluginDebugContext
 }
 
 func (c *Context) SetVerbose(value bool) {
@@ -75,25 +73,14 @@ func New() *Context {
 	// Default to respecting the PORTER_DEBUG env variable, the cli will override if --debug is set otherwise
 	debug, _ := strconv.ParseBool(os.Getenv("PORTER_DEBUG"))
 
-	runPlugInInDebugger := os.Getenv("PORTER_RUN_PLUGIN_IN_DEBUGGER")
-	debuggerPort := os.Getenv("PORTER_DEBUGGER_PORT")
-	debugWorkingDirectory := os.Getenv("PORTER_PLUGIN_WORKING_DIRECTORY")
-
-	port := "2345"
-	if _, err := strconv.ParseInt(debuggerPort, 10, 16); err != nil {
-		port = debuggerPort
-	}
-
 	return &Context{
-		Debug:                  debug,
-		RunPlugInInDebugger:    runPlugInInDebugger,
-		DebuggerPort:           port,
-		PlugInWorkingDirectory: debugWorkingDirectory,
-		FileSystem:             &afero.Afero{Fs: afero.NewOsFs()},
-		In:                     os.Stdin,
-		Out:                    NewCensoredWriter(os.Stdout),
-		Err:                    NewCensoredWriter(os.Stderr),
-		NewCommand:             exec.Command,
+		Debug:              debug,
+		FileSystem:         &afero.Afero{Fs: afero.NewOsFs()},
+		In:                 os.Stdin,
+		Out:                NewCensoredWriter(os.Stdout),
+		Err:                NewCensoredWriter(os.Stderr),
+		NewCommand:         exec.Command,
+		PlugInDebugContext: NewPluginDebugContext(),
 	}
 }
 

--- a/pkg/context/helpers.go
+++ b/pkg/context/helpers.go
@@ -42,6 +42,11 @@ func NewTestContext(t *testing.T) *TestContext {
 			Out:        aggOut,
 			Err:        aggErr,
 			NewCommand: NewTestCommand(),
+			PlugInDebugContext: &PluginDebugContext{
+				DebuggerPort:           "2735",
+				RunPlugInInDebugger:    "",
+				PlugInWorkingDirectory: "",
+			},
 		},
 		capturedOut: out,
 		capturedErr: err,

--- a/pkg/context/plugindebugcontext.go
+++ b/pkg/context/plugindebugcontext.go
@@ -1,0 +1,31 @@
+package context
+
+import (
+	"os"
+	"strconv"
+)
+
+type PluginDebugContext struct {
+	DebugPlugins           bool
+	RunPlugInInDebugger    string
+	PlugInWorkingDirectory string
+	DebuggerPort           string
+}
+
+func NewPluginDebugContext() *PluginDebugContext {
+
+	runPlugInInDebugger := os.Getenv("PORTER_RUN_PLUGIN_IN_DEBUGGER")
+	debugWorkingDirectory := os.Getenv("PORTER_PLUGIN_WORKING_DIRECTORY")
+	debuggerPort := os.Getenv("PORTER_DEBUGGER_PORT")
+
+	port := "2345"
+	if _, err := strconv.ParseInt(debuggerPort, 10, 16); err != nil {
+		port = debuggerPort
+	}
+
+	return &PluginDebugContext{
+		RunPlugInInDebugger:    runPlugInInDebugger,
+		DebuggerPort:           port,
+		PlugInWorkingDirectory: debugWorkingDirectory,
+	}
+}

--- a/pkg/context/plugindebugcontext.go
+++ b/pkg/context/plugindebugcontext.go
@@ -6,7 +6,6 @@ import (
 )
 
 type PluginDebugContext struct {
-	DebugPlugins           bool
 	RunPlugInInDebugger    string
 	PlugInWorkingDirectory string
 	DebuggerPort           string

--- a/pkg/plugins/pluggable/loader.go
+++ b/pkg/plugins/pluggable/loader.go
@@ -141,15 +141,16 @@ func (l *PluginLoader) Load(pluginType PluginTypeConfig) (interface{}, func(), e
 }
 
 func (l *PluginLoader) setUpDebugger(client *plugin.Client, cleanup func()) (func(), error) {
-	if len(l.Config.RunPlugInInDebugger) > 0 && strings.ToLower(l.SelectedPluginKey.String()) == strings.TrimSpace(strings.ToLower(l.Config.RunPlugInInDebugger)) {
+	debugContext := l.Context.PlugInDebugContext
+	if len(debugContext.RunPlugInInDebugger) > 0 && strings.ToLower(l.SelectedPluginKey.String()) == strings.TrimSpace(strings.ToLower(debugContext.RunPlugInInDebugger)) {
 		if !isDelveInstalled() {
 			return cleanup, errors.New("Delve needs to be installed to debug plugins")
 		}
-		listen := fmt.Sprintf("--listen=127.0.0.1:%s", l.Config.DebuggerPort)
-		if len(l.Config.PlugInWorkingDirectory) == 0 {
+		listen := fmt.Sprintf("--listen=127.0.0.1:%s", debugContext.DebuggerPort)
+		if len(debugContext.PlugInWorkingDirectory) == 0 {
 			return cleanup, errors.New("Plugin Working Directory is required for debugging")
 		}
-		wd := fmt.Sprintf("--wd=%s", l.Config.PlugInWorkingDirectory)
+		wd := fmt.Sprintf("--wd=%s", debugContext.PlugInWorkingDirectory)
 		pid := client.ReattachConfig().Pid
 		dlvCmd := exec.Command("dlv", "attach", strconv.Itoa(pid), "--headless=true", "--api-version=2", "--log", listen, "--accept-multiclient", wd)
 		dlvCmd.Stderr = os.Stderr

--- a/pkg/plugins/pluggable/loader.go
+++ b/pkg/plugins/pluggable/loader.go
@@ -141,8 +141,10 @@ func (l *PluginLoader) Load(pluginType PluginTypeConfig) (interface{}, func(), e
 }
 
 func (l *PluginLoader) setUpDebugger(client *plugin.Client, cleanup func()) (func(), error) {
-	// TODO check that dlv is installed
 	if len(l.Config.RunPlugInInDebugger) > 0 && strings.ToLower(l.SelectedPluginKey.String()) == strings.TrimSpace(strings.ToLower(l.Config.RunPlugInInDebugger)) {
+		if !isDelveInstalled() {
+			return cleanup, errors.New("Delve needs to be installed to debug plugins")
+		}
 		listen := fmt.Sprintf("--listen=127.0.0.1:%s", l.Config.DebuggerPort)
 		if len(l.Config.PlugInWorkingDirectory) == 0 {
 			return cleanup, errors.New("Plugin Working Directory is required for debugging")

--- a/pkg/plugins/pluggable/loader_nix.go
+++ b/pkg/plugins/pluggable/loader_nix.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package pluggable
+
+import (
+	"os"
+	"os/exec"
+)
+
+func isDelveInstalled() bool {
+	cmd := exec.Command("/bin/sh", "-c", "command -v dlv")
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+
+	return true
+}

--- a/pkg/plugins/pluggable/loader_windows.go
+++ b/pkg/plugins/pluggable/loader_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package pluggable
+
+import (
+	"os"
+	"os/exec"
+)
+
+func isDelveInstalled() bool {
+	cmd := exec.Command("where", "dlv")
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
# What this change does

Adds the ability to have porter start delve and attach it to a plugin.

The following variables are required/used:

`PORTER_RUN_PLUGIN_IN_DEBUGGER` should be set to the name of the plugin to be debugged (e.g. secrets.azure.keyvault to debug the azure secrets plugin)
`PORTER_DEBUGGER_PORT` should be set to the port number where the delve API will listen, if not set it defaults to 2345
`PORTER_PLUGIN_WORKING_DIRECTORY` should be the path to the source code for the plugin being executed. (e.g. for the Azure plugin this value would be <PATH>/porter-azure-plugins/cmd/azure

The plugin to be debugged should be compiled and placed in porters plugin path (e.g. in the Azure plugin case the plugin should be copied to $PORTER_HOME/plugins/azure/.

A process will then be started using [delve attach](https://github.com/go-delve/delve/blob/master/Documentation/usage/dlv_attach.md) which exposes the delve [API ](https://github.com/go-delve/delve/tree/master/Documentation/api) so that any delve client can connect to the server and debug the plugin.

