### PR TITLE
Handle removing stopped local registry in  stop-local-docker-registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ start-local-docker-registry:
 
 stop-local-docker-registry:
 	@if $$(docker inspect registry > /dev/null 2>&1); then \
-		docker kill registry && docker rm registry ; \
+		docker rm -f registry ; \
 	fi
 
 # all-bundles loops through all items under the dir provided by the first argument


### PR DESCRIPTION
# What does this change
I was running into errors running the integration tests because the local docker registry container was already stopped so kill was failing. This improves the `stop-local-docker-registry` target to handle when the container is already stopped (I think my computer went to sleep or something).

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
