### PR TITLE
fix(runtime-manifest): defer to bundle-level output def sensitivity

### DIFF
--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -258,11 +258,17 @@ func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 	}
 
 	bun["outputs"] = m.outputs
-	// Iterate through the runtime manifest's step outputs and mask by default
-	for _, stepOutput := range m.outputs {
-		// TODO: check if output declared sensitive or not; currently we default always sensitive
+
+	// Iterate through the runtime manifest's step outputs and determine if we should mask
+	for name, val := range m.outputs {
+		// TODO: support configuring sensitivity for step outputs that aren't also bundle-level outputs
 		// See https://github.com/deislabs/porter/issues/855
-		m.setSensitiveValue(stepOutput)
+
+		// If step output is also a bundle-level output, defer to bundle-level output sensitivity
+		if outputDef, ok := m.Outputs[name]; ok && !outputDef.Sensitive {
+			continue
+		}
+		m.setSensitiveValue(val)
 	}
 
 	// Externally injected outputs (bundle level outputs and dependency outputs) are

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -544,6 +544,48 @@ func TestResolveMissingStepOutputs(t *testing.T) {
 	assert.Equal(t, "unable to render step template helm:\n  Arguments:\n  - jdbc://{{bundle.outputs.database_url}}:{{bundle.outputs.database_port}}\n  description: install wordpress\n: Missing variable \"database_url\"", err.Error())
 }
 
+func TestResolveSensitiveOutputs(t *testing.T) {
+	cxt := context.NewTestContext(t)
+	m := &manifest.Manifest{
+		Outputs: manifest.OutputDefinitions{
+			"username": {
+				Name: "username",
+			},
+			"password": {
+				Name:      "password",
+				Sensitive: true,
+			},
+		},
+	}
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
+	rm.outputs = map[string]string{
+		"username": "sally",
+		"password": "top$ecret!",
+	}
+
+	s := &manifest.Step{
+		Data: map[string]interface{}{
+			"description": "a test step",
+			"Arguments": []string{
+				"{{ bundle.outputs.username }}",
+				"{{ bundle.outputs.password }}",
+			},
+		},
+	}
+
+	err := rm.ResolveStep(s)
+	require.NoError(t, err)
+
+	args, ok := s.Data["Arguments"].([]interface{})
+	require.True(t, ok)
+	require.Equal(t, 2, len(args))
+	require.Equal(t, "sally", args[0])
+	require.Equal(t, "top$ecret!", args[1])
+
+	// There should be only one sensitive value being tracked
+	require.Equal(t, []string{"top$ecret!"}, rm.GetSensitiveValues())
+}
+
 func TestManifest_ResolveBundleName(t *testing.T) {
 	cxt := context.NewTestContext(t)
 	m := &manifest.Manifest{


### PR DESCRIPTION

# What does this change
* Updates logic around masking output values.  We still regard step outputs as sensitive by default, but this updates step outputs that are also bundle-level outputs to inherit the bundle-level output setting.  (Note that bundle-level outputs are _not_ sensitive by default.)

# What issue does it fix
N/A
# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md