### PR TITLE
ref(Makefile.kind): bump kind and remove darwin workaround

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -21,12 +21,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerAddress: "${CURRENT_HOST_IP}"
-  apiServerPort: 6443
 EOF
 endef
 export KIND_CLUSTER_FILE_CREATOR = $(value get_kind_config_file)
 
-KIND_VERSION ?= v0.8.1
+KIND_VERSION ?= v0.9.0
 CLUSTER_NAME  = porter
 
 install-kind:
@@ -36,15 +35,10 @@ install-kind:
 
 create-kind-config-file:; @eval "$$KIND_CLUSTER_FILE_CREATOR"
 
-# TODO: remove need to manually set server value if darwin
-# https://github.com/kubernetes-sigs/kind/issues/1732
 create-kind-cluster: create-kind-config-file
 	@kind create cluster \
 		--name ${CLUSTER_NAME} \
 		--config ${KIND_CONFIG_FILE_NAME}
-	@if [[ "$(CLIENT_PLATFORM)" == "darwin" ]]; then \
-		kubectl config set clusters.kind-${CLUSTER_NAME}.server https://${CURRENT_HOST_IP}:6443 ; \
-	fi
 
 delete-kind-cluster:
 	@kind delete cluster --name ${CLUSTER_NAME}


### PR DESCRIPTION

# What does this change
* bumps Kind to [v0.9.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0), allowing us to remove the Mac OSX/Darwin workaround

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md