### PR TITLE
fix(dependencies.go): verify dep match before checking params

### DIFF
--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -200,20 +200,22 @@ func (e *dependencyExecutioner) prepareDependency(dep *queuedDependency) error {
 
 	// Handle any parameter overrides for the dependency defined in porter.yaml
 	// dependencies:
-	//   DEP:
+	//   - name: DEP
 	//     parameters:
 	//       PARAM: VALUE
-	for _, dep := range e.Manifest.Dependencies {
-		for paramName, value := range dep.Parameters {
-			// Make sure the parameter is defined in the bundle
-			if _, ok := depParams[paramName]; !ok {
-				return errors.Errorf("invalid dependencies.%s.parameters entry, %s is not a parameter defined in that bundle", dep.Name, paramName)
-			}
+	for _, manifestDep := range e.Manifest.Dependencies {
+		if manifestDep.Name == dep.Alias {
+			for paramName, value := range manifestDep.Parameters {
+				// Make sure the parameter is defined in the bundle
+				if _, ok := depParams[paramName]; !ok {
+					return errors.Errorf("invalid dependencies.%s.parameters entry, %s is not a parameter defined in that bundle", dep.Alias, paramName)
+				}
 
-			if dep.Parameters == nil {
-				dep.Parameters = make(map[string]string, 1)
+				if dep.Parameters == nil {
+					dep.Parameters = make(map[string]string, 1)
+				}
+				dep.Parameters[paramName] = value
 			}
-			dep.Parameters[paramName] = value
 		}
 	}
 


### PR DESCRIPTION
# What does this change
* Adds a check to be sure the manifest dep matches the current dep being processed before validating param def and setting param value

# What issue does it fix
Previously, we'd erroneously validate param definitions on the processed dep _against every dep listed in the manifest_ via the for loop, so we'd naturally hit errors.

# Notes for the reviewer

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md