### PR TITLE
fix(kubernetes): trim quotes from output before returning

### DIFF
--- a/pkg/kubernetes/helpers.go
+++ b/pkg/kubernetes/helpers.go
@@ -20,3 +20,13 @@ func NewTestMixin(t *testing.T) *TestMixin {
 		TestContext: c,
 	}
 }
+
+// trimQuotes receives data and returns it with double or single wrapping quotes removed
+func trimQuotes(data []byte) []byte {
+	if len(data) >= 2 {
+		if c := data[len(data)-1]; data[0] == c && (c == '"' || c == '\'') {
+			return data[1 : len(data)-1]
+		}
+	}
+	return data
+}

--- a/pkg/kubernetes/helpers_test.go
+++ b/pkg/kubernetes/helpers_test.go
@@ -1,0 +1,39 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelpers_trimQuotes(t *testing.T) {
+	t.Run("empty data", func(t *testing.T) {
+		data := []byte{}
+		require.Equal(t, "", string(trimQuotes(data)))
+	})
+
+	t.Run("only quotes", func(t *testing.T) {
+		data := []byte{'"', '"'}
+		require.Equal(t, "", string(trimQuotes(data)))
+	})
+
+	t.Run("double-quoted data", func(t *testing.T) {
+		data := []byte{'"', 'p', 'o', 'r', 't', 'e', 'r', '"'}
+		require.Equal(t, "porter", string(trimQuotes(data)))
+	})
+
+	t.Run("single-quoted data", func(t *testing.T) {
+		data := []byte{'\'', 'p', 'o', 'r', 't', 'e', 'r', '\''}
+		require.Equal(t, "porter", string(trimQuotes(data)))
+	})
+
+	t.Run("only beginning quote", func(t *testing.T) {
+		data := []byte{'\'', 'p', 'o', 'r', 't', 'e', 'r'}
+		require.Equal(t, "'porter", string(trimQuotes(data)))
+	})
+
+	t.Run("no quotes", func(t *testing.T) {
+		data := []byte{'p', 'o', 'r', 't', 'e', 'r'}
+		require.Equal(t, "porter", string(trimQuotes(data)))
+	})
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -100,11 +100,10 @@ func (m *Mixin) getOutput(resourceType, resourceName, namespace, jsonPath string
 		prettyCmd := fmt.Sprintf("%s%s", cmd.Dir, strings.Join(cmd.Args, " "))
 		return nil, errors.Wrap(err, fmt.Sprintf("couldn't run command %s", prettyCmd))
 	}
-	return out, nil
+	return trimQuotes(out), nil
 }
 
 func (m *Mixin) handleOutputs(outputs []KubernetesOutput) error {
-	//Now get the outputs
 	for _, output := range outputs {
 		bytes, err := m.getOutput(
 			output.ResourceType,


### PR DESCRIPTION
# What does this change
* Adds logic to remove quotes from a Kubernetes resource output, if applicable, before returning

Proposed fix for https://github.com/deislabs/porter/issues/1210, assuming it's agreed it is an issue we wish to fix.

# What issue does it fix
Closes https://github.com/deislabs/porter/issues/1210

# Notes for the reviewer
Do we want to trim both `"` and `'` as I have it currently?  Or limit to only `'`?

Also, please let me know if I'm missing a way to do this either via jsonpath or some other, simpler approach.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md