### PR TITLE
fix(cnab.go): ignore manifest if cnab-file provided

### DIFF
--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -136,7 +136,7 @@ func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
 			return errors.Wrap(err, "could not check if porter manifest exists in current directory")
 		}
 
-		if manifestExists {
+		if manifestExists && o.CNABFile == "" {
 			o.File = config.Name
 			o.CNABFile = build.LOCAL_BUNDLE
 		}

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -40,6 +40,24 @@ func TestSharedOptions_defaultBundleFiles_AltManifest(t *testing.T) {
 	assert.Equal(t, filepath.Join("mybun", build.LOCAL_BUNDLE), opts.CNABFile)
 }
 
+func TestSharedOptions_defaultBundleFiles_CNABFile(t *testing.T) {
+	cxt := context.NewTestContext(t)
+
+	pwd, _ := os.Getwd()
+	// Add existing porter manifest; ensure it isn't processed when cnab-file is spec'd
+	_, err := cxt.FileSystem.Create(filepath.Join(pwd, "porter.yaml"))
+	_, err = cxt.FileSystem.Create(filepath.Join(pwd, "mycnabfile.json"))
+	require.NoError(t, err)
+
+	opts := sharedOptions{}
+	opts.CNABFile = "mycnabfile.json"
+	err = opts.defaultBundleFiles(cxt.Context)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", opts.File)
+	assert.Equal(t, "mycnabfile.json", opts.CNABFile)
+}
+
 func TestSharedOptions_validateBundleJson(t *testing.T) {
 	pwd, _ := os.Getwd()
 


### PR DESCRIPTION

# What does this change
* Ignores the Porter manifest in the current directory, if exists, when `porter <action> --cnab-file bundle.json` is invoked

# What issue does it fix
N/A, encountered while testing

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md