### PR TITLE
fix(kubernetes.go): remove jsonpath quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-unit:
 
 test-integration: clean-last-testrun build start-local-docker-registry
 	$(GO) build -o $(PORTER_HOME)/testplugin ./cmd/testplugin
-	PROJECT_ROOT=$(shell pwd) $(GO) test -timeout 20m -tags=integration ./...
+	PROJECT_ROOT=$(shell pwd) $(GO) test -timeout 30m -tags=integration ./...
 
 test-cli: clean-last-testrun build init-porter-home-for-ci start-local-docker-registry
 	REGISTRY=$(REGISTRY) KUBECONFIG=$(KUBECONFIG) ./scripts/test/test-cli.sh

--- a/examples/kubernetes/porter.yaml
+++ b/examples/kubernetes/porter.yaml
@@ -38,3 +38,5 @@ uninstall:
 outputs:
   - name: IP_ADDRESS
     type: string
+    applyTo:
+      - install

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -22,14 +22,14 @@ const (
 
 type Mixin struct {
 	*context.Context
-	schemas *packr.Box
+	schemas                 *packr.Box
 	KubernetesClientVersion string
 }
 
 func New() *Mixin {
 	return &Mixin{
-		Context: context.New(),
-		schemas: NewSchemaBox(),
+		Context:                 context.New(),
+		schemas:                 NewSchemaBox(),
 		KubernetesClientVersion: defaultKubernetesClientVersion,
 	}
 }
@@ -94,7 +94,7 @@ func (m *Mixin) ValidatePayload(b []byte) error {
 
 func (m *Mixin) getOutput(resourceType, resourceName, namespace, jsonPath string) ([]byte, error) {
 	args := []string{"get", resourceType, resourceName}
-	args = append(args, fmt.Sprintf("-o=jsonpath='%s'", jsonPath))
+	args = append(args, fmt.Sprintf("-o=jsonpath=%s", jsonPath))
 	if namespace != "" {
 		args = append(args, fmt.Sprintf("--namespace=%s", namespace))
 	}

--- a/tests/outputs_test.go
+++ b/tests/outputs_test.go
@@ -9,7 +9,6 @@ import (
 
 	"get.porter.sh/porter/pkg/porter"
 	"get.porter.sh/porter/pkg/printer"
-	"github.com/cnabio/cnab-go/claim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -163,9 +162,4 @@ func TestKubernetesMixinOutputs(t *testing.T) {
 
 	err = p.UninstallBundle(uninstallOptions)
 	require.NoError(p.T(), err, "uninstall of bundle failed")
-
-	// Verify that the installation is deleted
-	i, err := p.Claims.ReadInstallation("kubernetes")
-	require.EqualError(p.T(), err, "Installation does not exist")
-	require.Equal(p.T(), claim.Installation{}, i)
 }

--- a/tests/outputs_test.go
+++ b/tests/outputs_test.go
@@ -9,6 +9,7 @@ import (
 
 	"get.porter.sh/porter/pkg/porter"
 	"get.porter.sh/porter/pkg/printer"
+	"github.com/cnabio/cnab-go/claim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -126,4 +127,45 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 	require.NoError(t, err)
 	err = p.UninstallBundle(uninstallOpts)
 	require.NoError(t, err, "uninstall should have succeeded")
+}
+
+func TestKubernetesMixinOutputs(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+	p.Debug = false
+
+	// Use the kubernetes example bundle
+	p.CopyDirectory(filepath.Join(p.TestDir, "../examples/kubernetes"), ".", false)
+
+	installOpts := porter.InstallOptions{}
+	installOpts.CredentialIdentifiers = []string{"ci"}
+
+	err := installOpts.Validate([]string{}, p.Porter)
+	require.NoError(p.T(), err, "validation of install opts for bundle failed")
+
+	err = p.InstallBundle(installOpts)
+	require.NoError(p.T(), err, "install of bundle failed")
+
+	// Verify the output value has no wrapping single quotes
+	output, err := p.ReadBundleOutput("IP_ADDRESS", "kubernetes")
+	require.NoError(p.T(), err, "could not read bundle output")
+	require.NotEmpty(p.T(), output, "expected the output value to not be empty")
+	require.NotContains(p.T(), "'", output, "did not expect the output value to contain any single quote characters")
+
+	// Uninstall and delete installation
+	uninstallOptions := porter.UninstallOptions{}
+	uninstallOptions.CredentialIdentifiers = []string{"ci"}
+	uninstallOptions.Delete = true
+
+	err = uninstallOptions.Validate([]string{}, p.Porter)
+	require.NoError(p.T(), err, "validation of uninstall opts for bundle failed")
+
+	err = p.UninstallBundle(uninstallOptions)
+	require.NoError(p.T(), err, "uninstall of bundle failed")
+
+	// Verify that the installation is deleted
+	i, err := p.Claims.ReadInstallation("kubernetes")
+	require.EqualError(p.T(), err, "Installation does not exist")
+	require.Equal(p.T(), claim.Installation{}, i)
 }


### PR DESCRIPTION
# What does this change
* Removes wrapping single quotes from the `-o jsonpath` flag when retrieving outputs from Kubernetes

All credit for the fix goes to @carolynvs 🙇 (see https://github.com/deislabs/porter/pull/1211#issuecomment-679299614)

# What issue does it fix
Closes #1210 

# Notes for the reviewer

* I opted for an integration test since we have the pre-existing kubernetes example bundle... which brings the added benefit of testing the example... but I can understand if we don't wish to introduce this overhead.

* Some auto-formatting changes came in to `kubernetes.go`, I guess from my VS Code IDE/golang extension(s)... if we feel strongly, I can see about keeping those out.

# Checklist
- [x] ~~Unit Tests~~ Integration test
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md