### PR TITLE
doc to explain github workflow

### DIFF
--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -44,7 +44,7 @@ The porter_version should be the version of Porter you want installed. You can c
 ### Login to DockerHub
 Next, you will want to login to Docker Hub so that you can publish your bundle to a Docker Hub registry. If you do not wish to publish your bundle to a Docker Hub registry, you can configure another registry in this step instead.
 In order to do this, you can use the [docker-login](https://github.com/Azure/docker-login) action
-to do it easily. Below is an example of how it is used:
+to do it. Below is an example of how it is used:
 ````yaml
 - uses: azure/docker-login@v1
   name: Docker Login

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -1,0 +1,158 @@
+---
+title: Best practices for Porter in a CI Pipeline
+description: How to effectively use a GitHub workflow to create a CI pipeline using Porter.
+---
+
+To properly test your bundle in a CI pipeline, you can utilize a GitHub workflow. 
+You can have the workflow run when you create a pull request, when you merge into 
+main, or both. We will go through the best practices of a CI pipeline for your 
+bundle and show you how to set up the GitHub workflow. [Here](https://github.com/gaurimadhok/porter-pipeline/blob/master/.github/workflows/publish.yaml) is the full working example explained in this article.
+
+## Parts of the Workflow
+
+We will go through each of the following components of the workflow. 
+
+* [Checking out code](#checking-out-code)
+* [Setting up Porter](#setting-up-porter)
+* [Logging in to DockerHub to publish the bundle](#logging-into-dockerhub)
+* [Installing mixins](#installing-mixins)
+* [Running Porter commands](#running-porter-commands)
+
+### Checking out code
+In order to test your bundle in a workflow, you need to checkout your repo. We 
+used the GitHub action [Checkout](https://github.com/actions/checkout) to do this. 
+By default, the action checks out the single commit that triggered the workflow. You
+can customize what you want to happen in the checkout action based on their documentation, 
+but if you do not need to customize, the code below in a step in your workflow is all that 
+is needed.
+````yaml
+- uses: actions/checkout@v1
+````
+
+### Setting up Porter
+After checking out the code in the repository, you need to install porter in the workflow
+so that you can run porter commands. There is a GitHub action for Porter that you can use
+for this step linked [here](https://github.com/deislabs/porter-gh-action). Adding this 
+action to your workflow will install Porter for you. Here is an example of how to use it:
+````yaml
+- name: Setup Porter
+  uses: deislabs/porter-gh-action@v0.27.2
+````
+The version should be the version of Porter you want installed. You can check [here](https://github.com/deislabs/porter) for the most recent released version of Porter.
+
+### Logging into DockerHub
+Next, you will want to log in to Docker Hub so that you can publish your bundle to a registry. 
+In order to do this, you can use the [docker-login](https://github.com/Azure/docker-login) action
+to do it easily. Here is an example of how it is used:
+````yaml
+- uses: azure/docker-login@v1
+  name: Docker Login
+  with:
+    username: ${{ secrets.DOCKER_USERNAME }}
+    password: ${{ secrets.DOCKER_PASSWORD }}
+````
+You will need to set your docker username and password as secrets in the repository you are setting up the workflow in.
+
+### Installing mixins
+Next, you should install any mixins your bundle will use so that it can be tested properly. You
+can simply add a line as a run command to install your mixin as shown below:
+````yaml
+run: porter mixins install az
+````
+You can also specify the version of the mixin by adding the version flag. For example:
+````yaml
+run: porter mixins install az --version v0.4.2
+````
+
+### Running Porter commands
+The final part of the workflow is running porter commands. The commands we suggest running are porter install, porter upgrade, porter uninstall, and porter publish. Porter install will install your bundle and give an error if something is wrong. This will be useful as part of your pipeline in testing your bundle because you can go fix the problem right away instead of finding it later. Porter upgrade and porter uninstall will execute the code and also give errors if there are problems. If all these commands run successfully, you can run porter publish to publish your working bundle image to Docker Hub. 
+
+## Setting up the Workflow
+Now that we know the parts that are needed in a workflow, we can learn how to set one up. Here are the steps we will go through to set up the workflow: 
+
+* [Making yaml files](#making-yaml-files)
+* [Setting up secrets in your repository](#setting-up-secrets-in-your-repository)
+* [Using credential files](#using-credential-files)
+
+### Making yaml files
+The way you set up your yaml files depends on who will be contributing to your repository. If you are the only one working on a project and no one else can make pull requests, you can set up one yaml file to run when a pull request opens and one yaml file to run when a commit is merged. You can have the one that runs on a pull request run your bundle to test it, and you can have the second yaml file publish the bundle to Docker Hub. 
+
+If you are not the only one contributing to the repository and other contributors will be making pull requests from forks, the yaml file setup is slightly different. GitHub actions and workflows do not run automatically on pull requests from a fork. So, in this situation, you will only need one yaml file that runs when a pull request is merged. You can test the bundle and publish in the same yaml file.  
+
+### Setting up secrets in your repository
+In order to publish your bundle to Docker Hub, you will need to set up secrets. You can add these in the settings of your repository and then use them in your workflow.
+
+### Using credential files
+If you were using credentials in your bundle, you will need to set up a credential file in your repository to use with your workflow. After you run `porter credentials generate`, you should see a JSON file with the name of your bundle in the ~/.porter/credentials directory. You need to add this file to your repository so you can pass in the file as the credential. For example, if my bundle was named hello, there would be a file with the credentials called hello.json. I would do the following to install my bundle:
+```yaml
+porter install -c ./hello.json
+```
+
+## Example Code
+
+Now, we will show example code for a workflow and then explain what the code does.
+
+* [Show example code](#show-example-code)
+* [Explain the code](#explain-the-code)
+
+### Show example code
+```yaml
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push event for the master branch
+on:
+  push:
+    branches: [ main ]
+
+# Set up environment variables needed for the bundle
+env:
+  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+# A workflow run
+jobs:
+  publish: 
+    runs-on: ubuntu-latest
+    
+    steps: 
+    # Check out code
+    - uses: actions/checkout@v1
+    # Use Porter GH action to set up Porter
+    - name: Setup Porter
+      uses: deislabs/porter-gh-action@v0.27.2
+    # Install docker mixin needed for the bundle
+    - name: Install Docker mixin
+      run: porter mixins install docker
+    # Run install
+    - name: Porter install
+      run: porter install -c ./docker-example.json --allow-docker-host-access
+    # Run upgrade
+    - name: Porter upgrade
+      run: porter upgrade -c ./docker-example.json --allow-docker-host-access
+    # Run uninstall
+    - name: Porter uninstall
+      run: porter uninstall -c ./docker-example.json --allow-docker-host-access
+    # Login to Docker Hub to publish the bundle
+    - uses: azure/docker-login@v1
+      name: Docker Login
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    # Run publish
+    - name: Porter Publish
+      run: porter publish
+```
+
+### Explain the code
+The first part of the code gives the workflow a name. Next, the on push explains that this workflow will run on a push to main. If you want it to run on a pull request, you can change this from push to pull_request. You can also change the branch name from main to the name of the branch you want the workflow to run on. 
+
+Next, we set up the environment variables that we need for our bundle. You should add any environment variables that you need for your bundle in this section. 
+
+Next, we set up the actual job. A workflow can be made of many jobs, but this example puts all the steps under one job. Publish is the name of this job. For runs-on, you specify the type of machine you want the job to run on. We chose ubuntu-latest. 
+
+Next, we add the steps we want to run. As explained above, the first thing we do is checkout the code. Next, we run the Porter GitHub action to set up and install Porter. You can specify the version of Porter that you want installed after the @. 
+
+Next, you can install any of the mixins your bundle needs to be able to run. After you have installed the necessary mixins, you can just run the porter commands that you want to run. We suggest running install, upgrade, and uninstall to verify that they are working as intended. 
+
+Finally, we run the docker-login action to login to Docker Hub so that we can publish our bundle. After logging in, you can run porter publish to publish the bundle. If any of the porter commands fail, the workflow will stop, so your bundle will only be published if it works properly.
+

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -44,7 +44,7 @@ The porter_version should be the version of Porter you want installed. You can c
 ### Logging into DockerHub
 Next, you will want to log in to Docker Hub so that you can publish your bundle to a registry. 
 In order to do this, you can use the [docker-login](https://github.com/Azure/docker-login) action
-to do it easily. Here is an example of how it is used:
+to do it easily. Below is an example of how it is used:
 ````yaml
 - uses: azure/docker-login@v1
   name: Docker Login

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -6,19 +6,19 @@ description: How to effectively use a GitHub workflow to create a CI pipeline us
 To properly test your bundle in a CI pipeline, you can utilize a GitHub workflow. 
 You can have the workflow run when you create a pull request, when you merge into 
 main, or both. We will go through the best practices of a CI pipeline for your 
-bundle and show you how to set up the GitHub workflow. [Here](https://github.com/gaurimadhok/porter-pipeline/blob/master/.github/workflows/publish.yaml) is the full working example explained in this article.
+bundle and show you how to set up the GitHub workflow. [Here](https://github.com/deislabs/porter-pipeline/blob/main/.github/workflows/publish.yaml) is the full working example explained in this article.
 
 ## Parts of the Workflow
 
 We will go through each of the following components of the workflow. 
 
-* [Checking out code](#checking-out-code)
-* [Setting up Porter](#setting-up-porter)
-* [Logging in to DockerHub to publish the bundle](#logging-into-dockerhub)
-* [Installing mixins](#installing-mixins)
-* [Running Porter commands](#running-porter-commands)
+* [Check out code](#check-out-code)
+* [Set up Porter](#set-up-porter)
+* [Log in to DockerHub to publish the bundle](#log-into-dockerhub)
+* [Install mixins](#install-mixins)
+* [Run Porter commands](#run-porter-commands)
 
-### Checking out code
+### Check out code
 In order to test your bundle in a workflow, you need to checkout your repo. We 
 used the GitHub action [Checkout](https://github.com/actions/checkout) to do this. 
 By default, the action checks out the single commit that triggered the workflow. You
@@ -29,7 +29,7 @@ is needed.
 - uses: actions/checkout@v1
 ````
 
-### Setting up Porter
+### Set up Porter
 After checking out the code in the repository, you need to install porter in the workflow
 so that you can run porter commands. The [Porter GitHub Action](https://github.com/deislabs/porter-gh-action) takes care of installing Porter for you. Adding this 
 action to your workflow will install Porter for you. Here is an example of how to use it:
@@ -41,7 +41,7 @@ action to your workflow will install Porter for you. Here is an example of how t
 ````
 The porter_version should be the version of Porter you want installed. You can check [our releases](https://github.com/deislabs/porter) for the list of recent versions of Porter. When not specified, porter_version defaults to latest version of Porter. 
 
-### Logging into DockerHub
+### Log into DockerHub
 Next, you will want to log in to Docker Hub so that you can publish your bundle to a registry. 
 In order to do this, you can use the [docker-login](https://github.com/Azure/docker-login) action
 to do it easily. Below is an example of how it is used:
@@ -54,7 +54,7 @@ to do it easily. Below is an example of how it is used:
 ````
 You will need to set your docker username and password as secrets in the repository you are setting up the workflow in.
 
-### Installing mixins
+### Install mixins
 Next, you should install any mixins your bundle will use so that it can be tested properly. You
 can simply add a line as a run command to install your mixin as shown below:
 ````yaml
@@ -65,25 +65,25 @@ You can also specify the version of the mixin by adding the version flag. For ex
 run: porter mixins install az --version v0.4.2
 ````
 
-### Running Porter commands
+### Run Porter commands
 The final part of the workflow is running porter commands. The commands we suggest running are porter install, porter upgrade, porter uninstall, and porter publish. Porter install will install your bundle and give an error if something is wrong. This will be useful as part of your pipeline in testing your bundle because you can go fix the problem right away instead of finding it later. Porter upgrade and porter uninstall will execute the code and also give errors if there are problems. If all these commands run successfully, you can run porter publish to publish your working bundle image to Docker Hub. 
 
-## Setting up the Workflow
+## Set up the Workflow
 Now that we know the parts that are needed in a workflow, we can learn how to set one up. Here are the steps we will go through to set up the workflow: 
 
-* [Making yaml files](#making-yaml-files)
-* [Setting up secrets in your repository](#setting-up-secrets-in-your-repository)
-* [Using credential files](#using-credential-files)
+* [Make yaml files](#make-yaml-files)
+* [Set up secrets in your repository](#set-up-secrets-in-your-repository)
+* [Use credential files](#use-credential-files)
 
-### Making yaml files
+### Make yaml files
 The way you set up your yaml files depends on who will be contributing to your repository. If you are the only one working on a project and no one else can make pull requests (you have a private repository), you can set up one yaml file to run when a pull request opens and one yaml file to run when a commit is merged. You can have the one that runs on a pull request run your bundle to test it, and you can have the second yaml file publish the bundle to Docker Hub. 
 
 If you are not the only one contributing to the repository and other contributors will be making pull requests from forks, the yaml file setup is slightly different. GitHub actions and workflows do not run automatically on pull requests from a fork. So, in this situation, you will only need one yaml file that runs when a pull request is merged. You can test the bundle and publish in the same yaml file.  
 
-### Setting up secrets in your repository
+### Set up secrets in your repository
 In order to publish your bundle to Docker Hub, you will need to set up secrets. You can add these in the settings of your repository and then use them in your workflow.
 
-### Using credential files
+### Use credential files
 If you were using credentials in your bundle, you will need to set up a credential file in your repository to use with your workflow. After you run `porter credentials generate`, you should see a JSON file with the name of your bundle in the ~/.porter/credentials directory. You need to add this file to your repository so you can pass in the file as the credential. For example, if my bundle was named hello, there would be a file with the credentials called hello.json. I would do the following to install my bundle:
 ```yaml
 porter install -c ./hello.json
@@ -100,7 +100,7 @@ Now, we will show example code for a workflow and then explain what the code doe
 ```yaml
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push event for the master branch
+# Controls when the action will run. Triggers the workflow on push event for the main branch
 on:
   push:
     branches: [ main ]

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -56,7 +56,7 @@ You will need to set your docker username and password as secrets in the reposit
 
 ### Install mixins
 Next, you should install any mixins your bundle will use so that it can be tested properly. You
-can simply add a line as a run command to install your mixin as shown below:
+can add a line as a run command to install your mixin as shown below:
 ````yaml
 run: porter mixins install az
 ````

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -31,8 +31,7 @@ is needed.
 
 ### Setting up Porter
 After checking out the code in the repository, you need to install porter in the workflow
-so that you can run porter commands. There is a GitHub action for Porter that you can use
-for this step linked [here](https://github.com/deislabs/porter-gh-action). Adding this 
+so that you can run porter commands. The [Porter GitHub Action](https://github.com/deislabs/porter-gh-action) takes care of installing Porter for you. Adding this 
 action to your workflow will install Porter for you. Here is an example of how to use it:
 ````yaml
 - name: Setup Porter
@@ -159,4 +158,3 @@ Next, we add the steps we want to run. As explained above, the first thing we do
 Next, you can install any of the mixins your bundle needs to be able to run. After you have installed the necessary mixins, you can just run the porter commands that you want to run. We suggest running install, upgrade, and uninstall to verify that they are working as intended. 
 
 Finally, we run the docker-login action to login to Docker Hub so that we can publish our bundle. After logging in, you can run porter publish to publish the bundle. If any of the porter commands fail, the workflow will stop, so your bundle will only be published if it works properly.
-

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -42,7 +42,7 @@ action to your workflow will install Porter for you. For example:
 The porter_version should be the version of Porter you want installed. You can check [our releases](https://github.com/deislabs/porter) for the list of recent versions of Porter. When not specified, porter_version defaults to latest version of Porter. 
 
 ### Login to DockerHub
-Next, you will want to login to Docker Hub so that you can publish your bundle to a registry. 
+Next, you will want to login to Docker Hub so that you can publish your bundle to a Docker Hub registry. If you do not wish to publish your bundle to a Docker Hub registry, you can configure another registry in this step instead.
 In order to do this, you can use the [docker-login](https://github.com/Azure/docker-login) action
 to do it easily. Below is an example of how it is used:
 ````yaml
@@ -52,7 +52,7 @@ to do it easily. Below is an example of how it is used:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
 ````
-You will need to set your docker username and password as secrets in the repository you are setting up the workflow in.
+You will need to set your docker username and password as [secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in the repository you are setting up the workflow in.
 
 ### Install mixins
 Next, you should install any mixins your bundle will use so that it can be tested properly. You
@@ -64,9 +64,17 @@ You can also specify the version of the mixin by adding the version flag. For ex
 ````yaml
 run: porter mixins install az --version v0.4.2
 ````
+Take a look at the [documentation](https://porter.sh/mixins) to see all available mixins and how to know what command to run to install them. The documentation provides install commands for each mixin. The command `porter mixin search` lists all the mixins created by the community. Depending on if the URL is an atom feed or a github url you can install the mixin using
+```yaml
+porter mixins install NAME --feed-url ATOM_URL
+```
+or
+```yaml
+porter mixins install NAME --url GITHUB_URL
+```
 
 ### Run Porter commands
-The final part of the workflow is running porter commands. The commands we suggest running are porter install, porter upgrade, porter uninstall, and porter publish. Porter install will install your bundle and give an error if something is wrong. This will be useful as part of your pipeline in testing your bundle because you can go fix the problem right away instead of finding it later. Porter upgrade and porter uninstall will execute the code and also give errors if there are problems. If all these commands run successfully, you can run porter publish to publish your working bundle image to Docker Hub. 
+The final part of the workflow is running porter commands. The commands we suggest running are porter install, porter upgrade, porter uninstall, and porter publish. Porter install will install your bundle and give an error if something is wrong. This will be useful as part of your pipeline in testing your bundle because you can go fix the problem right away instead of finding it later when users try to run your bundle. Porter upgrade and porter uninstall will execute the code and also give errors if there are problems. If all these commands run successfully, you can run porter publish to publish your working bundle image to a registry. In this example, we publish to Docker Hub, but porter publish can publish to any registry. 
 
 ## Set up the Workflow
 Now that we know the parts that are needed in a workflow, we can learn how to set one up. Here are the steps we will go through to set up the workflow: 
@@ -75,9 +83,11 @@ Now that we know the parts that are needed in a workflow, we can learn how to se
 * [Use credential files](#use-credential-files)
 
 ### Make yaml files
-The way you set up your yaml files depends on who will be contributing to your repository. If you are the only one working on a project and no one else can make pull requests (you have a private repository), you can set up one yaml file to run when a pull request opens and one yaml file to run when a commit is merged. You can have the one that runs on a pull request run your bundle to test it, and you can have the second yaml file publish the bundle to Docker Hub. 
+The way you set up your yaml files depends on who will be contributing to your repository and how they will be contributing. GitHub actions and workflows do not run automatically on pull requests from forks. 
 
-If you are not the only one contributing to the repository and other contributors will be making pull requests from forks, the yaml file setup is slightly different. GitHub actions and workflows do not run automatically on pull requests from a fork. So, in this situation, you will only need one yaml file that runs when a pull request is merged. You can test the bundle and publish in the same yaml file.  
+So, if you are the only one working on a project and no one else can make pull requests (you have a private repository) or no one will be contributing from a fork, you can set up one yaml file to run when a pull request opens and one yaml file to run when a commit is merged. You can have the one that runs on a pull request run your bundle to test it, and you can have the second yaml file publish the bundle to Docker Hub. 
+
+If you are not the only one contributing to the repository and other contributors will be making pull requests from forks, the yaml file setup is slightly different. Since the GitHub action won't be triggered from a fork, you will only need one yaml file that runs when a pull request is merged. You can test the bundle and publish in the same yaml file.  
 
 
 ### Use credential files

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -36,9 +36,11 @@ for this step linked [here](https://github.com/deislabs/porter-gh-action). Addin
 action to your workflow will install Porter for you. Here is an example of how to use it:
 ````yaml
 - name: Setup Porter
-  uses: deislabs/porter-gh-action@v0.27.2
+  uses: deislabs/porter-gh-action@v0.1.1
+  with:
+    porter_version: v0.27.2
 ````
-The version should be the version of Porter you want installed. You can check [here](https://github.com/deislabs/porter) for the most recent released version of Porter.
+The porter_version should be the version of Porter you want installed. You can check [here](https://github.com/deislabs/porter) for the most recent released version of Porter. If you do not pass it in, it will default to latest. 
 
 ### Logging into DockerHub
 Next, you will want to log in to Docker Hub so that you can publish your bundle to a registry. 
@@ -75,7 +77,7 @@ Now that we know the parts that are needed in a workflow, we can learn how to se
 * [Using credential files](#using-credential-files)
 
 ### Making yaml files
-The way you set up your yaml files depends on who will be contributing to your repository. If you are the only one working on a project and no one else can make pull requests, you can set up one yaml file to run when a pull request opens and one yaml file to run when a commit is merged. You can have the one that runs on a pull request run your bundle to test it, and you can have the second yaml file publish the bundle to Docker Hub. 
+The way you set up your yaml files depends on who will be contributing to your repository. If you are the only one working on a project and no one else can make pull requests (you have a private repository), you can set up one yaml file to run when a pull request opens and one yaml file to run when a commit is merged. You can have the one that runs on a pull request run your bundle to test it, and you can have the second yaml file publish the bundle to Docker Hub. 
 
 If you are not the only one contributing to the repository and other contributors will be making pull requests from forks, the yaml file setup is slightly different. GitHub actions and workflows do not run automatically on pull requests from a fork. So, in this situation, you will only need one yaml file that runs when a pull request is merged. You can test the bundle and publish in the same yaml file.  
 
@@ -119,7 +121,9 @@ jobs:
     - uses: actions/checkout@v1
     # Use Porter GH action to set up Porter
     - name: Setup Porter
-      uses: deislabs/porter-gh-action@v0.27.2
+      uses: deislabs/porter-gh-action@v0.1.1
+      with:
+        porter_version: v0.27.2
     # Install docker mixin needed for the bundle
     - name: Install Docker mixin
       run: porter mixins install docker
@@ -150,7 +154,7 @@ Next, we set up the environment variables that we need for our bundle. You shoul
 
 Next, we set up the actual job. A workflow can be made of many jobs, but this example puts all the steps under one job. Publish is the name of this job. For runs-on, you specify the type of machine you want the job to run on. We chose ubuntu-latest. 
 
-Next, we add the steps we want to run. As explained above, the first thing we do is checkout the code. Next, we run the Porter GitHub action to set up and install Porter. You can specify the version of Porter that you want installed after the @. 
+Next, we add the steps we want to run. As explained above, the first thing we do is checkout the code. Next, we run the Porter GitHub action to set up and install Porter. You can specify the version of Porter that you want installed by adding the lines for with and porter_version. 
 
 Next, you can install any of the mixins your bundle needs to be able to run. After you have installed the necessary mixins, you can just run the porter commands that you want to run. We suggest running install, upgrade, and uninstall to verify that they are working as intended. 
 

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -39,7 +39,7 @@ action to your workflow will install Porter for you. Here is an example of how t
   with:
     porter_version: v0.27.2
 ````
-The porter_version should be the version of Porter you want installed. You can check [here](https://github.com/deislabs/porter) for the most recent released version of Porter. If you do not pass it in, it will default to latest. 
+The porter_version should be the version of Porter you want installed. You can check [our releases](https://github.com/deislabs/porter) for the list of recent versions of Porter. When not specified, porter_version defaults to latest version of Porter. 
 
 ### Logging into DockerHub
 Next, you will want to log in to Docker Hub so that you can publish your bundle to a registry. 

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -93,7 +93,7 @@ Now, we will show example code for a workflow and explain what the code does.
 ```yaml
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push event for the main branch. 
+# On controls when the action will run. This triggers the workflow on push event for the main branch. 
 # Can change push to pull_request to run when a PR is made. 
 # You can also change the branch name from main to the name of the branch you want the workflow to run on. 
 on:

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -32,7 +32,7 @@ is needed.
 ### Set up Porter
 After checking out the code in the repository, you need to install porter in the workflow
 so that you can run porter commands. The [Porter GitHub Action](https://github.com/deislabs/porter-gh-action) takes care of installing Porter for you. Adding this 
-action to your workflow will install Porter for you. Here is an example of how to use it:
+action to your workflow will install Porter for you. For example:
 ````yaml
 - name: Setup Porter
   uses: deislabs/porter-gh-action@v0.1.1
@@ -93,12 +93,16 @@ Now, we will show example code for a workflow and explain what the code does.
 ```yaml
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push event for the main branch. Can change push to pull_request to run when a PR is made. You can also change the branch name from main to the name of the branch you want the workflow to run on. 
+# Controls when the action will run. Triggers the workflow on push event for the main branch. 
+# Can change push to pull_request to run when a PR is made. 
+# You can also change the branch name from main to the name of the branch you want the workflow to run on. 
 on:
   push:
     branches: [ main ]
 
-# Set up environment variables needed for the bundle. If these are sensitive, they should be set as secrets in the repository. To do this, go to settings -> secrets -> new secret.
+# Set up environment variables needed for the bundle. 
+# If these are sensitive, they should be set as secrets in the repository. 
+# To do this, go to settings -> secrets -> new secret.
 env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -113,10 +117,12 @@ jobs:
     steps: 
     # Check out code
     - uses: actions/checkout@v1
-    # Use Porter GH action to set up Porter. You can specify the version of Porter that you want installed by adding the lines for with and porter_version as explained above. 
+    # Use Porter GH action to set up Porter. 
+    # You can specify the version of Porter that you want installed by adding the lines for with and porter_version as explained above. 
     - name: Setup Porter
       uses: deislabs/porter-gh-action@v0.1.1
-    # Install docker mixin needed for this bundle. Add lines to install any of the mixins your bundle needs to be able to run.
+    # Install docker mixin needed for this bundle. 
+    # Add lines to install any of the mixins your bundle needs to be able to run.
     - name: Install Docker mixin
       run: porter mixins install docker
     # Run install
@@ -134,7 +140,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    # Run publish. If any of the porter commands above fail, the workflow will stop, so your bundle will only be published if it works properly.
+    # Run publish. 
+    # If any of the porter commands above fail, the workflow will stop, so your bundle will only be published if it works properly.
     - name: Porter Publish
       run: porter publish
 ```


### PR DESCRIPTION
# What does this change
This doc explains how to set up a GitHub workflow in your repository to test your bundle. This is needed to complement the Porter GH action and make it more usable. It shows how you can use the Porter GH action in conjunction with more steps to create a pipeline for your bundle.