### PR TITLE
Fix setting PORTER_HOME on plugins

### DIFF
--- a/pkg/plugins/pluggable/loader.go
+++ b/pkg/plugins/pluggable/loader.go
@@ -72,7 +72,7 @@ func (l *PluginLoader) Load(pluginType PluginTypeConfig) (interface{}, func(), e
 		if err != nil {
 			return nil, nil, err
 		}
-		pluginCommand.Env = append(pluginCommand.Env, home)
+		pluginCommand.Env = append(pluginCommand.Env, fmt.Sprintf("PORTER_HOME=%s", home))
 	}
 
 	if l.DebugPlugins {

--- a/scripts/test/test-linux-install.sh
+++ b/scripts/test/test-linux-install.sh
@@ -5,6 +5,7 @@ set -xeuo pipefail
 export PATH=$PATH:~/.porter
 
 PORTER_PERMALINK=canary ./scripts/install/install-linux.sh
+porter list
 
 PORTER_PERMALINK=v0.23.0-beta.1 ./scripts/install/install-linux.sh
 porter version | grep v0.23.0-beta.1

--- a/scripts/test/test-mac-install.sh
+++ b/scripts/test/test-mac-install.sh
@@ -5,6 +5,7 @@ set -xeuo pipefail
 export PATH=$PATH:~/.porter
 
 PORTER_PERMALINK=canary ./scripts/install/install-mac.sh
+porter list
 
 PORTER_PERMALINK=v0.23.0-beta.1 ./scripts/install/install-mac.sh
 porter version | grep v0.23.0-beta.1

--- a/scripts/test/test-windows-install.ps1
+++ b/scripts/test/test-windows-install.ps1
@@ -3,6 +3,7 @@ $ErrorActionPreference = "Stop"
 $env:PATH+=";$env:USERPROFILE\.porter"
 
 & $PSScriptRoot\..\install\install-windows.ps1 -PORTER_PERMALINK canary
+porter list
 
 & $PSScriptRoot\..\install\install-windows.ps1 -PORTER_PERMALINK v0.23.0-beta.1
 if (-Not (porter version | Select-String -Pattern 'v0.23.0-beta.1' -SimpleMatch))


### PR DESCRIPTION
# What does this change
When running a plugin, I was setting PORTER_HOME improperly. Windows was having none of it and was refusing to run the plugin with an improperly formatted env var, returning

```
The parameter is incorrect
```

# What issue does it fix
Closes #1154

# Notes for the reviewer
As a follow-up I'm looking at https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started-multiplatform?view=azure-devops to change our build to run on more than one OS. At first we can just run the CLI tests until we can build on all operating systems (not sure if building on windows is at 100% yet).

In the meantime, I've added a `porter list` call to our install script e2e test which does run on all OSs. This seems like a good thing to do anyway, make sure that Porter is not only installed but can run our most basic command without error.

# Checklist
- [x] Unit Tests (e2e tests)
- [ ] Documentation
- [ ] Schema (porter.yaml)