### PR TITLE
🐛 Fix non-string yaml keys of flags causing panic

### DIFF
--- a/pkg/exec/builder/flags.go
+++ b/pkg/exec/builder/flags.go
@@ -77,7 +77,7 @@ func (flags *Flags) ToSlice(dashes Dashes) []string {
 //
 // []Flags{ {"flag1", []string{"value"}}, {"flag2", []string{"value"}}, {"flag3", []string{"value1", "value2"} }
 func (flags *Flags) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	flagMap := map[interface{}]interface{}{}
+	flagMap := map[string]interface{}{}
 	err := unmarshal(&flagMap)
 	if err != nil {
 		return errors.Wrap(err, "could not unmarshal yaml into Step.Flags")
@@ -86,7 +86,7 @@ func (flags *Flags) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*flags = make(Flags, 0, len(flagMap))
 	for k, v := range flagMap {
 		f := Flag{}
-		f.Name = k.(string)
+		f.Name = k
 
 		switch t := v.(type) {
 		case []interface{}:

--- a/pkg/exec/builder/flags_test.go
+++ b/pkg/exec/builder/flags_test.go
@@ -82,3 +82,16 @@ func TestFlags_ToSlice(t *testing.T) {
 	// Flags should be sorted and sliced up on a platter
 	assert.Equal(t, []string{"-a", "1", "--bull", "2"}, args)
 }
+
+func TestFlags_NonStringKeys(t *testing.T) {
+	flags := Flags{}
+	err := yaml.Unmarshal([]byte(`
+yes: ""
+true:
+nil:
+1.0:
+1: ""
+`), &flags)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(flags))
+}

--- a/pkg/exec/builder/flags_test.go
+++ b/pkg/exec/builder/flags_test.go
@@ -86,11 +86,11 @@ func TestFlags_ToSlice(t *testing.T) {
 func TestFlags_NonStringKeys(t *testing.T) {
 	flags := Flags{}
 	err := yaml.Unmarshal([]byte(`
-yes: ""
-true:
-nil:
-1.0:
-1: ""
+yes: ["y", "true"]
+true: ["y", "yes"]
+nil: ["no", "nah"]
+1.0: ["true", "yes"]
+1: ["yes"]
 `), &flags)
 	assert.NoError(t, err)
 	assert.Equal(t, 5, len(flags))


### PR DESCRIPTION
# What does this change
Fixes non strings yaml keys of flags causing panic


# What issue does it fix
Closes #1215

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [x] Documentation - N/A
- [x] Schema (porter.yaml) - N/A


[contributors]: /CONTRIBUTORS.md