### PR TITLE
fix(schema/exec.json): add missing suppress-output entry

### DIFF
--- a/pkg/exec/schema/exec.json
+++ b/pkg/exec/schema/exec.json
@@ -71,6 +71,10 @@
             "minItems": 1
           }
         },
+        "suppress-output": {
+          "type": "boolean",
+          "default": false
+        },
         "outputs": {
           "type": "array",
           "items": {

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -295,6 +295,10 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "suppress-output": {
+            "default": false,
+            "type": "boolean"
           }
         },
         "required": [


### PR DESCRIPTION

# What does this change
* adds missing `suppress-output` field entry to the `exec` mixin schema

# What issue does it fix
N/A, noted when running an audit of applicable schemas after https://github.com/deislabs/porter-az/issues/17 was issued.

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md