### PR TITLE
docs(CONTRIBUTING.md): add DCO section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,79 @@ tackle it in a reasonable amount of time in a subsequent pull request. If you
 can't get to it soon, please create an issue and link to it from the pull
 request comment so that we don't collectively forget.
 
+## Signed commits
+
+A DCO sign-off is required for all contributions to Porter repos. A DCO
+sign-off is a line placed at the end of a commit message containing a
+contributor's signature. In adding this, the contributor certifies that
+they have the right to contribute the material.
+
+Here are the steps to sign one's work:
+
+Once the contributor certifies the DCO below (from [developercertificate.org](https://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+The contributor then just needs to add a line to every git commit message:
+
+    Signed-off-by: Jane Doe <jane.doe@example.com>
+
+One's real name must be used (no pseudonyms or anonymous contributions).
+
+The easiest way to do this is, assuming `user.name` and `user.email` are set via 
+the git cli configuration (`git config`), is to sign commits automatically via `git commit -s`.
+
+Finally, the `git log` information for a commit should show something like this:
+
+```
+Author: Jane Doe <jane.doe@example.com>
+Date:   Thu Feb 2 11:41:15 2018 -0800
+
+    Update README
+
+    Signed-off-by: Jane Doe <jane.doe@example.com>
+```
+
+Notice the `Author` and `Signed-off-by` lines match. If they don't,
+the PR will be rejected by the automated DCO check.
+
 ## The life of a pull request
 
 1. You create a draft or WIP pull request. Reviewers will ignore it mostly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,76 +133,34 @@ request comment so that we don't collectively forget.
 
 ## Signing your commits
 
-A DCO sign-off is required for all contributions to Porter repos. A DCO
-sign-off is a line placed at the end of a commit message containing a
-contributor's signature. In adding this, the contributor certifies that
-they have the right to contribute the material.
+Licensing is important to open source projects. It provides some assurances that the software
+will continue to be available based under the terms that the author(s) desired. We require that
+contributors sign off on commits submitted to our project's repositories. The 
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/) is a way to certify that 
+you wrote and have the right to contribute the code you are submitting to the project.
 
-Here are the steps to sign one's work:
-
-Once the contributor certifies the DCO below (from [developercertificate.org](https://developercertificate.org/)):
-
-```
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-1 Letterman Drive
-Suite D4700
-San Francisco, CA, 94129
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
-
-The contributor then just needs to add a line to every git commit message:
-
-    Signed-off-by: Jane Doe <jane.doe@example.com>
-
-One's real name must be used (no pseudonyms or anonymous contributions).
-
-The easiest way to do this is, assuming `user.name` and `user.email` are set via 
-the git cli configuration (`git config`), is to sign commits automatically via `git commit -s`.
-
-Finally, the `git log` information for a commit should show something like this:
+You sign-off by adding the following to your commit messages:
 
 ```
-Author: Jane Doe <jane.doe@example.com>
+Author: Your Name <your.name@example.com>
 Date:   Thu Feb 2 11:41:15 2018 -0800
 
-    Update README
+    This is my commit message
 
-    Signed-off-by: Jane Doe <jane.doe@example.com>
+    Signed-off-by: Your Name <your.name@example.com>
 ```
 
-Notice the `Author` and `Signed-off-by` lines match. If they don't,
-the PR will be rejected by the automated DCO check.
+Notice the `Author` and `Signed-off-by` lines match. If they don't, the PR will
+be rejected by the automated DCO check.
+
+Git has a `-s` command line option to do this automatically:
+
+    git commit -s -m 'This is my commit message'
+
+If you forgot to do this and have not yet pushed your changes to the remote repository, you can 
+amend your commit with the sign-off by running 
+
+    git commit --amend -s
 
 ## The life of a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
   * [Find an issue](#find-an-issue)
   * [When to open a pull request](#when-to-open-a-pull-request)
   * [How to get your pull request reviewed fast](#how-to-get-your-pull-request-reviewed-fast)
+  * [Signing your commits](#signing-your-commits)
   * [The life of a pull request](#the-life-of-a-pull-request)
 * [Contribution Ladder](#contribution-ladder)
 * [Developer Tasks](#developer-tasks)
@@ -130,7 +131,7 @@ tackle it in a reasonable amount of time in a subsequent pull request. If you
 can't get to it soon, please create an issue and link to it from the pull
 request comment so that we don't collectively forget.
 
-## Signed commits
+## Signing your commits
 
 A DCO sign-off is required for all contributions to Porter repos. A DCO
 sign-off is a line placed at the end of a commit message containing a


### PR DESCRIPTION

# What does this change
* Adds section around forthcoming DCO check

(DCO bot is added; will hold off on making it a mandatory check until this PR is approved and merged.)

# What issue does it fix
Ref https://github.com/deislabs/porter/issues/1250

# Notes for the reviewer

Do we want the full section inline'd how it is currently?  Or perhaps link from CONTRIBUTING to a new (DCO?) markdown doc?

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md