### PR TITLE
🐛 Skip bundle defaults if --tag passed

### DIFF
--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -34,6 +34,9 @@ type bundleFileOptions struct {
 
 	// RelocationMapping is the path to the relocation-mapping.json file, if one exists. Populated only for published bundles
 	RelocationMapping string
+
+	// TagSet indicates whether a bundle tag is present, to determine whether or not to default bundle files
+	TagSet bool
 }
 
 func (o *bundleFileOptions) Validate(cxt *context.Context) error {
@@ -42,9 +45,11 @@ func (o *bundleFileOptions) Validate(cxt *context.Context) error {
 		return err
 	}
 
-	err = o.defaultBundleFiles(cxt)
-	if err != nil {
-		return err
+	if !o.TagSet {
+		err = o.defaultBundleFiles(cxt)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err
@@ -84,6 +89,12 @@ type sharedOptions struct {
 // they exist and are accessible.
 func (o *sharedOptions) Validate(args []string, p *Porter) error {
 	err := o.validateInstallationName(args)
+	if err != nil {
+		return err
+	}
+
+	// tag takes precedence over manifest/cnab file
+	err = o.bundleFileOptions.Validate(p.Context)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -93,7 +93,6 @@ func (o *sharedOptions) Validate(args []string, p *Porter) error {
 		return err
 	}
 
-	// tag takes precedence over manifest/cnab file
 	err = o.bundleFileOptions.Validate(p.Context)
 	if err != nil {
 		return err

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -88,11 +88,6 @@ func (o *sharedOptions) Validate(args []string, p *Porter) error {
 		return err
 	}
 
-	err = o.bundleFileOptions.Validate(p.Context)
-	if err != nil {
-		return err
-	}
-
 	err = p.applyDefaultOptions(o)
 	if err != nil {
 		return err

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -25,7 +25,7 @@ func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {
 		return o.validateTag()
 	}
 
-	// since tag takes precedence over manifest/cnab file, validate manifest/cnab file if no tag present
+	// tag takes precedence over manifest/cnab file
 	err = o.bundleFileOptions.Validate(porter.Context)
 	if err != nil {
 		return err

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -12,21 +12,17 @@ type BundleLifecycleOpts struct {
 }
 
 func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {
-	err := o.sharedOptions.Validate(args, porter)
-	if err != nil {
-		return err
-	}
 
 	if o.Tag != "" {
 		// Ignore anything set based on the bundle directory we are in, go off of the tag
 		o.File = ""
 		o.CNABFile = ""
+		o.TagSet = true
 
 		return o.validateTag()
 	}
 
-	// tag takes precedence over manifest/cnab file
-	err = o.bundleFileOptions.Validate(porter.Context)
+	err := o.sharedOptions.Validate(args, porter)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -24,6 +24,13 @@ func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {
 
 		return o.validateTag()
 	}
+
+	// since tag takes precedence over manifest/cnab file, validate manifest/cnab file if no tag present
+	err = o.bundleFileOptions.Validate(porter.Context)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -169,11 +169,11 @@ func TestManifestIgnoredWithTag(t *testing.T) {
 		opts.Tag = "deislabs/kubekahn:latest"
 
 		wd, _ := os.Getwd()
-		// Below line makes cnab.go#defaultBundleFiles#manifestExists true
+		// `path.Join(wd...` -> makes cnab.go#defaultBundleFiles#manifestExists `true`
+		// Only when `manifestExists` eq to `true`, default bundle logic will run
 		p.TestConfig.TestContext.AddTestFileContents([]byte(""), path.Join(wd, config.Name))
 		// When execution reach to `readFromFile`, manifest file path will be lost.
-		// So, had to empty default manifest content also
-		// Below line makes manifest.go#readFromFile#exists true
+		// So, had to use root manifest file also for error simuation purpose
 		p.TestConfig.TestContext.AddTestFileContents([]byte(""), config.Name)
 
 		err := opts.Validate(nil, p.Porter)

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -170,6 +170,7 @@ func TestBundleLifecycleOpts_ToActionArgs(t *testing.T) {
 		p.TestConfig.TestContext.AddTestFileContents([]byte(""), path.Join(wd, "porter.yaml"))
 		err := opts.Validate(nil, p.Porter)
 		require.NoError(t, err, "Validate failed")
+		p.TestConfig.TestContext.FileSystem.Remove(path.Join(wd, "porter.yaml"))
 	})
 }
 

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -1,6 +1,8 @@
 package porter
 
 import (
+	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -157,6 +159,17 @@ func TestBundleLifecycleOpts_ToActionArgs(t *testing.T) {
 		assert.Equal(t, expectedParams, args.Params, "Params not populated correctly")
 		assert.Equal(t, opts.Name, args.Installation, "Claim not populated correctly")
 		assert.Equal(t, opts.RelocationMapping, args.RelocationMapping, "RelocationMapping not populated correctly")
+	})
+
+	t.Run("ignore manifest in cwd if tag present", func(t *testing.T) {
+		opts := BundleLifecycleOpts{}
+		opts.Tag = "deislabs/kubekahn:latest"
+
+		// cnab.go#defaultBundleFiles uses `os.Getwd()`
+		wd, _ := os.Getwd()
+		p.TestConfig.TestContext.AddTestFileContents([]byte(""), path.Join(wd, "porter.yaml"))
+		err := opts.Validate(nil, p.Porter)
+		require.NoError(t, err, "Validate failed")
 	})
 }
 


### PR DESCRIPTION
# What does this change
if `--tag` passed, porter still tries to validate local manifest file. This PR skips validating manifest file if `--tag` present

# What issue does it fix
Closes #1180


[1]: /CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation - N/A
- [x] Schema (porter.yaml) - N/A

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md