### PR TITLE
fix(adapter.go): set initial sequence slice to 0 length

### DIFF
--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -302,7 +302,7 @@ func (c *ManifestConverter) generateDependencies() *extensions.Dependencies {
 	}
 
 	deps := &extensions.Dependencies{
-		Sequence: make([]string, len(c.Manifest.Dependencies)),
+		Sequence: make([]string, 0, len(c.Manifest.Dependencies)),
 		Requires: make(map[string]extensions.Dependency, len(c.Manifest.Dependencies)),
 	}
 

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -393,6 +393,7 @@ func TestManifestConverter_generateDependencies(t *testing.T) {
 
 	deps := a.generateDependencies()
 	require.Len(t, deps.Requires, 3, "incorrect number of dependencies were generated")
+	require.Equal(t, []string{"mysql", "ad", "storage"}, deps.Sequence, "incorrect sequence was generated")
 
 	testcases := []struct {
 		name    string


### PR DESCRIPTION

# What does this change
* Ensures the initial dependency sequence slice has length of 0 so that empty entries are avoided

# What issue does it fix

Previously, with no initial length, I think the slice was initialized with a number of empty entries equaling its capacity.  Then, we'd append actual dependency entries on top of this.  Because the Sequence length ended up double what Requires specifies, we weren't hitting the correct logic [here](https://github.com/deislabs/porter/blob/main/pkg/cnab/extensions/dependencies.go#L108-L119) and thus losing any sequential ordering.

So, using the example bundle in the original issue https://github.com/deislabs/porter/issues/1243, we'd see the Sequence section in the bundle.json as:

```
      "sequence": [
        "",
        "",
        "nfs",
        "cowsay"
      ]
```

Whereas with this fix, we see it with the correct listing and right size:

```
      "sequence": [
        "nfs",
        "cowsay"
      ]
```

cc @MChorfa to check my work/analysis above.

Closes https://github.com/deislabs/porter/issues/1243

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md